### PR TITLE
feat: normalize casing of categories for each of the templates

### DIFF
--- a/lib/combine.py
+++ b/lib/combine.py
@@ -25,12 +25,24 @@ for file in files:
 seen_titles = set()
 filtered_data = []
 
+def normalize_string(original, lowercase = True):
+  normalized = original.translate(str.maketrans('', '', string.punctuation)).replace(' ', '')
+  return normalized.lower() if lowercase else normalized.capitalize()
+
 for x in templates:
-    normalized_title = x['title'].translate(str.maketrans('', '', string.punctuation)).replace(' ', '').lower()
+    normalized_title = normalize_string(x['title'])
     if normalized_title not in seen_titles:
         seen_titles.add(normalized_title)
         filtered_data.append(x)
 
+    categories = x.get('categories', [])
+    x['categories'] = []
+
+    for category in categories:
+      normalized_category = normalize_string(category, lowercase = False)
+
+      if normalized_category not in x['categories']:
+        x['categories'].append(normalized_category)
 
 fileData = {
   'version': '2',

--- a/lib/validate.py
+++ b/lib/validate.py
@@ -23,6 +23,9 @@ def main():
 
     except ValidationError as ve:
         print('Validation error:', ve.message)
+        json_obj = ve.instance
+        identifier = json_obj.get('title')
+        print('Title of invalid template:', identifier)
         sys.exit(1)
     except FileNotFoundError as fnfe:
         print(f'File not found error: {fnfe}')


### PR DESCRIPTION
Addressing https://github.com/Lissy93/portainer-templates/issues/17

While QA'ing the changes locally, I saw the `validate.py` would fail because the `Bookstack` template was missing the `image` property.
```
Validation error: 'image' is a required property
Title of invalid template: Bookstack
```

This was not obvious as to who the offending template was, so I made a minor change to more easily identify which template caused the issue.