### PR TITLE
Update sources.csv

### DIFF
--- a/sources.csv
+++ b/sources.csv
@@ -10,3 +10,4 @@ mediadepot_templates, https://raw.githubusercontent.com/mediadepot/templates/mas
 mycroftwilde_templates, https://raw.githubusercontent.com/mycroftwilde/portainer_templates/master/Template/template.json
 mediadepot_templates, https://raw.githubusercontent.com/mediadepot/templates/master/portainer.json
 portainer_templates, https://raw.githubusercontent.com/portainer/templates/master/templates-2.0.json
+cloudflare_templates, https://raw.githubusercontent.com/tempusthales/Portainer/main/pi_hosted_cloudflare_templates.json


### PR DESCRIPTION
Added Cloudflare Tunnel provides you with a secure way to connect your resources to Cloudflare without a publicly routable IP address. With Tunnel, you do not send traffic to an external IP — instead, a lightweight daemon in your infrastructure (cloudflared) creates outbound-only connections to Cloudflare's edge.