### PR TITLE
Revert "Revert "Update sources.csv""

### DIFF
--- a/sources.csv
+++ b/sources.csv
@@ -11,3 +11,4 @@ mycroftwilde_templates, https://raw.githubusercontent.com/mycroftwilde/portainer
 mediadepot_templates, https://raw.githubusercontent.com/mediadepot/templates/master/portainer.json
 shmolf_templates, https://raw.githubusercontent.com/shmolf/portainer-templates/main/templates-2.0.json
 portainer_templates, https://raw.githubusercontent.com/portainer/templates/master/templates-2.0.json
+cloudflare_templates, https://raw.githubusercontent.com/tempusthales/Portainer/main/pi_hosted_cloudflare_templates.json


### PR DESCRIPTION
Reverts Lissy93/portainer-templates#16

Since https://github.com/Lissy93/portainer-templates/pull/49 passively skips bad templates, I believe the original addition can be restored.