### PR TITLE
Added v3 version of templates for compatibility with Portainer v2.23.

### DIFF
--- a/templates_v3.json
+++ b/templates_v3.json
@@ -1,0 +1,22160 @@
+{
+  "version": "3",
+  "templates": [
+    {
+      "id": 1,
+      "type": 1,
+      "name": "baserow",
+      "title": "Baserow",
+      "description": " Open source no-code database and Airtable alternative ",
+      "logo": "https://mediadepot.github.io/templates/img/baserow.png",
+      "image": "baserow/baserow:1.22.3",
+      "categories": [
+        "Downloaders",
+        "Tools"
+      ],
+      "ports": [
+        "80/tcp"
+      ],
+      "volumes": [
+        {
+          "container": "/baserow/data",
+          "bind": "/opt/mediadepot/apps/baserow"
+        }
+      ],
+      "env": [
+        {
+          "name": "BASEROW_PUBLIC_URL",
+          "label": "BASEROW_PUBLIC_URL",
+          "preset": false
+        }
+      ],
+      "labels": [
+        {
+          "name": "traefik.enable",
+          "value": "true"
+        },
+        {
+          "name": "traefik.http.services.baserow.loadbalancer.server.port",
+          "value": "80"
+        },
+        {
+          "name": "traefik.http.routers.baserow.entrypoints",
+          "value": "websecure"
+        },
+        {
+          "name": "traefik.http.routers.baserow.tls.certresolver",
+          "value": "mydnschallenge"
+        }
+      ],
+      "maintainer": " https://github.com/mediadepot/templates/"
+    },
+    {
+      "id": 2,
+      "type": 1,
+      "name": "cardigann",
+      "title": "Cardigann",
+      "description": "Cardigann, a server for adding extra indexers to Sonarr, SickRage and CouchPotato via Torznab and TorrentPotato proxies. Behind the scenes Cardigann logs in and runs searches and then transforms the results into a compatible format.",
+      "logo": "https://mediadepot.github.io/templates/img/cardigann.png",
+      "image": "linuxserver/cardigann:latest",
+      "categories": [
+        "Downloaders"
+      ],
+      "ports": [
+        "5060/tcp"
+      ],
+      "volumes": [
+        {
+          "container": "/config",
+          "bind": "/opt/mediadepot/apps/cardigann"
+        }
+      ],
+      "env": [
+        {
+          "name": "PGID",
+          "label": "PGID",
+          "default": "15000",
+          "preset": true
+        },
+        {
+          "name": "PUID",
+          "label": "PUID",
+          "default": "15000",
+          "preset": true
+        }
+      ],
+      "labels": [
+        {
+          "name": "traefik.enable",
+          "value": "true"
+        },
+        {
+          "name": "traefik.http.services.cardigann.loadbalancer.server.port",
+          "value": "5060"
+        },
+        {
+          "name": "traefik.http.routers.cardigann.entrypoints",
+          "value": "websecure"
+        },
+        {
+          "name": "traefik.http.routers.cardigann.tls.certresolver",
+          "value": "mydnschallenge"
+        }
+      ],
+      "maintainer": " https://github.com/mediadepot/templates/"
+    },
+    {
+      "id": 3,
+      "type": 1,
+      "title": "Calibre Web",
+      "name": "calibreweb",
+      "note": "Portainer App Templates by <a href='https://www.technorabilia.com' target='_blank'>Technorabilia</a> based on data provided by <a href='https://www.linuxserver.io' target='_blank'>LinuxServer.io</a>.</p><p>Don't forget to create the volume directories on the host file system.</p><p>mkdir -p /volume1/docker/calibre-web/config<br>mkdir -p /volume1/docker/calibre-web/books</p>",
+      "description": "[Calibre-web](https://github.com/janeczku/calibre-web) is a web app providing a clean interface for browsing, reading and downloading eBooks using an existing Calibre database. It is also possible to integrate google drive and edit metadata and your calibre library through the app itself. This software is a fork of library and licensed under the GPL v3 License.",
+      "categories": [
+        "Books"
+      ],
+      "platform": "linux",
+      "logo": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/calibre-web-icon.png",
+      "image": "linuxserver/calibre-web:latest",
+      "env": [
+        {
+          "name": "PUID",
+          "label": "PUID",
+          "default": "15000",
+          "description": "for UserID"
+        },
+        {
+          "name": "PGID",
+          "label": "PGID",
+          "default": "15000",
+          "description": "for GroupID"
+        },
+        {
+          "name": "TZ",
+          "label": "TZ",
+          "default": "America/Los_Angeles",
+          "description": "Specify a timezone to use for example Europe/Amsterdam"
+        },
+        {
+          "name": "DOCKER_MODS",
+          "label": "DOCKER_MODS",
+          "default": "linuxserver/mods:universal-calibre",
+          "description": "#optional & **x86-64 only** Adds the ability to perform ebook conversion"
+        },
+        {
+          "name": "OAUTHLIB_RELAX_TOKEN_SCOPE",
+          "label": "OAUTHLIB_RELAX_TOKEN_SCOPE",
+          "default": "1",
+          "description": "Optionally set this to allow Google OAUTH to work"
+        }
+      ],
+      "ports": [
+        "8083/tcp"
+      ],
+      "volumes": [
+        {
+          "container": "/config",
+          "bind": "/opt/mediadepot/apps/calibre-web/config"
+        },
+        {
+          "container": "/books",
+          "bind": "/media/storage/ebooks"
+        }
+      ],
+      "restart_policy": "unless-stopped",
+      "labels": [
+        {
+          "name": "traefik.enable",
+          "value": "true"
+        },
+        {
+          "name": "traefik.http.services.calibreweb.loadbalancer.server.port",
+          "value": "8083"
+        },
+        {
+          "name": "traefik.http.routers.calibreweb.entrypoints",
+          "value": "websecure"
+        },
+        {
+          "name": "traefik.http.routers.calibreweb.tls.certresolver",
+          "value": "mydnschallenge"
+        }
+      ],
+      "maintainer": " https://github.com/mediadepot/templates/"
+    },
+    {
+      "id": 4,
+      "type": 1,
+      "name": "changedetection",
+      "title": "ChangeDetection",
+      "description": "changedetection.io - The best and simplest self-hosted open source website change detection monitoring and notification service. An alternative to Visualping, Watchtower",
+      "logo": "https://mediadepot.github.io/templates/img/changedetection.jpg",
+      "image": "ghcr.io/dgtlmoon/changedetection.io:latest",
+      "categories": [
+        "Documents",
+        "Networkother",
+        "Tools"
+      ],
+      "ports": [
+        "5000/tcp"
+      ],
+      "volumes": [
+        {
+          "container": "/datastore",
+          "bind": "/opt/mediadepot/apps/changedetection"
+        }
+      ],
+      "env": [],
+      "labels": [
+        {
+          "name": "traefik.enable",
+          "value": "true"
+        },
+        {
+          "name": "traefik.http.services.changedetection.loadbalancer.server.port",
+          "value": "5000"
+        },
+        {
+          "name": "traefik.http.routers.changedetection.entrypoints",
+          "value": "websecure"
+        },
+        {
+          "name": "traefik.http.routers.changedetection.tls.certresolver",
+          "value": "mydnschallenge"
+        }
+      ],
+      "maintainer": " https://github.com/mediadepot/templates/"
+    },
+    {
+      "id": 5,
+      "type": 1,
+      "name": "cloudcmd",
+      "title": "Cloud Commander",
+      "description": "Cloud Commander a file manager for the web with console and editor.",
+      "logo": "https://mediadepot.github.io/templates/img/cloudcmd-logo.png",
+      "image": "coderaiser/cloudcmd",
+      "categories": [
+        "Documents",
+        "Networkother",
+        "Tools"
+      ],
+      "ports": [
+        "8000/tcp"
+      ],
+      "volumes": [
+        {
+          "container": "/media/host/opt/mediadepot",
+          "bind": "/opt/mediadepot/apps"
+        },
+        {
+          "container": "/media/host/media/storage",
+          "bind": "/media/storage"
+        },
+        {
+          "container": "/media/host/media/temp",
+          "bind": "/media/temp"
+        }
+      ],
+      "env": [],
+      "labels": [
+        {
+          "name": "traefik.enable",
+          "value": "true"
+        },
+        {
+          "name": "traefik.http.services.cloudcmd.loadbalancer.server.port",
+          "value": "8000"
+        },
+        {
+          "name": "traefik.http.routers.cloudcmd.entrypoints",
+          "value": "websecure"
+        },
+        {
+          "name": "traefik.http.routers.cloudcmd.tls.certresolver",
+          "value": "mydnschallenge"
+        },
+        {
+          "name": "traefik.http.routers.cloudcmd.middlewares",
+          "value": "authme"
+        },
+        {
+          "name": "traefik.http.middlewares.authme.forwardauth.address",
+          "value": "http://authelia:9091/api/verify?rd=https://login.${DEPOT_DOMAIN_NAME}/"
+        },
+        {
+          "name": "traefik.http.middlewares.authme.forwardauth.trustforwardheader",
+          "value": "true"
+        }
+      ],
+      "maintainer": " https://github.com/mediadepot/templates/"
+    },
+    {
+      "id": 6,
+      "type": 1,
+      "name": "couchpotato",
+      "title": "Couchpotato",
+      "description": "CouchPotato (CP) is an automatic NZB and torrent downloader. You can keep a \"movies I want\"-list and it will search for NZBs/torrents of these movies every X hours. Once a movie is found, it will send it to SABnzbd or download the torrent to a specified directory.",
+      "logo": "https://mediadepot.github.io/templates/img/couchpotato-icon.png",
+      "image": "linuxserver/couchpotato:latest",
+      "categories": [
+        "Downloaders",
+        "Mediaappvideo"
+      ],
+      "ports": [
+        "5050/tcp"
+      ],
+      "volumes": [
+        {
+          "container": "/config",
+          "bind": "/opt/mediadepot/apps/couchpotato"
+        },
+        {
+          "container": "/downloads",
+          "bind": "/media/storage/downloads/movies"
+        },
+        {
+          "container": "/movies",
+          "bind": "/media/storage/movies"
+        },
+        {
+          "container": "/blackhole",
+          "bind": "/media/temp/blackhole/movies"
+        }
+      ],
+      "env": [
+        {
+          "name": "PGID",
+          "label": "PGID",
+          "default": "15000",
+          "preset": true
+        },
+        {
+          "name": "PUID",
+          "label": "PUID",
+          "default": "15000",
+          "preset": true
+        },
+        {
+          "name": "TZ",
+          "label": "TZ",
+          "default": "America/Los_Angeles"
+        }
+      ],
+      "labels": [
+        {
+          "name": "traefik.enable",
+          "value": "true"
+        },
+        {
+          "name": "traefik.http.services.couchpotato.loadbalancer.server.port",
+          "value": "5050"
+        },
+        {
+          "name": "traefik.http.routers.couchpotato.entrypoints",
+          "value": "websecure"
+        },
+        {
+          "name": "traefik.http.routers.couchpotato.tls.certresolver",
+          "value": "mydnschallenge"
+        }
+      ],
+      "maintainer": " https://github.com/mediadepot/templates/"
+    },
+    {
+      "id": 7,
+      "type": 1,
+      "name": "duckdns",
+      "title": "DuckDNS",
+      "description": "Duckdns is a free service which will point a DNS (sub domains of duckdns.org) to an IP of your choice.",
+      "logo": "https://mediadepot.github.io/templates/img/duckdns.png",
+      "image": "linuxserver/duckdns:latest",
+      "categories": [
+        "Networkdns",
+        "Tools"
+      ],
+      "volumes": [],
+      "env": [
+        {
+          "name": "SUBDOMAINS",
+          "label": "SUBDOMAINS"
+        },
+        {
+          "name": "TOKEN",
+          "label": "TOKEN"
+        },
+        {
+          "name": "TZ",
+          "label": "TZ",
+          "default": "America/Los_Angeles"
+        }
+      ],
+      "maintainer": " https://github.com/mediadepot/templates/"
+    },
+    {
+      "id": 8,
+      "type": 1,
+      "name": "duplicati",
+      "title": "Duplicati",
+      "description": "Duplicati works with standard protocols like FTP, SSH, WebDAV as well as popular services like Microsoft OneDrive, Amazon Cloud Drive & S3, Google Drive, box.com, Mega, hubiC and many others.",
+      "logo": "https://mediadepot.github.io/templates/img/duplicati-icon.png",
+      "image": "linuxserver/duplicati:latest",
+      "categories": [
+        "Utilitybackup"
+      ],
+      "ports": [
+        "8200/tcp"
+      ],
+      "volumes": [
+        {
+          "container": "/config",
+          "bind": "/opt/mediadepot/apps/duplicati"
+        },
+        {
+          "container": "/source",
+          "bind": "/opt/mediadepot/apps/"
+        }
+      ],
+      "env": [
+        {
+          "name": "TZ",
+          "label": "TZ",
+          "default": "America/Los_Angeles"
+        }
+      ],
+      "labels": [
+        {
+          "name": "traefik.enable",
+          "value": "true"
+        },
+        {
+          "name": "traefik.http.services.duplicati.loadbalancer.server.port",
+          "value": "8200"
+        },
+        {
+          "name": "traefik.http.routers.duplicati.entrypoints",
+          "value": "websecure"
+        },
+        {
+          "name": "traefik.http.routers.duplicati.tls.certresolver",
+          "value": "mydnschallenge"
+        }
+      ],
+      "maintainer": " https://github.com/mediadepot/templates/"
+    },
+    {
+      "id": 9,
+      "type": 1,
+      "name": "duplicacy",
+      "title": "Duplicacy",
+      "description": "Duplicacy backs up your files to many cloud storages with client-side encryption and the highest level of deduplication",
+      "logo": "https://mediadepot.github.io/templates/img/duplicacy-icon.png",
+      "image": "mediadepot/duplicacy:latest",
+      "categories": [
+        "Utilitybackup"
+      ],
+      "ports": [
+        "3875/tcp"
+      ],
+      "volumes": [
+        {
+          "container": "/config",
+          "bind": "/opt/mediadepot/apps/duplicacy/config"
+        },
+        {
+          "container": "/logs",
+          "bind": "/opt/mediadepot/apps/duplicacy/logs"
+        },
+        {
+          "container": "/cache",
+          "bind": "/opt/mediadepot/apps/duplicacy/cache"
+        },
+        {
+          "container": "/source/apps",
+          "bind": "/opt/mediadepot/apps/"
+        },
+        {
+          "container": "/source/storage",
+          "bind": "/media/storage/"
+        }
+      ],
+      "env": [
+        {
+          "name": "TZ",
+          "label": "TZ",
+          "default": "America/Los_Angeles"
+        }
+      ],
+      "labels": [
+        {
+          "name": "traefik.enable",
+          "value": "true"
+        },
+        {
+          "name": "traefik.http.services.duplicacy.loadbalancer.server.port",
+          "value": "3875"
+        },
+        {
+          "name": "traefik.http.routers.duplicacy.entrypoints",
+          "value": "websecure"
+        },
+        {
+          "name": "traefik.http.routers.duplicacy.tls.certresolver",
+          "value": "mydnschallenge"
+        }
+      ],
+      "maintainer": " https://github.com/mediadepot/templates/"
+    },
+    {
+      "id": 10,
+      "type": 1,
+      "name": "dozzle",
+      "title": "Dozzle",
+      "description": " Realtime log viewer for docker containers. ",
+      "logo": "https://mediadepot.github.io/templates/img/dozzle.png",
+      "image": "amir20/dozzle:latest",
+      "categories": [
+        "Tools"
+      ],
+      "ports": [
+        "8080/tcp"
+      ],
+      "privileged": true,
+      "volumes": [
+        {
+          "container": "/var/run/docker.sock",
+          "bind": "/var/run/docker.sock",
+          "readonly": true
+        }
+      ],
+      "command": "--no-analytics",
+      "env": [],
+      "labels": [
+        {
+          "name": "traefik.enable",
+          "value": "true"
+        },
+        {
+          "name": "traefik.http.services.dozzle.loadbalancer.server.port",
+          "value": "8080"
+        },
+        {
+          "name": "traefik.http.routers.dozzle.entrypoints",
+          "value": "websecure"
+        },
+        {
+          "name": "traefik.http.routers.dozzle.tls.certresolver",
+          "value": "mydnschallenge"
+        }
+      ],
+      "maintainer": " https://github.com/mediadepot/templates/"
+    },
+    {
+      "id": 11,
+      "type": 1,
+      "name": "droppy",
+      "title": "Droppy",
+      "description": "Droppy is a self-hosted file storage server",
+      "logo": "https://mediadepot.github.io/templates/img/filebrowser-icon.png",
+      "image": "silverwind/droppy:latest",
+      "categories": [
+        "Tools",
+        "Networkweb",
+        "Networkother"
+      ],
+      "ports": [
+        "8989/tcp"
+      ],
+      "volumes": [
+        {
+          "container": "/files/tvshows",
+          "bind": "/media/storage/tvshows"
+        },
+        {
+          "container": "/files/movies",
+          "bind": "/media/storage/movies"
+        },
+        {
+          "container": "/files/music",
+          "bind": "/media/storage/music"
+        },
+        {
+          "container": "/files/photos",
+          "bind": "/media/storage/photos"
+        },
+        {
+          "container": "/files/ebooks",
+          "bind": "/media/storage/ebooks"
+        },
+        {
+          "container": "/files/documents",
+          "bind": "/media/storage/documents"
+        },
+        {
+          "container": "/files/software",
+          "bind": "/media/storage/software"
+        },
+        {
+          "container": "/files/downloads",
+          "bind": "/media/storage/downloads"
+        },
+        {
+          "container": "/files/blackhole",
+          "bind": "/media/temp/blackhole"
+        },
+        {
+          "container": "/files/processing",
+          "bind": "/media/temp/processing"
+        },
+        {
+          "container": "/config",
+          "bind": "/opt/mediadepot/apps/droppy"
+        }
+      ],
+      "env": [
+        {
+          "name": "GID",
+          "label": "GID",
+          "default": "15000",
+          "preset": true
+        },
+        {
+          "name": "UID",
+          "label": "UID",
+          "default": "15000",
+          "preset": true
+        },
+        {
+          "name": "TZ",
+          "label": "TZ",
+          "default": "America/Los_Angeles"
+        }
+      ],
+      "labels": [
+        {
+          "name": "traefik.enable",
+          "value": "true"
+        },
+        {
+          "name": "traefik.http.services.droppy.loadbalancer.server.port",
+          "value": "8989"
+        },
+        {
+          "name": "traefik.http.routers.droppy.entrypoints",
+          "value": "websecure"
+        },
+        {
+          "name": "traefik.http.routers.droppy.tls.certresolver",
+          "value": "mydnschallenge"
+        }
+      ],
+      "maintainer": " https://github.com/mediadepot/templates/"
+    },
+    {
+      "id": 12,
+      "type": 1,
+      "name": "filebrowser",
+      "title": "Filebrowser",
+      "description": "filebrowser provides a file managing interface within a specified directory and it can be used to upload, delete, preview, rename and edit your files.",
+      "logo": "https://mediadepot.github.io/templates/img/filebrowser-icon.png",
+      "image": "mediadepot/filebrowser:latest",
+      "categories": [
+        "Tools",
+        "Networkweb",
+        "Networkother"
+      ],
+      "ports": [
+        "8080/tcp"
+      ],
+      "command": "-d /config/filebrowser.db -p 8080",
+      "volumes": [
+        {
+          "container": "/srv/tvshows",
+          "bind": "/media/storage/tvshows"
+        },
+        {
+          "container": "/srv/movies",
+          "bind": "/media/storage/movies"
+        },
+        {
+          "container": "/srv/music",
+          "bind": "/media/storage/music"
+        },
+        {
+          "container": "/srv/photos",
+          "bind": "/media/storage/photos"
+        },
+        {
+          "container": "/srv/ebooks",
+          "bind": "/media/storage/ebooks"
+        },
+        {
+          "container": "/srv/documents",
+          "bind": "/media/storage/documents"
+        },
+        {
+          "container": "/srv/software",
+          "bind": "/media/storage/software"
+        },
+        {
+          "container": "/srv/downloads",
+          "bind": "/media/storage/downloads"
+        },
+        {
+          "container": "/srv/blackhole",
+          "bind": "/media/temp/blackhole"
+        },
+        {
+          "container": "/srv/processing",
+          "bind": "/media/temp/processing"
+        },
+        {
+          "container": "/config",
+          "bind": "/opt/mediadepot/apps/filebrowser"
+        }
+      ],
+      "env": [
+        {
+          "name": "TZ",
+          "label": "TZ",
+          "default": "America/Los_Angeles"
+        }
+      ],
+      "labels": [
+        {
+          "name": "traefik.enable",
+          "value": "true"
+        },
+        {
+          "name": "traefik.http.services.filebrowser.loadbalancer.server.port",
+          "value": "8080"
+        },
+        {
+          "name": "traefik.http.routers.filebrowser.entrypoints",
+          "value": "websecure"
+        },
+        {
+          "name": "traefik.http.routers.filebrowser.tls.certresolver",
+          "value": "mydnschallenge"
+        }
+      ],
+      "maintainer": " https://github.com/mediadepot/templates/"
+    },
+    {
+      "id": 13,
+      "type": 3,
+      "name": "filerun",
+      "title": "Filerun",
+      "description": "access your files anywhere through self-hosted secure cloud storage, file backup and sharing for your photos, videos, files and more.",
+      "logo": "https://mediadepot.github.io/templates/img/filerun-logo.png",
+      "categories": [
+        "Documents",
+        "Networkother",
+        "Tools"
+      ],
+      "env": [],
+      "repository": {
+        "url": "https://github.com/mediadepot/templates",
+        "stackfile": "stacks/filerun/docker-compose.yml"
+      },
+      "maintainer": " https://github.com/mediadepot/templates/"
+    },
+    {
+      "id": 14,
+      "type": 1,
+      "name": "gaps",
+      "title": "Gaps",
+      "description": "Gaps searches through your Plex Server or local folders for all movies, then queries for known movies in the same collection.",
+      "logo": "https://mediadepot.github.io/templates/img/plex-icon.png",
+      "image": "housewrecker/gaps:latest",
+      "categories": [
+        "Tools",
+        "Networkweb",
+        "Networkother"
+      ],
+      "ports": [
+        "8484/tcp"
+      ],
+      "volumes": [],
+      "env": [
+        {
+          "name": "TZ",
+          "label": "TZ",
+          "default": "America/Los_Angeles"
+        }
+      ],
+      "labels": [
+        {
+          "name": "traefik.enable",
+          "value": "true"
+        },
+        {
+          "name": "traefik.http.services.gaps.loadbalancer.server.port",
+          "value": "8484"
+        },
+        {
+          "name": "traefik.http.routers.gaps.entrypoints",
+          "value": "websecure"
+        },
+        {
+          "name": "traefik.http.routers.gaps.tls.certresolver",
+          "value": "mydnschallenge"
+        }
+      ],
+      "maintainer": " https://github.com/mediadepot/templates/"
+    },
+    {
+      "id": 15,
+      "type": 1,
+      "name": "healthchecks",
+      "title": "Healthchecks",
+      "description": "Healthchecks is a watchdog for your cron jobs. It's a web server that listens for pings from your cron jobs, plus a web interface.",
+      "logo": "https://mediadepot.github.io/templates/img/healthchecks-logo.png",
+      "image": "linuxserver/healthchecks",
+      "categories": [
+        "Tools",
+        "Networkweb",
+        "Networkother",
+        "Statusstable"
+      ],
+      "ports": [
+        "8000/tcp"
+      ],
+      "volumes": [
+        {
+          "container": "/config",
+          "bind": "/opt/mediadepot/apps/healthchecks"
+        }
+      ],
+      "env": [
+        {
+          "name": "PGID",
+          "label": "PGID",
+          "default": "15000",
+          "preset": true
+        },
+        {
+          "name": "PUID",
+          "label": "PUID",
+          "default": "15000",
+          "preset": true
+        },
+        {
+          "name": "TZ",
+          "label": "TZ",
+          "default": "America/Los_Angeles"
+        },
+        {
+          "name": "SITE_ROOT",
+          "label": "SITE_ROOT",
+          "default": "healthchecks.depot.lan"
+        },
+        {
+          "name": "SITE_NAME",
+          "label": "SITE_NAME",
+          "default": "healthchecks"
+        },
+        {
+          "name": "DEFAULT_FROM_EMAIL",
+          "label": "DEFAULT_FROM_EMAIL",
+          "default": "healthchecks@depot.lan"
+        },
+        {
+          "name": "EMAIL_HOST",
+          "label": "EMAIL_HOST",
+          "default": ""
+        },
+        {
+          "name": "EMAIL_PORT",
+          "label": "EMAIL_PORT",
+          "default": ""
+        },
+        {
+          "name": "EMAIL_HOST_USER",
+          "label": "EMAIL_HOST_USER",
+          "default": ""
+        },
+        {
+          "name": "EMAIL_HOST_PASSWORD",
+          "label": "EMAIL_HOST_PASSWORD",
+          "default": ""
+        },
+        {
+          "name": "EMAIL_USE_TLS",
+          "label": "EMAIL_USE_TLS",
+          "default": ""
+        }
+      ],
+      "labels": [
+        {
+          "name": "traefik.enable",
+          "value": "true"
+        },
+        {
+          "name": "traefik.http.services.healthchecks.loadbalancer.server.port",
+          "value": "8000"
+        },
+        {
+          "name": "traefik.http.routers.healthchecks.entrypoints",
+          "value": "websecure"
+        },
+        {
+          "name": "traefik.http.routers.healthchecks.tls.certresolver",
+          "value": "mydnschallenge"
+        }
+      ],
+      "maintainer": " https://github.com/mediadepot/templates/"
+    },
+    {
+      "id": 16,
+      "type": 1,
+      "name": "heimdall",
+      "title": "Heimdall",
+      "description": "Heimdall is a way to organise all those links to your most used web sites and web applications in a simple way.",
+      "logo": "https://mediadepot.github.io/templates/img/heimdall-icon.png",
+      "image": "linuxserver/heimdall:latest",
+      "categories": [
+        "Tools",
+        "Networkweb",
+        "Networkother",
+        "Statusstable"
+      ],
+      "ports": [
+        "80/tcp",
+        "443/tcp"
+      ],
+      "volumes": [
+        {
+          "container": "/config",
+          "bind": "/opt/mediadepot/apps/heimdall"
+        }
+      ],
+      "env": [
+        {
+          "name": "PGID",
+          "label": "PGID",
+          "default": "15000",
+          "preset": true
+        },
+        {
+          "name": "PUID",
+          "label": "PUID",
+          "default": "15000",
+          "preset": true
+        },
+        {
+          "name": "TZ",
+          "label": "TZ",
+          "default": "America/Los_Angeles"
+        }
+      ],
+      "labels": [
+        {
+          "name": "traefik.enable",
+          "value": "true"
+        },
+        {
+          "name": "traefik.http.services.heimdall.loadbalancer.server.port",
+          "value": "80"
+        },
+        {
+          "name": "traefik.http.routers.heimdall.entrypoints",
+          "value": "websecure"
+        },
+        {
+          "name": "traefik.http.routers.heimdall.tls.certresolver",
+          "value": "mydnschallenge"
+        }
+      ],
+      "maintainer": " https://github.com/mediadepot/templates/"
+    },
+    {
+      "id": 17,
+      "type": 1,
+      "name": "homepage",
+      "title": "Homepage",
+      "description": "A modern (fully static, fast), secure (fully proxied), highly customizable application dashboard with integrations for more than 25 services and translations for over 15 languages. Easily configured via YAML files (or discovery via docker labels).",
+      "logo": "https://mediadepot.github.io/templates/img/homepage.png",
+      "image": "ghcr.io/benphelps/homepage:latest",
+      "categories": [
+        "Tools",
+        "Networkweb",
+        "Networkother",
+        "Statusstable"
+      ],
+      "ports": [
+        "3000/tcp"
+      ],
+      "volumes": [
+        {
+          "container": "/app/config",
+          "bind": "/opt/mediadepot/apps/homepage"
+        },
+        {
+          "container": "/etc/localtime",
+          "bind": "/etc/localtime",
+          "readonly": true
+        }
+      ],
+      "env": [
+        {
+          "name": "PGID",
+          "label": "PGID",
+          "default": "15000",
+          "preset": true
+        },
+        {
+          "name": "PUID",
+          "label": "PUID",
+          "default": "15000",
+          "preset": true
+        },
+        {
+          "name": "TZ",
+          "label": "TZ",
+          "default": "America/Los_Angeles"
+        }
+      ],
+      "labels": [
+        {
+          "name": "traefik.enable",
+          "value": "true"
+        },
+        {
+          "name": "traefik.http.services.homepage.loadbalancer.server.port",
+          "value": "3000"
+        },
+        {
+          "name": "traefik.http.routers.homepage.entrypoints",
+          "value": "websecure"
+        },
+        {
+          "name": "traefik.http.routers.homepage.tls.certresolver",
+          "value": "mydnschallenge"
+        }
+      ],
+      "maintainer": " https://github.com/mediadepot/templates/"
+    },
+    {
+      "id": 18,
+      "type": 1,
+      "name": "jackett",
+      "title": "Jackett",
+      "description": "Jackett works as a proxy server it translates queries from apps like Sonarr etc into tracker-site-specific http queries and parses the html response sending results back to the requesting software.",
+      "logo": "https://mediadepot.github.io/templates/img/jacket-icon.png",
+      "image": "linuxserver/jackett:latest",
+      "categories": [
+        "Downloaders",
+        "Tools"
+      ],
+      "ports": [
+        "9117/tcp"
+      ],
+      "volumes": [
+        {
+          "container": "/config",
+          "bind": "/opt/mediadepot/apps/jackett"
+        },
+        {
+          "container": "/downloads",
+          "bind": "/media/storage/downloads"
+        },
+        {
+          "container": "/etc/localtime",
+          "bind": "/etc/localtime",
+          "readonly": true
+        }
+      ],
+      "env": [
+        {
+          "name": "PGID",
+          "label": "PGID",
+          "default": "15000",
+          "preset": true
+        },
+        {
+          "name": "PUID",
+          "label": "PUID",
+          "default": "15000",
+          "preset": true
+        },
+        {
+          "name": "TZ",
+          "label": "TZ",
+          "default": "America/Los_Angeles"
+        }
+      ],
+      "labels": [
+        {
+          "name": "traefik.enable",
+          "value": "true"
+        },
+        {
+          "name": "traefik.http.services.jackett.loadbalancer.server.port",
+          "value": "9117"
+        },
+        {
+          "name": "traefik.http.routers.jackett.entrypoints",
+          "value": "websecure"
+        },
+        {
+          "name": "traefik.http.routers.jackett.tls.certresolver",
+          "value": "mydnschallenge"
+        }
+      ],
+      "maintainer": " https://github.com/mediadepot/templates/"
+    },
+    {
+      "id": 19,
+      "type": 3,
+      "name": "klaxon",
+      "title": "Klaxon",
+      "description": "Klaxon is a free, quick to set up and easy to use robot that checks websites regularly so you don't have to.",
+      "logo": "https://mediadepot.github.io/templates/img/klaxon-logo.png",
+      "categories": [
+        "Documents",
+        "Networkother",
+        "Tools"
+      ],
+      "env": [
+        {
+          "name": "SMTP_PROVIDER",
+          "label": "SMTP_PROVIDER",
+          "default": "SENDGRID"
+        },
+        {
+          "name": "SENDGRID_USERNAME",
+          "label": "SENDGRID_USERNAME",
+          "default": ""
+        },
+        {
+          "name": "SENDGRID_PASSWORD",
+          "label": "SENDGRID_PASSWORD",
+          "default": ""
+        },
+        {
+          "name": "ADMIN_EMAILS",
+          "label": "ADMIN_EMAILS",
+          "default": ""
+        }
+      ],
+      "repository": {
+        "url": "https://github.com/mediadepot/templates",
+        "stackfile": "stacks/klaxon/docker-compose.yml"
+      },
+      "maintainer": " https://github.com/mediadepot/templates/"
+    },
+    {
+      "id": 20,
+      "type": 1,
+      "title": "Librespeed",
+      "name": "librespeed",
+      "note": "Portainer App Templates by <a href='https://www.technorabilia.com' target='_blank'>Technorabilia</a> based on data provided by <a href='https://www.linuxserver.io' target='_blank'>LinuxServer.io</a>.</p><p>Don't forget to create the volume directories on the host file system.</p><p>mkdir -p /volume1/docker/librespeed/config</p>",
+      "description": "[Librespeed](https://github.com/librespeed/speedtest) is a very lightweight Speedtest implemented in Javascript, using XMLHttpRequest and Web Workers. No Flash, No Java, No Websocket, No Bullshit.",
+      "platform": "linux",
+      "logo": "https://raw.githubusercontent.com/librespeed/speedtest/master/.logo/logo3.png",
+      "image": "linuxserver/librespeed:latest",
+      "env": [
+        {
+          "name": "PUID",
+          "label": "PUID",
+          "default": "15000",
+          "description": "for UserID"
+        },
+        {
+          "name": "PGID",
+          "label": "PGID",
+          "default": "15000",
+          "description": "for GroupID"
+        },
+        {
+          "name": "TZ",
+          "label": "TZ",
+          "default": "America/Los_Angeles",
+          "description": "Specify a timezone to use for example Europe/Amsterdam"
+        },
+        {
+          "name": "PASSWORD",
+          "label": "PASSWORD",
+          "default": "PASSWORD",
+          "description": "Set the password for the results database."
+        },
+        {
+          "name": "CUSTOM_RESULTS",
+          "label": "CUSTOM_RESULTS",
+          "default": "false",
+          "description": "(optional) set to `true` to enable custom results page in `/config/www/results/index.php`."
+        },
+        {
+          "name": "DB_TYPE",
+          "label": "DB_TYPE",
+          "default": "sqlite",
+          "description": "Defaults to `sqlite`, can also be set to `mysql` or `postgresql`."
+        },
+        {
+          "name": "DB_NAME",
+          "label": "DB_NAME",
+          "default": "DB_NAME",
+          "description": "Database name. Required for mysql and pgsql."
+        },
+        {
+          "name": "DB_HOSTNAME",
+          "label": "DB_HOSTNAME",
+          "default": "DB_HOSTNAME",
+          "description": "Database address. Required for mysql and pgsql."
+        },
+        {
+          "name": "DB_USERNAME",
+          "label": "DB_USERNAME",
+          "default": "DB_USERNAME",
+          "description": "Database username. Required for mysql and pgsql."
+        },
+        {
+          "name": "DB_PASSWORD",
+          "label": "DB_PASSWORD",
+          "default": "DB_PASSWORD",
+          "description": "Database password. Required for mysql and pgsql."
+        },
+        {
+          "name": "DB_PORT",
+          "label": "DB_PORT",
+          "default": "DB_PORT",
+          "description": "Database port. Required for mysql."
+        }
+      ],
+      "ports": [
+        "80/tcp"
+      ],
+      "volumes": [
+        {
+          "container": "/config",
+          "bind": "/opt/mediadepot/apps/librespeed/config"
+        }
+      ],
+      "labels": [
+        {
+          "name": "traefik.enable",
+          "value": "true"
+        },
+        {
+          "name": "traefik.http.services.librespeed.loadbalancer.server.port",
+          "value": "80"
+        },
+        {
+          "name": "traefik.http.routers.librespeed.entrypoints",
+          "value": "websecure"
+        },
+        {
+          "name": "traefik.http.routers.librespeed.tls.certresolver",
+          "value": "mydnschallenge"
+        }
+      ],
+      "restart_policy": "unless-stopped",
+      "maintainer": " https://github.com/mediadepot/templates/",
+      "categories": []
+    },
+    {
+      "id": 21,
+      "type": 1,
+      "name": "logzio-logs-collector",
+      "title": "Logzio Logs Collector",
+      "description": "Docker container that uses Filebeat to collect logs from other Docker containers and forward those logs to your Logz.io account.",
+      "logo": "https://mediadepot.github.io/templates/img/logzio-icon.png",
+      "image": "logzio/docker-collector-logs",
+      "categories": [
+        "Tools"
+      ],
+      "ports": [],
+      "privileged": true,
+      "volumes": [
+        {
+          "container": "/var/run/docker.sock",
+          "bind": "/var/run/docker.sock",
+          "readonly": true
+        },
+        {
+          "container": "/var/lib/docker/containers",
+          "bind": "/var/lib/docker/containers"
+        }
+      ],
+      "env": [
+        {
+          "name": "LOGZIO_TOKEN",
+          "label": "LOGZIO_TOKEN",
+          "default": "REPLACE-LOGZIO-TOKEN-HERE"
+        },
+        {
+          "name": "LOGZIO_URL",
+          "label": "LOGZIO_URL",
+          "default": "listener.logz.io:5015"
+        }
+      ],
+      "labels": [],
+      "maintainer": " https://github.com/mediadepot/templates/"
+    },
+    {
+      "id": 22,
+      "type": 1,
+      "name": "logzio-metrics-collector",
+      "title": "Logzio Metrics Collector",
+      "description": "Docker Metrics Collector is a container that runs Metricbeat with the modules you enable at runtime.",
+      "logo": "https://mediadepot.github.io/templates/img/logzio-icon.png",
+      "image": "logzio/docker-collector-metrics",
+      "categories": [
+        "Tools"
+      ],
+      "ports": [],
+      "privileged": true,
+      "volumes": [
+        {
+          "container": "/var/run/docker.sock",
+          "bind": "/var/run/docker.sock",
+          "readonly": true
+        },
+        {
+          "container": "/hostfs/sys/fs/cgroup",
+          "bind": "/sys/fs/cgroup",
+          "readonly": true
+        },
+        {
+          "container": "/hostfs/proc",
+          "bind": "/proc",
+          "readonly": true
+        },
+        {
+          "container": "/hostfs",
+          "bind": "/",
+          "readonly": true
+        }
+      ],
+      "env": [
+        {
+          "name": "LOGZIO_TOKEN",
+          "label": "LOGZIO_TOKEN",
+          "default": "REPLACE-LOGZIO-TOKEN-HERE"
+        },
+        {
+          "name": "LOGZIO_MODULES",
+          "label": "LOGZIO_MODULES",
+          "default": "system,docker"
+        }
+      ],
+      "labels": [],
+      "maintainer": " https://github.com/mediadepot/templates/"
+    },
+    {
+      "id": 23,
+      "type": 3,
+      "name": "mayan",
+      "title": "Mayan EDMS",
+      "description": "Mayan EDMS is an electronic vault for your documents.",
+      "logo": "https://mediadepot.github.io/templates/img/mayan-logo.png",
+      "categories": [
+        "Documents",
+        "Tools"
+      ],
+      "repository": {
+        "url": "https://github.com/mediadepot/templates",
+        "stackfile": "stacks/mayan/docker-compose.yml"
+      },
+      "maintainer": " https://github.com/mediadepot/templates/"
+    },
+    {
+      "id": 24,
+      "type": 1,
+      "name": "n8n",
+      "title": "n8n",
+      "description": "n8n allows you to build flexible workflows focused on deep data integration.",
+      "logo": "https://mediadepot.github.io/templates/img/n8n.png",
+      "image": "docker.n8n.io/n8nio/n8n:latest",
+      "categories": [
+        "Networkother",
+        "Tools"
+      ],
+      "ports": [
+        "5678/tcp"
+      ],
+      "volumes": [
+        {
+          "container": "/home/node/.n8n",
+          "bind": "/opt/mediadepot/apps/n8n"
+        },
+        {
+          "container": "/etc/localtime",
+          "bind": "/etc/localtime",
+          "readonly": true
+        }
+      ],
+      "env": [
+        {
+          "name": "GENERIC_TIMEZONE",
+          "label": "GENERIC_TIMEZONE",
+          "default": "America/Los_Angeles",
+          "preset": true
+        },
+        {
+          "name": "TZ",
+          "label": "TZ",
+          "default": "America/Los_Angeles",
+          "preset": true
+        }
+      ],
+      "labels": [
+        {
+          "name": "traefik.enable",
+          "value": "true"
+        },
+        {
+          "name": "traefik.http.services.n8n.loadbalancer.server.port",
+          "value": "5678"
+        },
+        {
+          "name": "traefik.http.routers.n8n.entrypoints",
+          "value": "websecure"
+        },
+        {
+          "name": "traefik.http.routers.n8n.tls.certresolver",
+          "value": "mydnschallenge"
+        }
+      ],
+      "maintainer": " https://github.com/mediadepot/templates/"
+    },
+    {
+      "id": 25,
+      "type": 1,
+      "name": "netbootxyz",
+      "title": "Netboot.xyz",
+      "description": "Netbootxyz is a way to PXE boot various operating system installers or utilities from one place within the BIOS without the need of having to go retrieve the media to run the tool",
+      "logo": "https://mediadepot.github.io/templates/img/netbootxyz.jpg",
+      "image": "linuxserver/netbootxyz:latest",
+      "categories": [
+        "Downloaders",
+        "Networkother",
+        "Tools"
+      ],
+      "ports": [
+        "3000/tcp",
+        "69/udp"
+      ],
+      "volumes": [
+        {
+          "container": "/config",
+          "bind": "/opt/mediadepot/apps/netbootxyz"
+        },
+        {
+          "container": "/assets",
+          "bind": "/media/storage/software/netbootxyz"
+        },
+        {
+          "container": "/etc/localtime",
+          "bind": "/etc/localtime",
+          "readonly": true
+        }
+      ],
+      "env": [
+        {
+          "name": "PGID",
+          "label": "PGID",
+          "default": "15000",
+          "preset": true
+        },
+        {
+          "name": "PUID",
+          "label": "PUID",
+          "default": "15000",
+          "preset": true
+        }
+      ],
+      "labels": [
+        {
+          "name": "traefik.enable",
+          "value": "true"
+        },
+        {
+          "name": "traefik.http.services.netbootxyz.loadbalancer.server.port",
+          "value": "3000"
+        },
+        {
+          "name": "traefik.http.routers.netbootxyz.entrypoints",
+          "value": "websecure"
+        },
+        {
+          "name": "traefik.http.routers.netbootxyz.tls.certresolver",
+          "value": "mydnschallenge"
+        }
+      ],
+      "maintainer": " https://github.com/mediadepot/templates/"
+    },
+    {
+      "id": 26,
+      "type": 1,
+      "name": "ombi",
+      "title": "Ombi",
+      "description": "Ombi allows you to host your own Plex Request and user management system. If you are sharing your Plex server with other users, allow them to request new content using an easy to manage interface",
+      "logo": "https://mediadepot.github.io/templates/img/ombi.png",
+      "image": "linuxserver/ombi:latest",
+      "categories": [
+        "Downloaders",
+        "Networkother",
+        "Mediaappvideo",
+        "Tools"
+      ],
+      "ports": [
+        "3579/tcp"
+      ],
+      "volumes": [
+        {
+          "container": "/config",
+          "bind": "/opt/mediadepot/apps/ombi"
+        },
+        {
+          "container": "/etc/localtime",
+          "bind": "/etc/localtime",
+          "readonly": true
+        }
+      ],
+      "env": [
+        {
+          "name": "PGID",
+          "label": "PGID",
+          "default": "15000",
+          "preset": true
+        },
+        {
+          "name": "PUID",
+          "label": "PUID",
+          "default": "15000",
+          "preset": true
+        }
+      ],
+      "labels": [
+        {
+          "name": "traefik.enable",
+          "value": "true"
+        },
+        {
+          "name": "traefik.http.services.ombi.loadbalancer.server.port",
+          "value": "3579"
+        },
+        {
+          "name": "traefik.http.routers.ombi.entrypoints",
+          "value": "websecure"
+        },
+        {
+          "name": "traefik.http.routers.ombi.tls.certresolver",
+          "value": "mydnschallenge"
+        }
+      ],
+      "maintainer": " https://github.com/mediadepot/templates/"
+    },
+    {
+      "id": 27,
+      "type": 1,
+      "name": "overseerr",
+      "title": "Overseerr",
+      "description": "Overseerr is a request management and media discovery tool built to work with your existing Plex ecosystem.",
+      "logo": "https://mediadepot.github.io/templates/img/overseerr.png",
+      "image": "lscr.io/linuxserver/overseerr:latest",
+      "categories": [
+        "Downloaders",
+        "Networkother",
+        "Mediaappvideo",
+        "Tools"
+      ],
+      "ports": [
+        "5055/tcp"
+      ],
+      "volumes": [
+        {
+          "container": "/config",
+          "bind": "/opt/mediadepot/apps/overseerr"
+        },
+        {
+          "container": "/etc/localtime",
+          "bind": "/etc/localtime",
+          "readonly": true
+        }
+      ],
+      "env": [
+        {
+          "name": "PGID",
+          "label": "PGID",
+          "default": "15000",
+          "preset": true
+        },
+        {
+          "name": "PUID",
+          "label": "PUID",
+          "default": "15000",
+          "preset": true
+        },
+        {
+          "name": "TZ",
+          "label": "TZ",
+          "default": "America/Los_Angeles"
+        }
+      ],
+      "labels": [
+        {
+          "name": "traefik.enable",
+          "value": "true"
+        },
+        {
+          "name": "traefik.http.services.overseerr.loadbalancer.server.port",
+          "value": "5055"
+        },
+        {
+          "name": "traefik.http.routers.overseerr.entrypoints",
+          "value": "websecure"
+        },
+        {
+          "name": "traefik.http.routers.overseerr.tls.certresolver",
+          "value": "mydnschallenge"
+        }
+      ],
+      "maintainer": " https://github.com/mediadepot/templates/"
+    },
+    {
+      "id": 28,
+      "type": 1,
+      "name": "plex",
+      "title": "Plex Media Server",
+      "description": "Plex organizes your video, music, and photo collections and streams them to all of your screens.",
+      "logo": "https://mediadepot.github.io/templates/img/plex-icon.png",
+      "image": "linuxserver/plex:latest",
+      "network": "host",
+      "categories": [
+        "Mediaservervideo",
+        "Mediaservermusic",
+        "Mediaserverphotos"
+      ],
+      "privileged": true,
+      "ports": [],
+      "volumes": [
+        {
+          "container": "/config",
+          "bind": "/opt/mediadepot/apps/plex"
+        },
+        {
+          "container": "/data/tvshows",
+          "bind": "/media/storage/tvshows"
+        },
+        {
+          "container": "/data/movies",
+          "bind": "/media/storage/movies"
+        },
+        {
+          "container": "/data/music",
+          "bind": "/media/storage/music"
+        },
+        {
+          "container": "/transcode"
+        }
+      ],
+      "env": [
+        {
+          "name": "PGID",
+          "label": "PGID",
+          "default": "15000",
+          "preset": true
+        },
+        {
+          "name": "PUID",
+          "label": "PUID",
+          "default": "15000",
+          "preset": true
+        },
+        {
+          "name": "TZ",
+          "label": "TZ",
+          "default": "America/Los_Angeles"
+        },
+        {
+          "name": "VERSION",
+          "label": "VERSION",
+          "default": "latest"
+        }
+      ],
+      "labels": [
+        {
+          "name": "traefik.enable",
+          "value": "true"
+        },
+        {
+          "name": "traefik.http.services.plex.loadbalancer.server.port",
+          "value": "32400"
+        }
+      ],
+      "maintainer": " https://github.com/mediadepot/templates/"
+    },
+    {
+      "id": 29,
+      "type": 3,
+      "name": "plextraktsync",
+      "title": "PlexTraktSync",
+      "description": "A python script that syncs the movies, shows and ratings between trakt and Plex",
+      "logo": "https://mediadepot.github.io/templates/img/plex-icon.png",
+      "categories": [
+        "Documents",
+        "Tools"
+      ],
+      "repository": {
+        "url": "https://github.com/mediadepot/templates",
+        "stackfile": "stacks/plextraktsync/docker-compose.yml"
+      },
+      "maintainer": " https://github.com/mediadepot/templates/"
+    },
+    {
+      "id": 30,
+      "type": 1,
+      "name": "plexrequests",
+      "title": "Plex Requests",
+      "description": "Simple automated way for users to request new content for Plex.",
+      "logo": "https://mediadepot.github.io/templates/img/plex-requests-logo.jpeg",
+      "image": "linuxserver/plexrequests:latest",
+      "categories": [
+        "Downloaders",
+        "Networkother",
+        "Mediaappvideo",
+        "Tools"
+      ],
+      "ports": [
+        "3000/tcp"
+      ],
+      "volumes": [
+        {
+          "container": "/config",
+          "bind": "/opt/mediadepot/apps/plexrequests"
+        },
+        {
+          "container": "/etc/localtime",
+          "bind": "/etc/localtime",
+          "readonly": true
+        }
+      ],
+      "env": [
+        {
+          "name": "PGID",
+          "label": "PGID",
+          "default": "15000",
+          "preset": true
+        },
+        {
+          "name": "PUID",
+          "label": "PUID",
+          "default": "15000",
+          "preset": true
+        }
+      ],
+      "labels": [
+        {
+          "name": "traefik.enable",
+          "value": "true"
+        },
+        {
+          "name": "traefik.http.services.cardigann.plexrequests.server.port",
+          "value": "3000"
+        },
+        {
+          "name": "traefik.http.routers.cardigann.entrypoints",
+          "value": "websecure"
+        },
+        {
+          "name": "traefik.http.routers.cardigann.tls.certresolver",
+          "value": "mydnschallenge"
+        }
+      ],
+      "maintainer": " https://github.com/mediadepot/templates/"
+    },
+    {
+      "id": 31,
+      "type": 1,
+      "name": "prowlarr",
+      "title": "Prowlarr",
+      "description": "Prowlarr is a indexer manager/proxy built on the popular arr .net/reactjs base stack to integrate with your various PVR apps. Prowlarr supports both Torrent Trackers and Usenet Indexers. ",
+      "logo": "https://mediadepot.github.io/templates/img/prowlarr-banner.png",
+      "image": "ghcr.io/linuxserver/prowlarr:develop",
+      "categories": [
+        "Downloaders",
+        "Tools"
+      ],
+      "ports": [
+        "9696/tcp"
+      ],
+      "volumes": [
+        {
+          "container": "/config",
+          "bind": "/opt/mediadepot/apps/prowlarr"
+        },
+        {
+          "container": "/etc/localtime",
+          "bind": "/etc/localtime",
+          "readonly": true
+        }
+      ],
+      "env": [
+        {
+          "name": "PGID",
+          "label": "PGID",
+          "default": "15000",
+          "preset": true
+        },
+        {
+          "name": "PUID",
+          "label": "PUID",
+          "default": "15000",
+          "preset": true
+        },
+        {
+          "name": "TZ",
+          "label": "TZ",
+          "default": "America/Los_Angeles",
+          "preset": true
+        }
+      ],
+      "labels": [
+        {
+          "name": "traefik.enable",
+          "value": "true"
+        },
+        {
+          "name": "traefik.http.services.prowlarr.loadbalancer.server.port",
+          "value": "9696"
+        },
+        {
+          "name": "traefik.http.routers.prowlarr.entrypoints",
+          "value": "websecure"
+        },
+        {
+          "name": "traefik.http.routers.prowlarr.tls.certresolver",
+          "value": "mydnschallenge"
+        }
+      ],
+      "maintainer": " https://github.com/mediadepot/templates/"
+    },
+    {
+      "id": 32,
+      "type": 1,
+      "name": "pureftp",
+      "title": "Pure-FTP Server",
+      "description": "Pure-FTPd is a free (BSD), secure, production-quality and standard-conformant FTP server. ",
+      "logo": "https://mediadepot.github.io/templates/img/pureftpd-icon.jpg",
+      "image": "stilliard/pure-ftpd:hardened",
+      "network": "host",
+      "categories": [
+        "Networkother",
+        "Utilities"
+      ],
+      "ports": [
+        "21/tcp",
+        "30000/tcp",
+        "30001/tcp",
+        "30002/tcp",
+        "30003/tcp",
+        "30004/tcp",
+        "30005/tcp",
+        "30006/tcp",
+        "30007/tcp",
+        "30008/tcp",
+        "30009/tcp"
+      ],
+      "volumes": [
+        {
+          "container": "/etc/pure-ftpd/passwd",
+          "bind": "/opt/mediadepot/apps/pureftp"
+        },
+        {
+          "container": "/data/tvshows",
+          "bind": "/media/storage/tvshows"
+        },
+        {
+          "container": "/data/movies",
+          "bind": "/media/storage/movies"
+        },
+        {
+          "container": "/data/music",
+          "bind": "/media/storage/music"
+        },
+        {
+          "container": "/data/ebooks",
+          "bind": "/media/storage/ebooks"
+        },
+        {
+          "container": "/data/photos",
+          "bind": "/media/storage/photos"
+        },
+        {
+          "container": "/data/documents",
+          "bind": "/media/storage/documents"
+        },
+        {
+          "container": "/data/downloads",
+          "bind": "/media/storage/downloads"
+        },
+        {
+          "container": "/data/software",
+          "bind": "/media/storage/software"
+        },
+        {
+          "container": "/data/blackhole",
+          "bind": "/media/temp/blackhole"
+        },
+        {
+          "container": "/data/processing",
+          "bind": "/media/temp/processing"
+        }
+      ],
+      "env": [
+        {
+          "name": "FTP_USER_NAME",
+          "label": "FTP_USER_NAME",
+          "default": "depot",
+          "preset": true
+        },
+        {
+          "name": "FTP_USER_PASS",
+          "label": "FTP_USER_PASS",
+          "default": "badpass"
+        },
+        {
+          "name": "FTP_USER_HOME",
+          "label": "FTP_USER_HOME",
+          "default": "/data",
+          "preset": true
+        },
+        {
+          "name": "FTP_USER_GID",
+          "label": "FTP_USER_GID",
+          "default": "15000",
+          "preset": true
+        },
+        {
+          "name": "FTP_USER_UID",
+          "label": "FTP_USER_UID",
+          "default": "15000",
+          "preset": true
+        },
+        {
+          "name": "TZ",
+          "label": "TZ",
+          "default": "America/Los_Angeles"
+        },
+        {
+          "name": "PUBLICHOST",
+          "label": "PUBLICHOST",
+          "default": "localhost"
+        }
+      ],
+      "labels": [],
+      "maintainer": " https://github.com/mediadepot/templates/"
+    },
+    {
+      "id": 33,
+      "type": 1,
+      "name": "qdirstat",
+      "title": "qdirstat",
+      "description": "QDirStat is a graphical application to show where your disk space has gone and to help you to clean it up.",
+      "logo": "https://mediadepot.github.io/templates/img/cardigann.png",
+      "image": "jlesage/qdirstat:latest",
+      "categories": [
+        "Utilities"
+      ],
+      "ports": [
+        "5800/tcp"
+      ],
+      "volumes": [
+        {
+          "container": "/config",
+          "bind": "/opt/mediadepot/apps/qdirstat"
+        },
+        {
+          "container": "/storage/opt",
+          "bind": "/opt"
+        },
+        {
+          "container": "/storage/mnt",
+          "bind": "/mnt"
+        }
+      ],
+      "env": [
+        {
+          "name": "PGID",
+          "label": "PGID",
+          "default": "15000",
+          "preset": true
+        },
+        {
+          "name": "PUID",
+          "label": "PUID",
+          "default": "15000",
+          "preset": true
+        }
+      ],
+      "labels": [
+        {
+          "name": "traefik.enable",
+          "value": "true"
+        },
+        {
+          "name": "traefik.http.services.qdirstat.loadbalancer.server.port",
+          "value": "5800"
+        },
+        {
+          "name": "traefik.http.routers.qdirstat.entrypoints",
+          "value": "websecure"
+        },
+        {
+          "name": "traefik.http.routers.qdirstat.tls.certresolver",
+          "value": "mydnschallenge"
+        }
+      ],
+      "maintainer": " https://github.com/mediadepot/templates/"
+    },
+    {
+      "id": 34,
+      "type": 1,
+      "name": "radarr",
+      "title": "Radarr",
+      "description": "Radarr - A fork of Sonarr to work with movies la Couchpotato.",
+      "logo": "https://mediadepot.github.io/templates/img/radarr.png",
+      "image": "linuxserver/radarr:latest",
+      "categories": [
+        "Downloaders",
+        "Mediaappvideo"
+      ],
+      "ports": [
+        "7878/tcp"
+      ],
+      "volumes": [
+        {
+          "container": "/config",
+          "bind": "/opt/mediadepot/apps/radarr"
+        },
+        {
+          "container": "/downloads",
+          "bind": "/media/storage/downloads/movies"
+        },
+        {
+          "container": "/movies",
+          "bind": "/media/storage/movies"
+        },
+        {
+          "container": "/blackhole",
+          "bind": "/media/temp/blackhole/movies"
+        },
+        {
+          "container": "/etc/localtime",
+          "bind": "/etc/localtime",
+          "readonly": true
+        }
+      ],
+      "env": [
+        {
+          "name": "PGID",
+          "label": "PGID",
+          "default": "15000",
+          "preset": true
+        },
+        {
+          "name": "PUID",
+          "label": "PUID",
+          "default": "15000",
+          "preset": true
+        }
+      ],
+      "labels": [
+        {
+          "name": "traefik.enable",
+          "value": "true"
+        },
+        {
+          "name": "traefik.http.services.radarr.loadbalancer.server.port",
+          "value": "7878"
+        },
+        {
+          "name": "traefik.http.routers.radarr.entrypoints",
+          "value": "websecure"
+        },
+        {
+          "name": "traefik.http.routers.radarr.tls.certresolver",
+          "value": "mydnschallenge"
+        }
+      ],
+      "maintainer": " https://github.com/mediadepot/templates/"
+    },
+    {
+      "id": 35,
+      "type": 1,
+      "name": "readarr",
+      "title": "Readarr",
+      "description": "Readarr - Book Manager and Automation (Sonarr for Ebooks)",
+      "logo": "https://mediadepot.github.io/templates/img/readarr-logo.png",
+      "image": "ghcr.io/linuxserver/readarr:nightly",
+      "categories": [
+        "Downloaders",
+        "Mediaappbooks"
+      ],
+      "ports": [
+        "8787/tcp"
+      ],
+      "volumes": [
+        {
+          "container": "/config",
+          "bind": "/opt/mediadepot/apps/readarr"
+        },
+        {
+          "container": "/downloads",
+          "bind": "/media/storage/downloads/ebooks"
+        },
+        {
+          "container": "/books",
+          "bind": "/media/storage/ebooks"
+        },
+        {
+          "container": "/blackhole",
+          "bind": "/media/temp/blackhole/ebooks"
+        },
+        {
+          "container": "/etc/localtime",
+          "bind": "/etc/localtime",
+          "readonly": true
+        }
+      ],
+      "env": [
+        {
+          "name": "PGID",
+          "label": "PGID",
+          "default": "15000",
+          "preset": true
+        },
+        {
+          "name": "PUID",
+          "label": "PUID",
+          "default": "15000",
+          "preset": true
+        },
+        {
+          "name": "TZ",
+          "label": "TZ",
+          "default": "America/Los_Angeles"
+        }
+      ],
+      "labels": [
+        {
+          "name": "traefik.enable",
+          "value": "true"
+        },
+        {
+          "name": "traefik.http.services.readarr.loadbalancer.server.port",
+          "value": "8787"
+        },
+        {
+          "name": "traefik.http.routers.readarr.entrypoints",
+          "value": "websecure"
+        },
+        {
+          "name": "traefik.http.routers.readarr.tls.certresolver",
+          "value": "mydnschallenge"
+        }
+      ],
+      "maintainer": " https://github.com/mediadepot/templates/"
+    },
+    {
+      "id": 36,
+      "type": 1,
+      "name": "rclone",
+      "title": "Rclone Config Backup",
+      "description": "Rclone is a command line program to sync files and directories to and from cloud providers (Dropbox, GDrive, Box, etc)",
+      "logo": "https://mediadepot.github.io/templates/img/rclone.png",
+      "image": "mediadepot/rclone:latest",
+      "categories": [
+        "Backup",
+        "Cloud",
+        "Networkother",
+        "Tools"
+      ],
+      "ports": [],
+      "volumes": [
+        {
+          "container": "/srv/rclone/config",
+          "bind": "/opt/mediadepot/apps/rclone"
+        },
+        {
+          "container": "/mnt/data",
+          "bind": "/opt/mediadepot/apps"
+        }
+      ],
+      "maintainer": " https://github.com/mediadepot/templates/"
+    },
+    {
+      "id": 37,
+      "type": 1,
+      "name": "resilio",
+      "title": "Resilio Sync",
+      "description": "Resilio Sync (formerly BitTorrent Sync) uses the BitTorrent protocol to sync files and folders between all of your devices. There are both free and paid versions, this container supports both.",
+      "logo": "https://mediadepot.github.io/templates/img/resilio.png",
+      "image": "linuxserver/resilio-sync:latest",
+      "categories": [
+        "Backup",
+        "Cloud",
+        "Networkother",
+        "Tools"
+      ],
+      "ports": [
+        "8888/tcp",
+        "55555/tcp"
+      ],
+      "volumes": [
+        {
+          "container": "/config",
+          "bind": "/opt/mediadepot/apps/resilio"
+        },
+        {
+          "container": "/sync",
+          "bind": "/media/storage"
+        },
+        {
+          "container": "/downloads",
+          "bind": "/media/storage/downloads"
+        }
+      ],
+      "env": [
+        {
+          "name": "PGID",
+          "label": "PGID",
+          "default": "15000",
+          "preset": true
+        },
+        {
+          "name": "PUID",
+          "label": "PUID",
+          "default": "15000",
+          "preset": true
+        },
+        {
+          "name": "TZ",
+          "label": "TZ",
+          "default": "America/Los_Angeles"
+        }
+      ],
+      "labels": [
+        {
+          "name": "traefik.enable",
+          "value": "true"
+        },
+        {
+          "name": "traefik.http.services.resilio.loadbalancer.server.port",
+          "value": "8888"
+        },
+        {
+          "name": "traefik.http.routers.resilio.entrypoints",
+          "value": "websecure"
+        },
+        {
+          "name": "traefik.http.routers.resilio.tls.certresolver",
+          "value": "mydnschallenge"
+        }
+      ],
+      "maintainer": " https://github.com/mediadepot/templates/"
+    },
+    {
+      "id": 38,
+      "type": 1,
+      "name": "rutorrent",
+      "title": "ruTorrent",
+      "description": "ruTorrent is a quick and efficient BitTorrent client",
+      "logo": "https://mediadepot.github.io/templates/img/rtorrent-icon.png",
+      "image": "mediadepot/rutorrent",
+      "categories": [
+        "Downloaders",
+        "Networkother",
+        "Tools"
+      ],
+      "ports": [
+        "80/tcp",
+        "51413/tcp",
+        "6881/tcp"
+      ],
+      "volumes": [
+        {
+          "container": "/config",
+          "bind": "/opt/mediadepot/apps/rutorrent"
+        },
+        {
+          "container": "/processing",
+          "bind": "/media/temp/processing"
+        },
+        {
+          "container": "/blackhole",
+          "bind": "/media/temp/blackhole"
+        },
+        {
+          "container": "/downloads",
+          "bind": "/media/storage/downloads"
+        }
+      ],
+      "env": [
+        {
+          "name": "PGID",
+          "label": "PGID",
+          "default": "15000",
+          "preset": true
+        },
+        {
+          "name": "PUID",
+          "label": "PUID",
+          "default": "15000",
+          "preset": true
+        },
+        {
+          "name": "TZ",
+          "label": "TZ",
+          "default": "America/Los_Angeles"
+        }
+      ],
+      "labels": [
+        {
+          "name": "traefik.enable",
+          "value": "true"
+        },
+        {
+          "name": "traefik.http.services.rutorrent.loadbalancer.server.port",
+          "value": "80"
+        },
+        {
+          "name": "traefik.http.routers.rutorrent.entrypoints",
+          "value": "websecure"
+        },
+        {
+          "name": "traefik.http.routers.rutorrent.tls.certresolver",
+          "value": "mydnschallenge"
+        }
+      ],
+      "maintainer": " https://github.com/mediadepot/templates/"
+    },
+    {
+      "id": 39,
+      "type": 1,
+      "name": "scrutiny",
+      "title": "Scrutiny",
+      "description": "WebUI for smartd S.M.A.R.T monitoring",
+      "logo": "https://mediadepot.github.io/templates/img/scrutiny.png",
+      "image": "analogj/scrutiny:latest",
+      "categories": [
+        "Monitoring"
+      ],
+      "ports": [
+        "8080/tcp"
+      ],
+      "volumes": [
+        {
+          "container": "/scrutiny/config/",
+          "bind": "/opt/mediadepot/apps/scrutiny"
+        },
+        {
+          "container": "/run/udev",
+          "bind": "/run/udev",
+          "readonly": true
+        }
+      ],
+      "env": [],
+      "labels": [
+        {
+          "name": "traefik.enable",
+          "value": "true"
+        },
+        {
+          "name": "traefik.http.services.scrutiny.loadbalancer.server.port",
+          "value": "8080"
+        },
+        {
+          "name": "traefik.http.routers.scrutiny.entrypoints",
+          "value": "websecure"
+        },
+        {
+          "name": "traefik.http.routers.scrutiny.tls.certresolver",
+          "value": "mydnschallenge"
+        }
+      ],
+      "maintainer": " https://github.com/mediadepot/templates/"
+    },
+    {
+      "id": 40,
+      "type": 1,
+      "name": "sickrage",
+      "title": "SickRage",
+      "description": "Automatic Video Library Manager for TV Shows. It watches for new episodes of your favorite shows, and when they are posted it does its magic.",
+      "logo": "https://mediadepot.github.io/templates/img/sickrage-icon.png",
+      "image": "linuxserver/sickrage:latest",
+      "categories": [
+        "Downloaders",
+        "Mediaappvideo"
+      ],
+      "ports": [
+        "8081/tcp"
+      ],
+      "volumes": [
+        {
+          "container": "/config",
+          "bind": "/opt/mediadepot/apps/sickrage"
+        },
+        {
+          "container": "/downloads",
+          "bind": "/media/storage/downloads/tvshows"
+        },
+        {
+          "container": "/tv",
+          "bind": "/media/storage/tvshows"
+        },
+        {
+          "container": "/blackhole",
+          "bind": "/media/temp/blackhole/tvshows"
+        }
+      ],
+      "env": [
+        {
+          "name": "PGID",
+          "label": "PGID",
+          "default": "15000",
+          "preset": true
+        },
+        {
+          "name": "PUID",
+          "label": "PUID",
+          "default": "15000",
+          "preset": true
+        },
+        {
+          "name": "TZ",
+          "label": "TZ",
+          "default": "America/Los_Angeles"
+        }
+      ],
+      "labels": [
+        {
+          "name": "traefik.enable",
+          "value": "true"
+        },
+        {
+          "name": "traefik.http.services.sickrage.loadbalancer.server.port",
+          "value": "8081"
+        },
+        {
+          "name": "traefik.http.routers.sickrage.entrypoints",
+          "value": "websecure"
+        },
+        {
+          "name": "traefik.http.routers.sickrage.tls.certresolver",
+          "value": "mydnschallenge"
+        }
+      ],
+      "maintainer": " https://github.com/mediadepot/templates/"
+    },
+    {
+      "id": 41,
+      "type": 1,
+      "name": "sonarr",
+      "title": "Sonarr",
+      "description": "Sonarr (formerly NZBdrone) is a PVR for usenet and bittorrent users. It can monitor multiple RSS feeds for new episodes of your favorite shows and will grab, sort and rename them. It can also be configured to automatically upgrade the quality of files already downloaded when a better quality format becomes available.",
+      "logo": "https://mediadepot.github.io/templates/img/sonarr-icon.png",
+      "image": "linuxserver/sonarr:latest",
+      "categories": [
+        "Downloaders",
+        "Mediaappvideo"
+      ],
+      "ports": [
+        "8989/tcp"
+      ],
+      "volumes": [
+        {
+          "container": "/config",
+          "bind": "/opt/mediadepot/apps/sonarr"
+        },
+        {
+          "container": "/downloads",
+          "bind": "/media/storage/downloads/tvshows"
+        },
+        {
+          "container": "/tv",
+          "bind": "/media/storage/tvshows"
+        },
+        {
+          "container": "/blackhole",
+          "bind": "/media/temp/blackhole/tvshows"
+        },
+        {
+          "container": "/etc/localtime",
+          "bind": "/etc/localtime",
+          "readonly": true
+        }
+      ],
+      "env": [
+        {
+          "name": "PGID",
+          "label": "PGID",
+          "default": "15000",
+          "preset": true
+        },
+        {
+          "name": "PUID",
+          "label": "PUID",
+          "default": "15000",
+          "preset": true
+        }
+      ],
+      "labels": [
+        {
+          "name": "traefik.enable",
+          "value": "true"
+        },
+        {
+          "name": "traefik.http.services.sonarr.loadbalancer.server.port",
+          "value": "8989"
+        },
+        {
+          "name": "traefik.http.routers.sonarr.entrypoints",
+          "value": "websecure"
+        },
+        {
+          "name": "traefik.http.routers.sonarr.tls.certresolver",
+          "value": "mydnschallenge"
+        }
+      ],
+      "maintainer": " https://github.com/mediadepot/templates/"
+    },
+    {
+      "id": 42,
+      "type": 1,
+      "name": "syncserver",
+      "title": "Mozilla Syncserver",
+      "description": "Run-Your-Own Firefox Sync Server",
+      "logo": "https://mediadepot.github.io/templates/img/firefox-logo.png",
+      "image": "mozilla/syncserver:latest",
+      "categories": [
+        "Tools"
+      ],
+      "ports": [
+        "5000/tcp"
+      ],
+      "volumes": [
+        {
+          "container": "/data",
+          "bind": "/opt/mediadepot/apps/syncserver"
+        }
+      ],
+      "env": [
+        {
+          "name": "SYNCSERVER_PUBLIC_URL",
+          "label": "SYNCSERVER_PUBLIC_URL",
+          "default": "https://syncserver.depot.lan"
+        },
+        {
+          "name": "SYNCSERVER_SECRET_FILE",
+          "label": "SYNCSERVER_SECRET_FILE",
+          "default": "/data/secret_key"
+        },
+        {
+          "name": "SYNCSERVER_SQLURI",
+          "label": "SYNCSERVER_SQLURI",
+          "default": "sqlite:////data/syncserver.db"
+        },
+        {
+          "name": "SYNCSERVER_BATCH_UPLOAD_ENABLED",
+          "label": "SYNCSERVER_BATCH_UPLOAD_ENABLED",
+          "default": "true"
+        },
+        {
+          "name": "SYNCSERVER_FORCE_WSGI_ENVIRON",
+          "label": "SYNCSERVER_FORCE_WSGI_ENVIRON",
+          "default": "false"
+        },
+        {
+          "name": "PORT",
+          "label": "PORT",
+          "default": "5000"
+        }
+      ],
+      "labels": [
+        {
+          "name": "traefik.enable",
+          "value": "true"
+        },
+        {
+          "name": "traefik.http.services.syncservere.loadbalancer.server.port",
+          "value": "5000"
+        },
+        {
+          "name": "traefik.http.routers.syncserver.entrypoints",
+          "value": "websecure"
+        },
+        {
+          "name": "traefik.http.routers.syncserver.tls.certresolver",
+          "value": "mydnschallenge"
+        }
+      ],
+      "maintainer": " https://github.com/mediadepot/templates/"
+    },
+    {
+      "id": 43,
+      "type": 1,
+      "name": "tautulli",
+      "title": "Tautulli",
+      "description": "A Python based monitoring and tracking tool for Plex Media Server.",
+      "logo": "https://mediadepot.github.io/templates/img/tautulli-icon.png",
+      "image": "linuxserver/tautulli:latest",
+      "categories": [
+        "Mediaserverother",
+        "Tools"
+      ],
+      "ports": [
+        "8181/tcp"
+      ],
+      "volumes": [
+        {
+          "container": "/config",
+          "bind": "/opt/mediadepot/apps/tautulli"
+        }
+      ],
+      "env": [
+        {
+          "name": "PGID",
+          "label": "PGID",
+          "default": "15000",
+          "preset": true
+        },
+        {
+          "name": "PUID",
+          "label": "PUID",
+          "default": "15000",
+          "preset": true
+        },
+        {
+          "name": "TZ",
+          "label": "TZ",
+          "default": "America/Los_Angeles"
+        }
+      ],
+      "labels": [
+        {
+          "name": "traefik.enable",
+          "value": "true"
+        },
+        {
+          "name": "traefik.http.services.tautulli.loadbalancer.server.port",
+          "value": "8181"
+        },
+        {
+          "name": "traefik.http.routers.tautulli.entrypoints",
+          "value": "websecure"
+        },
+        {
+          "name": "traefik.http.routers.tautulli.tls.certresolver",
+          "value": "mydnschallenge"
+        }
+      ],
+      "maintainer": " https://github.com/mediadepot/templates/"
+    },
+    {
+      "id": 44,
+      "type": 1,
+      "name": "urlwatch",
+      "title": "UrlWatch",
+      "description": "A tool for monitoring webpages for updates",
+      "logo": "https://mediadepot.github.io/templates/img/urlwatch.png",
+      "image": "mediadepot/urlwatch:master",
+      "categories": [
+        "Tools"
+      ],
+      "ports": [
+        "8081/tcp"
+      ],
+      "volumes": [
+        {
+          "container": "/srv/urlwatch/config",
+          "bind": "/opt/mediadepot/apps/urlwatch"
+        },
+        {
+          "container": "/etc/localtime",
+          "bind": "/etc/localtime",
+          "readonly": true
+        }
+      ],
+      "env": [],
+      "labels": [
+        {
+          "name": "traefik.enable",
+          "value": "true"
+        },
+        {
+          "name": "traefik.http.services.urlwatch.loadbalancer.server.port",
+          "value": "8081"
+        },
+        {
+          "name": "traefik.http.routers.urlwatch.entrypoints",
+          "value": "websecure"
+        },
+        {
+          "name": "traefik.http.routers.urlwatch.tls.certresolver",
+          "value": "mydnschallenge"
+        }
+      ],
+      "maintainer": " https://github.com/mediadepot/templates/"
+    },
+    {
+      "id": 45,
+      "type": 1,
+      "name": "vsftpd",
+      "title": "vsftpd FTP Server",
+      "description": "Secure, fast FTP server for UNIX-like systems",
+      "logo": "https://mediadepot.github.io/templates/img/pureftpd-icon.jpg",
+      "image": "delfer/alpine-ftp-server",
+      "network": "host",
+      "categories": [
+        "Networkother",
+        "Utilities"
+      ],
+      "ports": [
+        "21/tcp",
+        "21000/tcp",
+        "21001/tcp",
+        "21002/tcp",
+        "21003/tcp",
+        "21004/tcp",
+        "21005/tcp",
+        "21006/tcp",
+        "21007/tcp",
+        "21008/tcp",
+        "21009/tcp",
+        "21010/tcp"
+      ],
+      "volumes": [
+        {
+          "container": "/home/depot/tvshows",
+          "bind": "/media/storage/tvshows"
+        },
+        {
+          "container": "/home/depot/movies",
+          "bind": "/media/storage/movies"
+        },
+        {
+          "container": "/home/depot/music",
+          "bind": "/media/storage/music"
+        },
+        {
+          "container": "/home/depot/ebooks",
+          "bind": "/media/storage/ebooks"
+        },
+        {
+          "container": "/home/depot/photos",
+          "bind": "/media/storage/photos"
+        },
+        {
+          "container": "/home/depot/documents",
+          "bind": "/media/storage/documents"
+        },
+        {
+          "container": "/home/depot/downloads",
+          "bind": "/media/storage/downloads"
+        },
+        {
+          "container": "/home/depot/software",
+          "bind": "/media/storage/software"
+        },
+        {
+          "container": "/home/depot/blackhole",
+          "bind": "/media/temp/blackhole"
+        },
+        {
+          "container": "/home/depot/processing",
+          "bind": "/media/temp/processing"
+        }
+      ],
+      "env": [
+        {
+          "name": "ADDRESS",
+          "label": "ADDRESS"
+        },
+        {
+          "name": "USERS",
+          "label": "USERS",
+          "default": "depot|badpass|/home/depot|15000"
+        }
+      ],
+      "labels": [],
+      "maintainer": " https://github.com/mediadepot/templates/"
+    },
+    {
+      "id": 46,
+      "type": 1,
+      "name": "watchtower",
+      "title": "Watchtower",
+      "description": "Automatically update running Docker containers",
+      "logo": "https://mediadepot.github.io/templates/img/watchtower-logo.png",
+      "image": "containrrr/watchtower:latest",
+      "command": "--cleanup --label-enable",
+      "categories": [
+        "Tools"
+      ],
+      "volumes": [
+        {
+          "container": "/var/run/docker.sock",
+          "bind": "/var/run/docker.sock"
+        }
+      ],
+      "env": [],
+      "maintainer": " https://github.com/mediadepot/templates/"
+    },
+    {
+      "id": 47,
+      "type": 1,
+      "name": "wizarr",
+      "title": "Wizarr",
+      "description": " Wizarr is an advanced user invitation and management system for Jellyfin, Plex, Emby etc. ",
+      "logo": "https://mediadepot.github.io/templates/img/wizarr-logo.png",
+      "image": "ghcr.io/wizarrrr/wizarr",
+      "categories": [
+        "Tools"
+      ],
+      "ports": [
+        "5690/tcp"
+      ],
+      "volumes": [
+        {
+          "container": "/data/database",
+          "bind": "/opt/mediadepot/apps/wizarr"
+        },
+        {
+          "container": "/etc/localtime",
+          "bind": "/etc/localtime",
+          "readonly": true
+        }
+      ],
+      "env": [
+        {
+          "name": "APP_URL",
+          "label": "APP_URL",
+          "default": "https://wizarr.domain.com"
+        }
+      ],
+      "labels": [
+        {
+          "name": "traefik.enable",
+          "value": "true"
+        },
+        {
+          "name": "traefik.http.services.wizarr.loadbalancer.server.port",
+          "value": "5690"
+        },
+        {
+          "name": "traefik.http.routers.wizarr.entrypoints",
+          "value": "websecure"
+        },
+        {
+          "name": "traefik.http.routers.wizarr.tls.certresolver",
+          "value": "mydnschallenge"
+        }
+      ],
+      "maintainer": " https://github.com/mediadepot/templates/"
+    },
+    {
+      "id": 48,
+      "categories": [
+        "Productivity",
+        "Social"
+      ],
+      "description": "Open source collaborative knowledge base for modern teams",
+      "env": [
+        {
+          "default": "production",
+          "label": "NODE_ENV",
+          "name": "NODE_ENV"
+        },
+        {
+          "default": "",
+          "label": "SECRET_KEY",
+          "name": "SECRET_KEY"
+        },
+        {
+          "default": "",
+          "label": "UTILS_SECRET",
+          "name": "UTILS_SECRET"
+        },
+        {
+          "default": "",
+          "label": "DATABASE_URL",
+          "name": "DATABASE_URL"
+        },
+        {
+          "default": "",
+          "label": "DATABASE_URL_TEST",
+          "name": "DATABASE_URL_TEST"
+        },
+        {
+          "default": "",
+          "label": "DATABASE_CONNECTION_POOL_MIN",
+          "name": "DATABASE_CONNECTION_POOL_MIN"
+        },
+        {
+          "default": "",
+          "label": "DATABASE_CONNECTION_POOL_MAX",
+          "name": "DATABASE_CONNECTION_POOL_MAX"
+        },
+        {
+          "default": "",
+          "label": "REDIS_URL",
+          "name": "REDIS_URL"
+        },
+        {
+          "default": "",
+          "label": "URL",
+          "name": "URL"
+        },
+        {
+          "default": "3000",
+          "label": "PORT",
+          "name": "PORT"
+        },
+        {
+          "default": "",
+          "label": "COLLABORATION_URL",
+          "name": "COLLABORATION_URL"
+        },
+        {
+          "default": "",
+          "label": "GOOGLE_CLIENT_ID",
+          "name": "GOOGLE_CLIENT_ID"
+        },
+        {
+          "default": "",
+          "label": "GOOGLE_CLIENT_SECRET",
+          "name": "GOOGLE_CLIENT_SECRET"
+        },
+        {
+          "default": "",
+          "label": "SSL_KEY",
+          "name": "SSL_KEY"
+        },
+        {
+          "default": "",
+          "label": "SSL_CERT",
+          "name": "SSL_CERT"
+        },
+        {
+          "default": "true",
+          "label": "FORCE_HTTPS",
+          "name": "FORCE_HTTPS"
+        },
+        {
+          "default": "true",
+          "label": "ENABLE_UPDATES",
+          "name": "ENABLE_UPDATES"
+        },
+        {
+          "default": "1",
+          "label": "WEB_CONCURRENCY",
+          "name": "WEB_CONCURRENCY"
+        },
+        {
+          "default": "5120000",
+          "label": "MAXIMUM_IMPORT_SIZE",
+          "name": "MAXIMUM_IMPORT_SIZE"
+        },
+        {
+          "default": "http",
+          "label": "DEBUG",
+          "name": "DEBUG"
+        },
+        {
+          "default": "info",
+          "label": "LOG_LEVEL",
+          "name": "LOG_LEVEL"
+        },
+        {
+          "default": "",
+          "label": "GOOGLE_ANALYTICS_ID",
+          "name": "GOOGLE_ANALYTICS_ID"
+        },
+        {
+          "default": "",
+          "label": "SENTRY_DSN",
+          "name": "SENTRY_DSN"
+        },
+        {
+          "default": "",
+          "label": "SENTRY_TUNNEL",
+          "name": "SENTRY_TUNNEL"
+        },
+        {
+          "default": "",
+          "label": "SMTP_HOST",
+          "name": "SMTP_HOST"
+        },
+        {
+          "default": "",
+          "label": "SMTP_PORT",
+          "name": "SMTP_PORT"
+        },
+        {
+          "default": "",
+          "label": "SMTP_USERNAME",
+          "name": "SMTP_USERNAME"
+        },
+        {
+          "default": "",
+          "label": "SMTP_PASSWORD",
+          "name": "SMTP_PASSWORD"
+        },
+        {
+          "default": "",
+          "label": "SMTP_FROM_EMAIL",
+          "name": "SMTP_FROM_EMAIL"
+        },
+        {
+          "default": "",
+          "label": "SMTP_REPLY_EMAIL",
+          "name": "SMTP_REPLY_EMAIL"
+        },
+        {
+          "default": "",
+          "label": "SMTP_TLS_CIPHERS",
+          "name": "SMTP_TLS_CIPHERS"
+        },
+        {
+          "default": "true",
+          "label": "SMTP_SECURE",
+          "name": "SMTP_SECURE"
+        },
+        {
+          "default": "en_US",
+          "label": "DEFAULT_LANGUAGE",
+          "name": "DEFAULT_LANGUAGE"
+        },
+        {
+          "default": "true",
+          "label": "RATE_LIMITER_ENABLED",
+          "name": "RATE_LIMITER_ENABLED"
+        },
+        {
+          "default": "1000",
+          "label": "RATE_LIMITER_REQUESTS",
+          "name": "RATE_LIMITER_REQUESTS"
+        },
+        {
+          "default": "60",
+          "label": "RATE_LIMITER_DURATION_WINDOW",
+          "name": "RATE_LIMITER_DURATION_WINDOW"
+        }
+      ],
+      "logo": "https://avatars.githubusercontent.com/u/1765001",
+      "name": "outline",
+      "note": "Open source collaborative knowledge base for modern teams",
+      "platform": "linux",
+      "repository": {
+        "stackfile": "sources/stacks/outline.yml",
+        "url": "https://github.com/lissy93/portainer-templates"
+      },
+      "restart_policy": "unless-stopped",
+      "title": "Outline",
+      "type": 3
+    },
+    {
+      "id": 49,
+      "categories": [
+        "Authenticationserver"
+      ],
+      "description": "Authentik is an open-source Identity Provider focused on flexibility and versatility",
+      "env": [
+        {
+          "default": "1000",
+          "label": "PUID",
+          "name": "PUID"
+        },
+        {
+          "default": "1000",
+          "label": "PGID",
+          "name": "PGID"
+        },
+        {
+          "label": "PORT",
+          "name": "PORT"
+        }
+      ],
+      "logo": "https://raw.githubusercontent.com/mycroftwilde/portainer_templates/master/Images/goauthentik.png",
+      "name": "Authentik",
+      "platform": "linux",
+      "repository": {
+        "stackfile": "Template/Stack/authentik.yml",
+        "url": "https://github.com/xneo1/portainer_templates"
+      },
+      "title": "Authentik",
+      "type": 3,
+      "maintainer": " https://github.com/mycroftwilde/portainer_templates/"
+    },
+    {
+      "id": 50,
+      "type": 1,
+      "title": "Apprise-api",
+      "name": "Apprise-api",
+      "note": "Portainer App Templates by <a href='https://www.technorabilia.com' target='_blank'>Technorabilia</a> based on data provided by <a href='https://www.linuxserver.io' target='_blank'>LinuxServer.io</a>.</p><p>Don't forget to create the volume directories on the host file system.</p><p>mkdir -p /volume1/docker/apprise-api/config</p>",
+      "description": "[Apprise-api](https://github.com/caronc/apprise-api) Takes advantage of [Apprise](https://github.com/caronc/apprise) through your network with a user-friendly API. * Send notifications to more then 65+ services. * An incredibly lightweight gateway to Apprise. * A production ready micro-service at your disposal. Apprise API was designed to easily fit into existing (and new) eco-systems that are looking for a simple notification solution.",
+      "categories": [
+        "Taskserver"
+      ],
+      "platform": "linux",
+      "logo": "https://raw.githubusercontent.com/caronc/apprise-api/master/apprise_api/static/logo.png",
+      "image": "linuxserver/apprise-api:latest",
+      "env": [
+        {
+          "name": "PUID",
+          "label": "PUID",
+          "default": "1024",
+          "description": "for UserID"
+        },
+        {
+          "name": "PGID",
+          "label": "PGID",
+          "default": "100",
+          "description": "for GroupID"
+        },
+        {
+          "name": "TZ",
+          "label": "TZ",
+          "default": "Europe/Amsterdam",
+          "description": "Specify a timezone to use for example Europe/Amsterdam"
+        }
+      ],
+      "ports": [
+        "8000:8000/tcp"
+      ],
+      "volumes": [
+        {
+          "container": "/config",
+          "bind": "/volume1/docker/apprise-api/config"
+        }
+      ],
+      "restart_policy": "unless-stopped",
+      "maintainer": " https://github.com/mycroftwilde/portainer_templates/"
+    },
+    {
+      "id": 51,
+      "type": 1,
+      "title": "Pwndrop",
+      "name": "Pwndrop",
+      "note": "Portainer App Templates by <a href='https://www.technorabilia.com' target='_blank'>Technorabilia</a> based on data provided by <a href='https://www.linuxserver.io' target='_blank'>LinuxServer.io</a>.</p><p>Don't forget to create the volume directories on the host file system.</p><p>mkdir -p /volume1/docker/pwndrop/config</p>",
+      "description": "[Pwndrop](https://github.com/kgretzky/pwndrop) is a self-deployable file hosting service for sending out red teaming payloads or securely sharing your private files over HTTP and WebDAV.",
+      "platform": "linux",
+      "logo": "https://raw.githubusercontent.com/kgretzky/pwndrop/master/media/pwndrop-logo-512.png",
+      "image": "linuxserver/pwndrop:latest",
+      "categories": [
+        "Taskserver"
+      ],
+      "env": [
+        {
+          "name": "PUID",
+          "label": "PUID",
+          "default": "1024",
+          "description": "for UserID"
+        },
+        {
+          "name": "PGID",
+          "label": "PGID",
+          "default": "100",
+          "description": "for GroupID"
+        },
+        {
+          "name": "TZ",
+          "label": "TZ",
+          "default": "Europe/Amsterdam",
+          "description": "Specify a timezone to use for example Europe/Amsterdam"
+        },
+        {
+          "name": "SECRET_PATH",
+          "label": "SECRET_PATH",
+          "default": "/pwndrop",
+          "description": "Secret path for admin access. Defaults to `/pwndrop`. This parameter only takes effect during initial install; it can later be changed in the web gui."
+        }
+      ],
+      "ports": [
+        "8080:8080/tcp"
+      ],
+      "volumes": [
+        {
+          "container": "/config",
+          "bind": "/volume1/docker/pwndrop/config"
+        }
+      ],
+      "restart_policy": "unless-stopped",
+      "maintainer": " https://github.com/mycroftwilde/portainer_templates/"
+    },
+    {
+      "id": 52,
+      "type": 1,
+      "categories": [
+        "Familyappserver"
+      ],
+      "title": "Firefox",
+      "name": "Firefox",
+      "note": "Portainer App Templates by <a href='https://www.technorabilia.com' target='_blank'>Technorabilia</a> based on data provided by <a href='https://www.linuxserver.io' target='_blank'>LinuxServer.io</a>.</p><p>Don't forget to create the volume directories on the host file system.</p><p>mkdir -p /volume1/docker/firefox/config</p>",
+      "description": "[Firefox](https://www.mozilla.org/en-US/firefox/) Browser, also known as Mozilla Firefox or simply Firefox, is a free and open-source web browser developed by the Mozilla Foundation and its subsidiary, the Mozilla Corporation. Firefox uses the Gecko layout engine to render web pages, which implements current and anticipated web standards.",
+      "platform": "linux",
+      "logo": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/firefox-logo.png",
+      "image": "linuxserver/firefox:latest",
+      "env": [
+        {
+          "name": "PUID",
+          "label": "PUID",
+          "default": "1024",
+          "description": "for GroupID"
+        },
+        {
+          "name": "PGID",
+          "label": "PGID",
+          "default": "100",
+          "description": "for UserID"
+        },
+        {
+          "name": "TZ",
+          "label": "TZ",
+          "default": "Europe/Amsterdam",
+          "description": "Specify a timezone to use for example Europe/Amsterdam"
+        }
+      ],
+      "ports": [
+        "3000:3000/tcp"
+      ],
+      "volumes": [
+        {
+          "container": "/config",
+          "bind": "/volume1/docker/firefox/config"
+        }
+      ],
+      "restart_policy": "unless-stopped",
+      "maintainer": " https://github.com/mycroftwilde/portainer_templates/"
+    },
+    {
+      "id": 53,
+      "categories": [
+        "Managementutilityserver"
+      ],
+      "description": "Remote Management Server",
+      "env": [
+        {
+          "default": "/portainer/Files/AppData/MeshCentral/Config",
+          "label": "Config Container Bind",
+          "name": "CONFIG"
+        },
+        {
+          "default": "/portainer/Files/AppData/MeshCentral/Files",
+          "label": "Files Container Bind",
+          "name": "FILES"
+        },
+        {
+          "default": "/portainer/Files/AppData/MeshCentral/Backup",
+          "label": "Backup Container Bind",
+          "name": "BACK"
+        },
+        {
+          "default": "443",
+          "label": "Container Port 443",
+          "name": "PORT4"
+        },
+        {
+          "default": "80",
+          "label": "Container Port 80",
+          "name": "PORT8"
+        }
+      ],
+      "logo": "https://raw.githubusercontent.com/mycroftwilde/portainer_templates/master/Images/meshc.png",
+      "note": "MeshCentral",
+      "platform": "linux",
+      "repository": {
+        "stackfile": "Template/Stack/mesh.yml",
+        "url": "https://github.com/mycroftwilde/portainer_templates"
+      },
+      "title": "MeshCentral",
+      "type": 3,
+      "maintainer": " https://github.com/mycroftwilde/portainer_templates/"
+    },
+    {
+      "id": 54,
+      "categories": [
+        "Dashboardserver"
+      ],
+      "description": "Freeboard is a turn-key HTML-based 'engine' for dashboards. Besides a nice looking layout engine, it provides a plugin architecture for creating datasources (which fetch data) and widgets (which display data)— freeboard then does all the work to connect the two together.",
+      "logo": "https://raw.githubusercontent.com/xneo1/portainer_templates/master/Images/freeboard.jpg",
+      "name": "freeboard",
+      "repository": {
+        "stackfile": "Template/Stack/freeboard.yml",
+        "url": "https://github.com/xneo1/portainer_templates"
+      },
+      "platform": "linux",
+      "ports": [
+        "8000:80/tcp"
+      ],
+      "restart_policy": "always",
+      "title": "Freeboard",
+      "type": 3,
+      "maintainer": " https://github.com/mycroftwilde/portainer_templates/"
+    },
+    {
+      "id": 55,
+      "categories": [
+        "Financeserver"
+      ],
+      "description": "Ghostfolio is an open source wealth management software built with web technology.",
+      "logo": "https://avatars.githubusercontent.com/u/82473144?s=200",
+      "name": "Ghostfolio",
+      "repository": {
+        "stackfile": "Template/Stack/ghostfolio.yml",
+        "url": "https://github.com/xneo1/portainer_templates"
+      },
+      "platform": "linux",
+      "ports": [
+        "3663:80/tcp"
+      ],
+      "restart_policy": "always",
+      "title": "Ghostfolio",
+      "type": 3,
+      "maintainer": " https://github.com/mycroftwilde/portainer_templates/"
+    },
+    {
+      "id": 56,
+      "categories": [
+        "Tools"
+      ],
+      "description": "A self-hosted bookmark management tool.",
+      "logo": "https://github.com/beromir/Servas/raw/main/docs/images/home.png",
+      "name": "Servas",
+      "repository": {
+        "stackfile": "Template/Stack/servas.yml",
+        "url": "https://github.com/xneo1/portainer_templates"
+      },
+      "platform": "linux",
+      "ports": [
+        "8456:80/tcp"
+      ],
+      "restart_policy": "always",
+      "title": "Servas",
+      "type": 3,
+      "maintainer": " https://github.com/mycroftwilde/portainer_templates/"
+    },
+    {
+      "id": 57,
+      "categories": [
+        "Tools"
+      ],
+      "description": "wallabag is a web application allowing you to save web pages for later reading. Click, save and read it when you want.",
+      "logo": "https://www.wallabag.org/user/themes/boxify/img/logo-wallabag.svg",
+      "name": "Wallabag",
+      "repository": {
+        "stackfile": "Template/Stack/wallabag.yml",
+        "url": "https://github.com/xneo1/portainer_templates"
+      },
+      "platform": "linux",
+      "ports": [
+        "8234:80/tcp"
+      ],
+      "restart_policy": "always",
+      "title": "Wallabag",
+      "type": 3,
+      "maintainer": " https://github.com/mycroftwilde/portainer_templates/"
+    },
+    {
+      "id": 58,
+      "categories": [
+        "Networkserver"
+      ],
+      "description": "WIFI / LAN intruder detector",
+      "env": [
+        {
+          "default": "1000",
+          "label": "PUID",
+          "name": "PUID"
+        },
+        {
+          "default": "100",
+          "label": "PGID",
+          "name": "PGID"
+        }
+      ],
+      "image": "jokobsk/pi.alert",
+      "logo": "https://raw.githubusercontent.com/pucherot/Pi.Alert/main/docs/img/1_devices.jpg",
+      "name": "pi.alert",
+      "platform": "linux",
+      "ports": [
+        "20211:20211/udp"
+      ],
+      "restart_policy": "always",
+      "title": "Pi.alert",
+      "type": 1,
+      "volumes": [
+        {
+          "bind": "/portainer/Files/AppData/Config/pi.alert",
+          "container": "/config"
+        }
+      ],
+      "maintainer": " https://github.com/mycroftwilde/portainer_templates/"
+    },
+    {
+      "id": 59,
+      "categories": [
+        "Notesserver"
+      ],
+      "description": "Trilium Notes is a hierarchical note taking application with focus on building large personal knowledge bases",
+      "env": [
+        {
+          "default": "/home/node/trilium-data",
+          "label": "TRILIUM_DATA_DIR",
+          "name": "TRILIUM_DATA_DIR"
+        },
+        {
+          "label": "PORT",
+          "name": "PORT"
+        }
+      ],
+      "image": "zadam/trilium:latest",
+      "logo": "https://www.saashub.com/images/app/service_logos/55/2901389fab77/large.png?1561117248",
+      "name": "trilium",
+      "platform": "linux",
+      "ports": [
+        "3388:8080/tcp"
+      ],
+      "restart_policy": "unless-stopped",
+      "title": "Trilium",
+      "type": 1,
+      "volumes": [
+        {
+          "bind": "/portainer/Files/AppData/Config/trilium-data",
+          "container": "/home/node/trilium-data"
+        }
+      ],
+      "maintainer": " https://github.com/mycroftwilde/portainer_templates/"
+    },
+    {
+      "id": 60,
+      "categories": [
+        "Smarthome"
+      ],
+      "description": "A complete and local NVR designed for Home Assistant with AI object detection. Uses OpenCV and Tensorflow to perform realtime object detection locally for IP cameras.",
+      "logo": "https://raw.githubusercontent.com/blakeblackshear/frigate/master/docs/static/img/frigate.png",
+      "name": "frigatenvr",
+      "platform": "linux",
+      "repository": {
+        "stackfile": "Template/Stack/frigatenvr.yml",
+        "url": "https://github.com/xneo1/portainer_templates"
+      },
+      "title": "Frigate NVR",
+      "type": 3,
+      "maintainer": " https://github.com/mycroftwilde/portainer_templates/"
+    },
+    {
+      "id": 61,
+      "categories": [
+        "Dashboardserver"
+      ],
+      "description": "Fenrus is a Node application and requires NodeJS to run. Once NodeJS is installed you can run Fenrus",
+      "env": [
+        {
+          "default": "1000",
+          "label": "PUID",
+          "name": "PUID"
+        },
+        {
+          "default": "1000",
+          "label": "PGID",
+          "name": "PGID"
+        },
+        {
+          "label": "PORT",
+          "name": "PORT"
+        }
+      ],
+      "logo": "https://user-images.githubusercontent.com/958400/154829266-62206846-c6ef-4718-9910-2b83eb6aa41c.png",
+      "name": "Fenrus",
+      "platform": "linux",
+      "repository": {
+        "stackfile": "Template/Stack/fenrus.yml",
+        "url": "https://github.com/xneo1/portainer_templates"
+      },
+      "title": "Fenrus",
+      "type": 3,
+      "maintainer": " https://github.com/mycroftwilde/portainer_templates/"
+    },
+    {
+      "id": 62,
+      "categories": [
+        "Libraryserver"
+      ],
+      "description": "Audiobook Server",
+      "env": [
+        {
+          "default": "1000",
+          "label": "PUID",
+          "name": "PUID"
+        },
+        {
+          "default": "1000",
+          "label": "PGID",
+          "name": "PGID"
+        }
+      ],
+      "image": "ghcr.io/advplyr/audiobookshelf:latest",
+      "logo": "https://raw.githubusercontent.com/mycroftwilde/portainer_templates/master/Images/AudioBookshelfLogo.png",
+      "name": "Audiobookshelf",
+      "platform": "linux",
+      "ports": [
+        "13378:80/tcp"
+      ],
+      "restart_policy": "unless-stopped",
+      "title": "Audiobookshelf",
+      "type": 1,
+      "volumes": [
+        {
+          "bind": "/portainer/Files/AppData/Config/Audiobookshelf",
+          "container": "/config"
+        },
+        {
+          "bind": "/path/to/audiobooks",
+          "container": "/audiobooks"
+        },
+        {
+          "bind": "/path/to/podcasts",
+          "container": "/podcasts"
+        },
+        {
+          "bind": "/path/to/Metadata",
+          "container": "/metadata"
+        }
+      ],
+      "maintainer": " https://github.com/mycroftwilde/portainer_templates/"
+    },
+    {
+      "id": 63,
+      "categories": [
+        "Familyappserver"
+      ],
+      "description": "Vikunja is a self hosted, open-source to-do list application",
+      "env": [
+        {
+          "default": "192.168.0.2",
+          "label": "IP",
+          "name": "IP"
+        },
+        {
+          "default": "80",
+          "label": "PORT",
+          "name": "PORT"
+        }
+      ],
+      "logo": "https://raw.githubusercontent.com/go-vikunja/frontend/main/public/images/icons/android-chrome-192x192.png",
+      "note": "Vikunja is a self hosted, open-source to-do list application",
+      "platform": "linux",
+      "repository": {
+        "stackfile": "Template/Stack/vikunja.yml",
+        "url": "https://github.com/mycroftwilde/portainer_templates"
+      },
+      "title": "Vikunja",
+      "type": 3,
+      "maintainer": " https://github.com/mycroftwilde/portainer_templates/"
+    },
+    {
+      "id": 64,
+      "categories": [
+        "Mediaserver"
+      ],
+      "description": "Helps you organize your *Ahem* ...more MATURE Media material....",
+      "env": [
+        {
+          "label": "PORT",
+          "name": "PORT"
+        }
+      ],
+      "logo": "https://dashy.to/img/dashy.png",
+      "name": "Stash",
+      "note": "## Keep configs, scrapers, and plugins here. </p><p> - /portainer/Files/AppData/Config/stash:/root/.stash </p><p> ## Point this at your collection. </p><p> - ./data:/data </p><p> ## This is where your stash's metadata lives </p><p> - /portainer/Files/AppData/Config/stashmeta:/metadata </p><p> ## Any other cache content. </p><p> - /portainer/Files/AppData/Config/stashcache:/cache </p><p> ## Where to store generated content (screenshots,previews,transcodes,sprites) </p><p> - /portainer/Files/AppData/Config/stashgenerated:/generated",
+      "platform": "linux",
+      "repository": {
+        "stackfile": "Template/Stack/stash.yml",
+        "url": "https://github.com/mycroftwilde/portainer_templates"
+      },
+      "title": "Stash",
+      "type": 3,
+      "maintainer": " https://github.com/mycroftwilde/portainer_templates/"
+    },
+    {
+      "id": 65,
+      "categories": [
+        "Chatserver"
+      ],
+      "description": "Rocket.Chat Server",
+      "logo": "https://raw.githubusercontent.com/portapps/rocketchat-portable/master/res/papp.png",
+      "note": "Rocket.Chat Server Container",
+      "platform": "linux",
+      "repository": {
+        "stackfile": "Template/Stack/rocketchat.yml",
+        "url": "https://github.com/mycroftwilde/portainer_templates"
+      },
+      "title": "Rocket Chat",
+      "type": 3,
+      "maintainer": " https://github.com/mycroftwilde/portainer_templates/"
+    },
+    {
+      "id": 66,
+      "categories": [
+        "Notesserver"
+      ],
+      "description": "Joplin is an open-source note-taking app",
+      "env": [
+        {
+          "default": "22300",
+          "label": "PORT",
+          "name": "PORT"
+        },
+        {
+          "default": "http://joplin.yourdomain.tld:22300",
+          "label": "URL",
+          "name": "URL"
+        }
+      ],
+      "logo": "https://raw.githubusercontent.com/laurent22/joplin/master/Assets/SquareIcon512.png",
+      "note": "Joplin is an open-source note-taking app",
+      "platform": "linux",
+      "repository": {
+        "stackfile": "Template/Stack/joplin.yml",
+        "url": "https://github.com/mycroftwilde/portainer_templates"
+      },
+      "title": "Joplin",
+      "type": 3,
+      "maintainer": " https://github.com/mycroftwilde/portainer_templates/"
+    },
+    {
+      "id": 67,
+      "type": 1,
+      "categories": [
+        "Libraryserver"
+      ],
+      "title": "Calibre",
+      "name": "Calibre",
+      "note": "Portainer App Templates by <a href='https://www.technorabilia.com' target='_blank'>Technorabilia</a> based on data provided by <a href='https://www.linuxserver.io' target='_blank'>LinuxServer.io</a>.</p><p>Don't forget to create the volume directories on the host file system.</p><p>mkdir -p /volume1/docker/calibre/config</p>",
+      "description": "Calibre is a powerful and easy to use e-book manager. Users say it’s outstanding and a must-have. It’ll allow you to do nearly everything and it takes things a step beyond normal e-book software. It’s also completely free and open source and great for both casual users and computer experts.",
+      "platform": "linux",
+      "logo": "https://github.com/kovidgoyal/calibre/raw/master/resources/images/lt.png",
+      "image": "linuxserver/calibre:latest",
+      "env": [
+        {
+          "name": "PUID",
+          "label": "PUID",
+          "default": "1024",
+          "description": "for GroupID"
+        },
+        {
+          "name": "PGID",
+          "label": "PGID",
+          "default": "100",
+          "description": "for UserID"
+        },
+        {
+          "name": "TZ",
+          "label": "TZ",
+          "default": "Europe/Amsterdam",
+          "description": "Specify a timezone to use for example Europe/Amsterdam"
+        },
+        {
+          "name": "PASSWORD",
+          "label": "PASSWORD",
+          "default": "",
+          "description": "Optionally set a password for the gui."
+        },
+        {
+          "name": "CLI_ARGS",
+          "label": "CLI_ARGS",
+          "default": "",
+          "description": "Optionally pass cli start arguments to calibre."
+        }
+      ],
+      "ports": [
+        "8080:8080/tcp",
+        "8081:8081/tcp"
+      ],
+      "volumes": [
+        {
+          "container": "/config",
+          "bind": "/volume1/docker/calibre/config"
+        }
+      ],
+      "restart_policy": "unless-stopped",
+      "maintainer": " https://github.com/mycroftwilde/portainer_templates/"
+    },
+    {
+      "id": 68,
+      "type": 1,
+      "categories": [
+        "Smarthome"
+      ],
+      "title": "Habridge",
+      "name": "Habridge",
+      "note": "Portainer App Templates by <a href='https://www.technorabilia.com' target='_blank'>Technorabilia</a> based on data provided by <a href='https://www.linuxserver.io' target='_blank'>LinuxServer.io</a>.</p><p>Don't forget to create the volume directories on the host file system.</p><p>mkdir -p /volume1/docker/habridge/config</p>",
+      "description": "Habridge emulates Philips Hue API to other home automation gateways such as an Amazon Echo/Dot Gen 1 (gen 2 has issues discovering ha-bridge) or other systems that support Philips Hue.  [https://github.com/bwssytems/ha-bridge/wiki](https://github.com/bwssytems/ha-bridge/wiki)",
+      "platform": "linux",
+      "logo": "https://raw.githubusercontent.com/bwssytems/ha-bridge/master/src/main/resources/public/img/favicon.ico",
+      "image": "linuxserver/habridge:latest",
+      "env": [
+        {
+          "name": "PUID",
+          "label": "PUID",
+          "default": "1024",
+          "description": "for GroupID"
+        },
+        {
+          "name": "PGID",
+          "label": "PGID",
+          "default": "100",
+          "description": "for UserID"
+        },
+        {
+          "name": "SEC_KEY",
+          "label": "SEC_KEY",
+          "default": "<Your Key To Encrypt Security Data>",
+          "description": "Key used to secure communication."
+        },
+        {
+          "name": "TZ",
+          "label": "TZ",
+          "default": "Europe/Amsterdam",
+          "description": "Specify a timezone to use for example Europe/Amsterdam"
+        }
+      ],
+      "ports": [
+        "8080:8080/tcp",
+        "50000:50000/tcp"
+      ],
+      "volumes": [
+        {
+          "container": "/config",
+          "bind": "/volume1/docker/habridge/config"
+        }
+      ],
+      "restart_policy": "unless-stopped",
+      "maintainer": " https://github.com/mycroftwilde/portainer_templates/"
+    },
+    {
+      "id": 69,
+      "categories": [
+        "Dashboardserver"
+      ],
+      "description": "MagicMirror2 Server",
+      "env": [
+        {
+          "default": "1000",
+          "label": "PUID",
+          "name": "PUID"
+        },
+        {
+          "default": "100",
+          "label": "PGID",
+          "name": "PGID"
+        }
+      ],
+      "image": "karsten13/magicmirror:latest",
+      "logo": "https://github.com/MichMich/MagicMirror/raw/master/.github/header.png",
+      "name": "MagicMirror2",
+      "platform": "linux",
+      "ports": [
+        "8080:8080/tcp"
+      ],
+      "restart_policy": "unless-stopped",
+      "command": "/bin/bash -c \"npm run server\" && exit 777",
+      "title": "MagicMirror2",
+      "type": 1,
+      "volumes": [
+        {
+          "container": "/opt/magic_mirror/config"
+        },
+        {
+          "container": "/opt/magic_mirror/modules"
+        },
+        {
+          "container": "/opt/magic_mirror/css"
+        }
+      ],
+      "maintainer": " https://github.com/mycroftwilde/portainer_templates/"
+    },
+    {
+      "id": 70,
+      "categories": [
+        "Libraryserver"
+      ],
+      "description": "Koomga Manga, Comic and E-Book Server",
+      "env": [
+        {
+          "default": "1000",
+          "label": "PUID",
+          "name": "PUID"
+        },
+        {
+          "default": "100",
+          "label": "PGID",
+          "name": "PGID"
+        }
+      ],
+      "image": "gotson/komga:latest",
+      "logo": "https://raw.githubusercontent.com/gotson/komga/master/.github/readme-images/app-icon.png",
+      "name": "Komga",
+      "platform": "linux",
+      "ports": [
+        "8080:8080/tcp"
+      ],
+      "restart_policy": "unless-stopped",
+      "title": "Komga",
+      "type": 1,
+      "volumes": [
+        {
+          "container": "/books"
+        },
+        {
+          "container": "/comics"
+        },
+        {
+          "container": "/manga"
+        },
+        {
+          "container": "/config"
+        }
+      ],
+      "maintainer": " https://github.com/mycroftwilde/portainer_templates/"
+    },
+    {
+      "id": 71,
+      "categories": [
+        "Libraryserver"
+      ],
+      "description": "Kavita Manga, Comic and E-Book Server",
+      "env": [
+        {
+          "default": "1000",
+          "label": "PUID",
+          "name": "PUID"
+        },
+        {
+          "default": "100",
+          "label": "PGID",
+          "name": "PGID"
+        }
+      ],
+      "image": "kizaing/kavita:latest",
+      "logo": "https://raw.githubusercontent.com/Kareadita/Kavita/main/UI/Web/src/assets/images/logo.png",
+      "name": "Kavita",
+      "platform": "linux",
+      "ports": [
+        "5000:5000/tcp"
+      ],
+      "restart_policy": "unless-stopped",
+      "title": "Kavita",
+      "type": 1,
+      "volumes": [
+        {
+          "container": "/books"
+        },
+        {
+          "container": "/comics"
+        },
+        {
+          "container": "/manga"
+        },
+        {
+          "container": "/config"
+        }
+      ],
+      "maintainer": " https://github.com/mycroftwilde/portainer_templates/"
+    },
+    {
+      "id": 72,
+      "type": 1,
+      "categories": [
+        "Managementutilityserver"
+      ],
+      "title": "Snipe-it",
+      "name": "Snipe-it",
+      "note": "Portainer App Templates by <a href='https://www.technorabilia.com' target='_blank'>Technorabilia</a> based on data provided by <a href='https://www.linuxserver.io' target='_blank'>LinuxServer.io</a>.</p><p>Don't forget to create the volume directories on the host file system.</p><p>mkdir -p /volume1/docker/snipe-it/config</p>",
+      "description": "Snipe-it makes asset management easy. It was built by people solving real-world IT and asset management problems, and a solid UX has always been a top priority. Straightforward design and bulk actions mean getting things done faster.",
+      "platform": "linux",
+      "logo": "https://s3-us-west-2.amazonaws.com/linuxserver-docs/images/snipe-it-logo500x500.png",
+      "image": "linuxserver/snipe-it:latest",
+      "env": [
+        {
+          "name": "PUID",
+          "label": "PUID",
+          "default": "1024",
+          "description": "for GroupID"
+        },
+        {
+          "name": "PGID",
+          "label": "PGID",
+          "default": "100",
+          "description": "for UserID"
+        },
+        {
+          "name": "APP_URL",
+          "label": "APP_URL",
+          "default": "<hostname or ip>",
+          "description": "Hostname or IP and port if applicable IE <ip or hostname>:8080"
+        },
+        {
+          "name": "MYSQL_PORT_3306_TCP_ADDR",
+          "label": "MYSQL_PORT_3306_TCP_ADDR",
+          "default": "<mysql host>",
+          "description": "Mysql hostname or IP to use"
+        },
+        {
+          "name": "MYSQL_PORT_3306_TCP_PORT",
+          "label": "MYSQL_PORT_3306_TCP_PORT",
+          "default": "<mysql port>",
+          "description": "Mysql port to use"
+        },
+        {
+          "name": "MYSQL_DATABASE",
+          "label": "MYSQL_DATABASE",
+          "default": "<mysql database>",
+          "description": "Mysql database to use"
+        },
+        {
+          "name": "MYSQL_USER",
+          "label": "MYSQL_USER",
+          "default": "<mysql pass>",
+          "description": "Mysql user to use"
+        },
+        {
+          "name": "MYSQL_PASSWORD",
+          "label": "MYSQL_PASSWORD",
+          "default": "changeme",
+          "description": "Mysql password to use"
+        }
+      ],
+      "ports": [
+        "8080:80/tcp"
+      ],
+      "volumes": [
+        {
+          "container": "/config",
+          "bind": "/volume1/docker/snipe-it/config"
+        }
+      ],
+      "restart_policy": "unless-stopped",
+      "maintainer": " https://github.com/mycroftwilde/portainer_templates/"
+    },
+    {
+      "id": 73,
+      "categories": [
+        "Taskserver"
+      ],
+      "description": "It is a self-hosted monitoring tool like Uptime Robot",
+      "image": "louislam/uptime-kuma:latest",
+      "logo": "https://images.opencollective.com/uptime-kuma/29c5113/logo/256.png",
+      "name": "uptime-kuma",
+      "platform": "linux",
+      "ports": [
+        "3001:3001/tcp"
+      ],
+      "restart_policy": "always",
+      "title": "Uptime Kuma",
+      "type": 1,
+      "volumes": [
+        {
+          "bind": "/portainer/Files/AppData/Config/UptimeKuma",
+          "container": "/app/data"
+        }
+      ],
+      "maintainer": " https://github.com/mycroftwilde/portainer_templates/"
+    },
+    {
+      "id": 74,
+      "type": 1,
+      "title": "Grafana",
+      "description": "Metrics Graphing Tool",
+      "logo": "https://raw.githubusercontent.com/grafana/grafana/main/docs/logo-horizontal.png",
+      "platform": "linux",
+      "restart_policy": "unless-stopped",
+      "categories": [
+        "Dashboardserver"
+      ],
+      "image": "grafana/grafana:latest",
+      "ports": [
+        "3000/tcp"
+      ],
+      "network": "bridge",
+      "volumes": [
+        {
+          "container": "/etc/grafana/grafana.ini"
+        },
+        {
+          "container": "/var/lib/grafana"
+        },
+        {
+          "container": "/var/log/grafana"
+        }
+      ],
+      "maintainer": " https://github.com/mycroftwilde/portainer_templates/"
+    },
+    {
+      "id": 75,
+      "categories": [
+        "Smarthome"
+      ],
+      "description": "Node-RED provides a browser-based flow editor that makes it easy to wire together flows using the wide range of nodes in the palette.",
+      "image": "nodered/node-red",
+      "logo": "https://raw.githubusercontent.com/xneo1/portainer_templates/master/Images/node-red-icon.svg",
+      "name": "nodered",
+      "platform": "linux",
+      "ports": [
+        "1880:1880/tcp"
+      ],
+      "restart_policy": "always",
+      "title": "Nodered",
+      "type": 1,
+      "volumes": [
+        {
+          "bind": "/portainer/Files/AppData/Config/Nodered",
+          "container": "/data"
+        }
+      ],
+      "maintainer": " https://github.com/mycroftwilde/portainer_templates/"
+    },
+    {
+      "id": 76,
+      "categories": [
+        "Managementutilityserver"
+      ],
+      "description": "draw.io (formerly Diagramly) is free online diagram software. You can use it as a flowchart maker, network diagram software, to create UML online, as an ER diagram tool, to design database schema, to build BPMN online, as a circuit diagram maker, and more. draw.io can import .vsdx, Gliffy™ and Lucidchart™ files.",
+      "image": "jgraph/drawio:latest",
+      "logo": "https://raw.githubusercontent.com/qwerty00007/portainer_templates/master/Images/draw.io.png",
+      "name": "draw.io",
+      "platform": "linux",
+      "ports": [
+        "8080:8080/tcp"
+      ],
+      "restart_policy": "unless-stopped",
+      "title": "draw.io",
+      "type": 1,
+      "maintainer": " https://github.com/mycroftwilde/portainer_templates/"
+    },
+    {
+      "id": 77,
+      "categories": [
+        "Dashboardserver"
+      ],
+      "description": "Helps you organize your self-hosted services by making them accessible from a single place.",
+      "logo": "https://dashy.to/img/dashy.png",
+      "name": "Dashy",
+      "platform": "linux",
+      "repository": {
+        "stackfile": "Template/Stack/dashy.yml",
+        "url": "https://github.com/mycroftwilde/portainer_templates"
+      },
+      "title": "Dashy",
+      "type": 3,
+      "maintainer": " https://github.com/mycroftwilde/portainer_templates/"
+    },
+    {
+      "id": 78,
+      "categories": [
+        "Musicserver"
+      ],
+      "description": "Navidrome is an open source web-based music collection server and streamer. It gives you freedom to listen to your music collection from any browser or mobile device. It's like your personal Spotify!",
+      "env": [
+        {
+          "default": "1000",
+          "label": "PUID",
+          "name": "PUID"
+        },
+        {
+          "default": "1000",
+          "label": "PGID",
+          "name": "PGID"
+        },
+        {
+          "label": "PORT",
+          "name": "PORT"
+        }
+      ],
+      "logo": "https://github.com/navidrome/navidrome/raw/master/resources/logo-192x192.png",
+      "name": "Navidrome",
+      "platform": "linux",
+      "repository": {
+        "stackfile": "Template/Stack/navidrome.yml",
+        "url": "https://github.com/xneo1/portainer_templates"
+      },
+      "title": "Navidrome",
+      "type": 3,
+      "maintainer": " https://github.com/mycroftwilde/portainer_templates/"
+    },
+    {
+      "id": 79,
+      "categories": [
+        "Dashboardserver"
+      ],
+      "description": "Flame is self-hosted startpage for your server. Its design is inspired (heavily) by SUI. Flame is very easy to setup and use. With built-in editors, it allows you to setup your very own application hub in no time - no file editing necessary.",
+      "image": "pawelmalak/flame",
+      "logo": "https://raw.githubusercontent.com/xneo1/portainer_templates/master/Images/flame.png",
+      "name": "flame-dashboard",
+      "platform": "linux",
+      "ports": [
+        "5005:5005/tcp"
+      ],
+      "restart_policy": "unless-stopped",
+      "title": "Flame-Dashboard",
+      "type": 1,
+      "volumes": [
+        {
+          "bind": "/portainer/Files/AppData/Config/flame-dashboard",
+          "container": "/app/data"
+        }
+      ],
+      "maintainer": " https://github.com/mycroftwilde/portainer_templates/"
+    },
+    {
+      "id": 80,
+      "type": 1,
+      "categories": [
+        "Tools"
+      ],
+      "title": "Foldingathome",
+      "name": "Foldingathome",
+      "note": "Portainer App Templates by <a href='https://www.technorabilia.com' target='_blank'>Technorabilia</a> based on data provided by <a href='https://www.linuxserver.io' target='_blank'>LinuxServer.io</a>.</p><p>Don't forget to create the volume directories on the host file system.</p><p>mkdir -p /volume1/docker/foldingathome/config</p>",
+      "description": "[Folding@home](https://foldingathome.org/) is a distributed computing project for simulating protein dynamics, including the process of protein folding and the movements of proteins implicated in a variety of diseases. It brings together citizen scientists who volunteer to run simulations of protein dynamics on their personal computers. Insights from this data are helping scientists to better understand biology, and providing new opportunities for developing therapeutics.",
+      "platform": "linux",
+      "logo": "https://foldingathome.org/wp-content/uploads/2016/09/folding-at-home-logo.png",
+      "image": "linuxserver/foldingathome:latest",
+      "env": [
+        {
+          "name": "PUID",
+          "label": "PUID",
+          "default": "1024",
+          "description": "for GroupID"
+        },
+        {
+          "name": "PGID",
+          "label": "PGID",
+          "default": "100",
+          "description": "for UserID"
+        },
+        {
+          "name": "TZ",
+          "label": "TZ",
+          "default": "Europe/Amsterdam",
+          "description": "Specify a timezone to use for example Europe/Amsterdam"
+        }
+      ],
+      "ports": [
+        "7396:7396/tcp",
+        "36330:36330/tcp"
+      ],
+      "volumes": [
+        {
+          "container": "/config",
+          "bind": "/volume1/docker/foldingathome/config"
+        }
+      ],
+      "restart_policy": "unless-stopped",
+      "maintainer": " https://github.com/mycroftwilde/portainer_templates/"
+    },
+    {
+      "id": 81,
+      "categories": [
+        "Authenticationserver"
+      ],
+      "description": "An open-source authentication and authorization server providing 2-factor authentication and single sign-on (SSO) for your applications via a web portal.",
+      "env": [
+        {
+          "label": "TZ",
+          "name": "TZ"
+        }
+      ],
+      "image": "authelia/authelia:latest",
+      "logo": "https://raw.githubusercontent.com/Qballjos/portainer_templates/master/Images/authelia.png",
+      "name": "authelia",
+      "note": "Requires a configuration.yml file in order to work. Documentation is available <a href='https://docs.authelia.com/deployment/deployment-ha'>here</a>.",
+      "platform": "linux",
+      "ports": [
+        "9091:9091/tcp"
+      ],
+      "restart_policy": "unless-stopped",
+      "title": "Authelia",
+      "type": 1,
+      "volumes": [
+        {
+          "bind": "/portainer/Files/AppData/Config/Authelia",
+          "container": "/etc/authelia/"
+        }
+      ],
+      "maintainer": " https://github.com/mycroftwilde/portainer_templates/"
+    },
+    {
+      "id": 82,
+      "categories": [
+        "Usenetserver"
+      ],
+      "description": "Bazarr is a companion application to Sonarr and Radarr. It can manage and download subtitles based on your requirements. You define your preferences by TV show or movie and Bazarr takes care of everything for you.",
+      "env": [
+        {
+          "default": "1000",
+          "label": "PUID",
+          "name": "PUID"
+        },
+        {
+          "default": "100",
+          "label": "PGID",
+          "name": "PGID"
+        },
+        {
+          "label": "TZ",
+          "name": "TZ"
+        }
+      ],
+      "image": "hotio/bazarr:release",
+      "logo": "https://raw.githubusercontent.com/Qballjos/portainer_templates/master/Images/bazarr.png",
+      "name": "Bazarr",
+      "platform": "linux",
+      "ports": [
+        "6767:6767/tcp"
+      ],
+      "restart_policy": "unless-stopped",
+      "title": "Bazarr",
+      "type": 1,
+      "volumes": [
+        {
+          "bind": "/portainer/Files/AppData/Config/Bazarr",
+          "container": "/config"
+        },
+        {
+          "bind": "/portainer/TV",
+          "container": "/tv"
+        },
+        {
+          "bind": "/portainer/Movies",
+          "container": "/movies"
+        }
+      ],
+      "maintainer": " https://github.com/mycroftwilde/portainer_templates/"
+    },
+    {
+      "id": 83,
+      "categories": [
+        "Musicserver"
+      ],
+      "description": "The purpose of beets is to get your music collection right once and for all. It catalogs your collection, automatically improving its metadata as it goes using the MusicBrainz database. Then it provides a bouquet of tools for manipulating and accessing your music.",
+      "env": [
+        {
+          "default": "1000",
+          "label": "PUID",
+          "name": "PUID"
+        },
+        {
+          "default": "100",
+          "label": "PGID",
+          "name": "PGID"
+        }
+      ],
+      "image": "linuxserver/beets:latest",
+      "logo": "https://raw.githubusercontent.com/Qballjos/portainer_templates/master/Images/beets-icon.png",
+      "name": "beets",
+      "platform": "linux",
+      "ports": [
+        "8337:8337/tcp"
+      ],
+      "restart_policy": "unless-stopped",
+      "title": "Beets",
+      "type": 1,
+      "volumes": [
+        {
+          "bind": "/portainer/Files/AppData/Config/Beets",
+          "container": "/config"
+        },
+        {
+          "bind": "/portainer/Downloads",
+          "container": "/downloads"
+        },
+        {
+          "bind": "/portainer/Music",
+          "container": "/music"
+        }
+      ],
+      "maintainer": " https://github.com/mycroftwilde/portainer_templates/"
+    },
+    {
+      "id": 84,
+      "categories": [
+        "Passwordserver"
+      ],
+      "description": "This is a Bitwarden server API implementation written in Rust compatible with upstream Bitwarden clients*, perfect for self-hosted deployment where running the official resource-heavy service might not be ideal.",
+      "image": "vaultwarden/server:latest",
+      "logo": "https://raw.githubusercontent.com/Qballjos/portainer_templates/master/Images/bitwarden.png",
+      "name": "vaultwarden",
+      "note": "This project is not associated with the Bitwarden project nor 8bit Solutions LLC.",
+      "platform": "linux",
+      "ports": [
+        ":80/tcp"
+      ],
+      "restart_policy": "unless-stopped",
+      "title": "Vaultwarden",
+      "type": 1,
+      "volumes": [
+        {
+          "bind": "/portainer/Files/AppData/Config/Vaultwarden",
+          "container": "/config"
+        }
+      ],
+      "maintainer": " https://github.com/mycroftwilde/portainer_templates/"
+    },
+    {
+      "id": 85,
+      "categories": [
+        "Libraryserver"
+      ],
+      "description": "Booksonic is a server and an app for streaming your audiobooks to any pc or android phone. Most of the functionality is also availiable on other platforms that have apps for subsonic.",
+      "env": [
+        {
+          "default": "1000",
+          "label": "PUID",
+          "name": "PUID"
+        },
+        {
+          "default": "100",
+          "label": "PGID",
+          "name": "PGID"
+        },
+        {
+          "default": "booksonic",
+          "label": "CONTEXT_PATH",
+          "name": "CONTEXT_PATH"
+        }
+      ],
+      "image": "linuxserver/booksonic:latest",
+      "logo": "https://raw.githubusercontent.com/Qballjos/portainer_templates/master/Images/booksonic.png",
+      "name": "booksonic",
+      "platform": "linux",
+      "ports": [
+        "4040:4040/tcp"
+      ],
+      "restart_policy": "unless-stopped",
+      "title": "Booksonic",
+      "type": 1,
+      "volumes": [
+        {
+          "bind": "/portainer/Books",
+          "container": "/books"
+        },
+        {
+          "bind": "/portainer/Files/Podcasts",
+          "container": "/podcast"
+        },
+        {
+          "bind": "/portainer/Files/AppData/Config/Booksonic",
+          "container": "/config"
+        }
+      ],
+      "maintainer": " https://github.com/mycroftwilde/portainer_templates/"
+    },
+    {
+      "id": 86,
+      "categories": [
+        "Notesserver"
+      ],
+      "description": "Bookstack is a free and open source Wiki designed for creating beautiful documentation. Feautring a simple, but powerful WYSIWYG editor it allows for teams to create detailed and useful documentation with ease.",
+      "env": [
+        {
+          "default": "1000",
+          "label": "PUID",
+          "name": "PUID"
+        },
+        {
+          "default": "100",
+          "label": "PGID",
+          "name": "PGID"
+        },
+        {
+          "label": "TZ",
+          "name": "TZ"
+        },
+        {
+          "label": "DATABASE_PASSWORD",
+          "name": "DATABASE_PASSWORD"
+        },
+        {
+          "label": "MYSQL_ROOT_PASSWORD",
+          "name": "MYSQL_ROOT_PASSWORD"
+        },
+        {
+          "label": "PORT",
+          "name": "PORT"
+        }
+      ],
+      "logo": "https://raw.githubusercontent.com/Qballjos/portainer_templates/master/Images/bookstack2.png",
+      "note": "Default login is admin@admin.com with a password of password. The database created is called bookstackapp and the database user is called bookstack",
+      "platform": "linux",
+      "repository": {
+        "stackfile": "Template/Stack/bookstack.yml",
+        "url": "https://github.com/Qballjos/portainer_templates"
+      },
+      "title": "Bookstack",
+      "type": 3,
+      "maintainer": " https://github.com/mycroftwilde/portainer_templates/"
+    },
+    {
+      "id": 87,
+      "categories": [
+        "Libraryserver"
+      ],
+      "description": "COPS links to your Calibre library database and allows downloading and emailing of books directly from a web browser and provides a OPDS feed to connect to your devices.",
+      "env": [
+        {
+          "default": "1000",
+          "label": "PUID",
+          "name": "PUID"
+        },
+        {
+          "default": "100",
+          "label": "PGID",
+          "name": "PGID"
+        }
+      ],
+      "image": "linuxserver/cops:latest",
+      "logo": "https://raw.githubusercontent.com/Qballjos/portainer_templates/master/Images/cops-icon.png",
+      "name": "cops",
+      "platform": "linux",
+      "ports": [
+        "80/tcp"
+      ],
+      "restart_policy": "unless-stopped",
+      "title": "COPS",
+      "type": 1,
+      "volumes": [
+        {
+          "bind": "/portainer/Books",
+          "container": "/books"
+        },
+        {
+          "bind": "/portainer/Files/AppData/Config/Cops",
+          "container": "/config"
+        }
+      ],
+      "maintainer": " https://github.com/mycroftwilde/portainer_templates/"
+    },
+    {
+      "id": 88,
+      "categories": [
+        "Photos"
+      ],
+      "description": "Chevereto is a powerful and fast image hosting script that allows you to create your very own full featured image hosting website in just minutes. Please note that this offers only the free Chevereto version.",
+      "env": [
+        {
+          "default": "1000",
+          "label": "PUID",
+          "name": "PUID"
+        },
+        {
+          "default": "100",
+          "label": "PGID",
+          "name": "PGID"
+        },
+        {
+          "label": "CHEVERETO_DB_HOST",
+          "name": "CHEVERETO_DB_HOST",
+          "set": ""
+        },
+        {
+          "label": "CHEVERETO_DB_USERNAME",
+          "name": "CHEVERETO_DB_USERNAME",
+          "set": ""
+        },
+        {
+          "label": "CHEVERETO_DB_PASSWORD",
+          "name": "CHEVERETO_DB_PASSWORD",
+          "set": ""
+        },
+        {
+          "label": "CHEVERETO_DB_NAME",
+          "name": "CHEVERETO_DB_NAME",
+          "set": ""
+        },
+        {
+          "label": "CHEVERETO_DB_PREFIX",
+          "name": "CHEVERETO_DB_PREFIX",
+          "set": ""
+        }
+      ],
+      "image": "nmtan/chevereto:latest",
+      "logo": "https://raw.githubusercontent.com/Qballjos/portainer_templates/master/Images/Chevereto.png",
+      "name": "Chevereto",
+      "platform": "linux",
+      "ports": [
+        "80/tcp"
+      ],
+      "restart_policy": "unless-stopped",
+      "title": "Chevereto",
+      "type": 1,
+      "volumes": [
+        {
+          "container": "/var/www/html/images"
+        }
+      ],
+      "maintainer": " https://github.com/mycroftwilde/portainer_templates/"
+    },
+    {
+      "id": 89,
+      "categories": [
+        "Familyappserver"
+      ],
+      "description": "ave recipes in seconds with plain text formatting and create beatiful recipe pages with automated ease.",
+      "image": "gregyankovoy/chowdown:latest",
+      "logo": "https://raw.githubusercontent.com/Qballjos/portainer_templates/master/Images/chowdown.png",
+      "name": "Chowdown",
+      "platform": "linux",
+      "ports": [
+        "4000:4000/tcp"
+      ],
+      "restart_policy": "unless-stopped",
+      "title": "Chowdown",
+      "type": 1,
+      "volumes": [
+        {
+          "bind": "/portainer/Files/AppData/Config/Chowdown",
+          "container": "/config"
+        }
+      ],
+      "maintainer": " https://github.com/mycroftwilde/portainer_templates/"
+    },
+    {
+      "id": 90,
+      "categories": [
+        "Codeserver"
+      ],
+      "description": "Code-server is VS Code running on a remote server, accessible through the browser.",
+      "env": [
+        {
+          "default": "1000",
+          "label": "PUID",
+          "name": "PUID"
+        },
+        {
+          "default": "1000",
+          "label": "PUID",
+          "name": "GUID"
+        },
+        {
+          "label": "TZ",
+          "name": "TZ"
+        },
+        {
+          "label": "PASSWORD",
+          "name": "PASSWORD"
+        },
+        {
+          "label": "SUDO_PASSWORD",
+          "name": "SUDO_PASSWORD"
+        },
+        {
+          "default": "example.my.domain",
+          "label": "PROXY_DOMAIN",
+          "name": "PROXY_DOMAIN"
+        }
+      ],
+      "image": "linuxserver/code-server:latest",
+      "logo": "https://raw.githubusercontent.com/Qballjos/portainer_templates/master/Images/code-server.png",
+      "name": "code-server",
+      "platform": "linux",
+      "ports": [
+        "8443:8443/tcp"
+      ],
+      "restart_policy": "unless-stopped",
+      "title": "Code Server",
+      "type": 1,
+      "volumes": [
+        {
+          "bind": "/portainer/Files/AppData/Config/Code-Server",
+          "container": "/config"
+        }
+      ],
+      "maintainer": " https://github.com/mycroftwilde/portainer_templates/"
+    },
+    {
+      "id": 91,
+      "categories": [
+        "Codeserver"
+      ],
+      "description": "Codiad is a web-based IDE framework with a small footprint and minimal requirements.",
+      "env": [
+        {
+          "default": "1000",
+          "label": "PUID",
+          "name": "PUID"
+        },
+        {
+          "default": "100",
+          "label": "PGID",
+          "name": "PGID"
+        }
+      ],
+      "image": "linuxserver/codiad:latest",
+      "logo": "https://raw.githubusercontent.com/Qballjos/portainer_templates/master/Images/codiad-icon.png",
+      "name": "codiad",
+      "platform": "linux",
+      "ports": [
+        "80/tcp"
+      ],
+      "restart_policy": "unless-stopped",
+      "title": "Codiad",
+      "type": 1,
+      "volumes": [
+        {
+          "bind": "/portainer/Files/AppData/Config/Codiad",
+          "container": "/config"
+        }
+      ],
+      "maintainer": " https://github.com/mycroftwilde/portainer_templates/"
+    },
+    {
+      "id": 92,
+      "categories": [
+        "Musicserver"
+      ],
+      "description": "DAAP (iTunes) media server with support for AirPlay devices, Apple Remote (and compatibles), MPD and internet radio.",
+      "env": [
+        {
+          "default": "1000",
+          "label": "PUID",
+          "name": "PUID"
+        },
+        {
+          "default": "100",
+          "label": "PGID",
+          "name": "PGID"
+        }
+      ],
+      "image": "linuxserver/daapd:latest",
+      "logo": "https://raw.githubusercontent.com/linuxserver/beta-templates/master/lsiodev/img/daapd-icon.png",
+      "name": "daapd",
+      "platform": "linux",
+      "restart_policy": "unless-stopped",
+      "title": "Daapd",
+      "type": 1,
+      "volumes": [
+        {
+          "bind": "/portainer/Files/AppData/Config/Daapd",
+          "container": "/config"
+        },
+        {
+          "bind": "/portainer/Music",
+          "container": "/music"
+        }
+      ],
+      "maintainer": " https://github.com/mycroftwilde/portainer_templates/"
+    },
+    {
+      "id": 93,
+      "categories": [
+        "Dashboardserver"
+      ],
+      "description": "Another application bookmark dashboard, with fun features.",
+      "image": "rmountjoy/dashmachine:latest",
+      "logo": "https://raw.githubusercontent.com/Qballjos/portainer_templates/master/Images/dashmachine_logo.png",
+      "name": "dashmachine",
+      "platform": "linux",
+      "ports": [
+        "5000:5000/tcp"
+      ],
+      "restart_policy": "unless-stopped",
+      "title": "DashMachine",
+      "type": 1,
+      "volumes": [
+        {
+          "bind": "/portainer/Files/AppData/Config/Dashmachine",
+          "container": "/dashmachine/dashmachine/user_data"
+        }
+      ],
+      "maintainer": " https://github.com/mycroftwilde/portainer_templates/"
+    },
+    {
+      "id": 94,
+      "categories": [
+        "Ftpserver"
+      ],
+      "description": "davos is an FTP automation tool that periodically scans given host locations for new files. It can be configured for various purposes, including listening for specific files to appear in the host location, ready for it to download and then move, if required. It also supports completion notifications as well as downstream API calls, to further the workflow.",
+      "env": [
+        {
+          "default": "1000",
+          "label": "PUID",
+          "name": "PUID"
+        },
+        {
+          "default": "100",
+          "label": "PGID",
+          "name": "PGID"
+        }
+      ],
+      "image": "linuxserver/davos:latest",
+      "logo": "https://raw.githubusercontent.com/Qballjos/portainer_templates/master/Images/davos.png",
+      "name": "davos",
+      "note": "Configuration <ul><li><b>/config</b> - AppData Location</li><li><b>/downloads</b> - File Download Location</li></ul>",
+      "platform": "linux",
+      "ports": [
+        "8080/tcp"
+      ],
+      "restart_policy": "unless-stopped",
+      "title": "Davos",
+      "type": 1,
+      "volumes": [
+        {
+          "bind": "/portainer/Files/AppData/Config/Davos",
+          "container": "/config"
+        },
+        {
+          "bind": "/portainer/Downloads",
+          "container": "/downloads"
+        }
+      ],
+      "maintainer": " https://github.com/mycroftwilde/portainer_templates/"
+    },
+    {
+      "id": 95,
+      "categories": [
+        "Torrentserver"
+      ],
+      "description": "Deluge is a lightweight, Free Software, cross-platform BitTorrent client providing: Full Encryption, WebUI, Plugin System, Much more...",
+      "env": [
+        {
+          "default": "1000",
+          "label": "PUID",
+          "name": "PUID"
+        },
+        {
+          "default": "100",
+          "label": "PGID",
+          "name": "PGID"
+        },
+        {
+          "label": "UMASK_SET",
+          "name": "UMASK_SET",
+          "set": "000"
+        }
+      ],
+      "image": "linuxserver/deluge:latest",
+      "logo": "https://raw.githubusercontent.com/Qballjos/portainer_templates/master/Images/deluge-icon.png",
+      "name": "deluge",
+      "platform": "linux",
+      "restart_policy": "unless-stopped",
+      "title": "Deluge",
+      "type": 1,
+      "volumes": [
+        {
+          "bind": "/portainer/Files/AppData/Config/Deluge",
+          "container": "/config"
+        },
+        {
+          "bind": "/portainer/Downloads",
+          "container": "/downloads"
+        }
+      ],
+      "maintainer": " https://github.com/mycroftwilde/portainer_templates/"
+    },
+    {
+      "id": 96,
+      "categories": [
+        "Smarthome"
+      ],
+      "description": "Domoticz is a Home Automation System that lets you monitor and configure various devices like: Lights, Switches, various sensors/meters like Temperature, Rain, Wind, UV, Electra, Gas, Water and much more. Notifications/Alerts can be sent to any mobile device.",
+      "env": [
+        {
+          "default": "1000",
+          "label": "PUID",
+          "name": "PUID"
+        },
+        {
+          "default": "100",
+          "label": "PGID",
+          "name": "PGID"
+        }
+      ],
+      "image": "linuxserver/domoticz:latest",
+      "logo": "https://github.com/domoticz/domoticz/raw/master/www/images/logo.png",
+      "name": "domoticz",
+      "platform": "linux",
+      "ports": [
+        "1443:1443/tcp",
+        "6144:6144/tcp",
+        "8080:8080/tcp"
+      ],
+      "restart_policy": "unless-stopped",
+      "title": "Domoticz",
+      "type": 1,
+      "volumes": [
+        {
+          "bind": "/portainer/Files/AppData/Config/Domoticz",
+          "container": "/config"
+        }
+      ],
+      "maintainer": " https://github.com/mycroftwilde/portainer_templates/"
+    },
+    {
+      "id": 97,
+      "categories": [
+        "Mediaserver"
+      ],
+      "description": "Emby organizes video, music, live TV, and photos from personal media libraries and streams them to smart TVs, streaming boxes and mobile devices. This container is packaged as a standalone emby Media Server.",
+      "env": [
+        {
+          "default": "1000",
+          "label": "PUID",
+          "name": "PUID"
+        },
+        {
+          "default": "100",
+          "label": "PGID",
+          "name": "PGID"
+        },
+        {
+          "label": "TZ",
+          "name": "TZ"
+        }
+      ],
+      "image": "linuxserver/emby:latest",
+      "logo": "https://raw.githubusercontent.com/Qballjos/portainer_templates/master/Images/emby.png",
+      "name": "Emby",
+      "platform": "linux",
+      "ports": [
+        "8096:8096/tcp",
+        "8920:8920/tcp"
+      ],
+      "restart_policy": "unless-stopped",
+      "title": "Emby",
+      "type": 1,
+      "volumes": [
+        {
+          "bind": "/portainer/Files/AppData/Config/Emby",
+          "container": "/config"
+        },
+        {
+          "bind": "/portainer/TV",
+          "container": "/data/tvshows"
+        },
+        {
+          "bind": "/portainer/Movies",
+          "container": "/data/movies"
+        }
+      ],
+      "maintainer": " https://github.com/mycroftwilde/portainer_templates/"
+    },
+    {
+      "id": 98,
+      "categories": [
+        "Mediaserver"
+      ],
+      "description": "Embystat is a personal web server that can calculate all kinds of statistics from your (local) Emby server. Just install this on your server and let him calculate all kinds of fun stuff.",
+      "image": "linuxserver/embystat:latest",
+      "logo": "https://raw.githubusercontent.com/Qballjos/portainer_templates/master/Images/embystat.png",
+      "name": "EmbyStat",
+      "note": "Access the ui at your-ip:6555. Follow the setup wizard on initial install. Then configure the required services.",
+      "platform": "linux",
+      "ports": [
+        "6555:6555/tcp"
+      ],
+      "restart_policy": "unless-stopped",
+      "title": "EmbyStat",
+      "type": 1,
+      "volumes": [
+        {
+          "bind": "/portainer/Files/AppData/Config/EmbyStat",
+          "container": "/config"
+        }
+      ],
+      "maintainer": " https://github.com/mycroftwilde/portainer_templates/"
+    },
+    {
+      "id": 99,
+      "categories": [
+        "Smarthome"
+      ],
+      "description": "A free, self-hostable rss aggregator.",
+      "env": [
+        {
+          "default": "1000",
+          "label": "PUID",
+          "name": "PUID"
+        },
+        {
+          "default": "100",
+          "label": "PGID",
+          "name": "PGID"
+        }
+      ],
+      "image": "linuxserver/freshrss:latest",
+      "logo": "https://raw.githubusercontent.com/Qballjos/portainer_templates/master/Images/freshrss-icon.png",
+      "name": "freshrss",
+      "platform": "linux",
+      "ports": [
+        "80/tcp"
+      ],
+      "restart_policy": "unless-stopped",
+      "title": "FreshRSS",
+      "type": 1,
+      "volumes": [
+        {
+          "bind": "/portainer/Files/AppData/Config/freshrss",
+          "container": "/config"
+        }
+      ],
+      "maintainer": " https://github.com/mycroftwilde/portainer_templates/"
+    },
+    {
+      "id": 100,
+      "categories": [
+        "Libraryserver"
+      ],
+      "description": "A WebApp Comic Reader for your favorite digital comics. Reach and read your comic library from any web connected device with a modern web browser.",
+      "env": [
+        {
+          "default": "1000",
+          "label": "PUID",
+          "name": "PUID"
+        },
+        {
+          "default": "100",
+          "label": "PGID",
+          "name": "PGID"
+        }
+      ],
+      "image": "linuxserver/gazee:latest",
+      "logo": "https://raw.githubusercontent.com/Qballjos/portainer_templates/master/Images/gazee-logo.png",
+      "name": "gazee",
+      "platform": "linux",
+      "restart_policy": "unless-stopped",
+      "title": "Gazee",
+      "type": 1,
+      "volumes": [
+        {
+          "bind": "/portainer/Files/AppData/Config/Gazee",
+          "container": "/config"
+        },
+        {
+          "bind": "/portainer/Comics",
+          "container": "/comics"
+        },
+        {
+          "bind": "/portainer/Files/AppData/Gazee",
+          "container": "/mylar"
+        }
+      ],
+      "maintainer": " https://github.com/mycroftwilde/portainer_templates/"
+    },
+    {
+      "id": 101,
+      "categories": [
+        "Managementutilityserver"
+      ],
+      "description": "A clientless remote desktop gateway.",
+      "image": "oznu/guacamole:latest",
+      "logo": "https://raw.githubusercontent.com/Qballjos/portainer_templates/master/Images/guacamole.png",
+      "name": "guacamole",
+      "note": "The default login will be guacadmin/guacadmin. It is common practice to add a new admin user and remove the default user for Guacamole.",
+      "platform": "linux",
+      "ports": [
+        "8080:8080/tcp"
+      ],
+      "restart_policy": "unless-stopped",
+      "title": "Guacamole",
+      "type": 1,
+      "volumes": [
+        {
+          "bind": "/portainer/Files/AppData/Config/Guacamole",
+          "container": "/config"
+        }
+      ],
+      "maintainer": " https://github.com/mycroftwilde/portainer_templates/"
+    },
+    {
+      "id": 102,
+      "categories": [
+        "Familyappserver"
+      ],
+      "description": "Grocy is an ERP system for your kitchen! Cut down on food waste, and manage your chores with this brilliant utility.",
+      "env": [
+        {
+          "default": "1000",
+          "label": "PUID",
+          "name": "PUID"
+        },
+        {
+          "default": "100",
+          "label": "PGID",
+          "name": "PGID"
+        },
+        {
+          "label": "Timezone",
+          "name": "TZ"
+        }
+      ],
+      "image": "linuxserver/grocy:latest",
+      "logo": "https://raw.githubusercontent.com/Qballjos/portainer_templates/master/Images/grocy_logo.png",
+      "name": "grocy",
+      "platform": "linux",
+      "ports": [
+        "80/tcp"
+      ],
+      "restart_policy": "unless-stopped",
+      "title": "Grocy",
+      "type": 1,
+      "volumes": [
+        {
+          "bind": "/portainer/Files/AppData/Config/Grocy",
+          "container": "/config"
+        }
+      ],
+      "maintainer": " https://github.com/mycroftwilde/portainer_templates/"
+    },
+    {
+      "id": 103,
+      "categories": [
+        "Usenetserver"
+      ],
+      "description": "Headphones is an automated music downloader for NZB and Torrent, written in Python. It supports SABnzbd, NZBget, Transmission, µTorrent and Blackhole.",
+      "env": [
+        {
+          "default": "1000",
+          "label": "PUID",
+          "name": "PUID"
+        },
+        {
+          "default": "100",
+          "label": "PGID",
+          "name": "PGID"
+        }
+      ],
+      "image": "linuxserver/headphones:latest",
+      "logo": "https://raw.githubusercontent.com/Qballjos/portainer_templates/master/Images/headphones-icon.png",
+      "name": "headphones",
+      "platform": "linux",
+      "ports": [
+        "8181:8181/tcp"
+      ],
+      "restart_policy": "unless-stopped",
+      "title": "Headphones",
+      "type": 1,
+      "volumes": [
+        {
+          "bind": "/portainer/Files/AppData/Config/Headphones",
+          "container": "/config"
+        },
+        {
+          "bind": "/portainer/Downloads",
+          "container": "/Downloads"
+        },
+        {
+          "bind": "/portainer/Music",
+          "container": "/music"
+        }
+      ],
+      "maintainer": " https://github.com/mycroftwilde/portainer_templates/"
+    },
+    {
+      "id": 104,
+      "categories": [
+        "Dashboardserver"
+      ],
+      "description": "A dead simple static HOMepage for your servER to keep your s ervices on hand, from a simple yaml configuration file.",
+      "image": "b4bz/homer:latest",
+      "logo": "https://raw.githubusercontent.com/Qballjos/portainer_templates/master/Images/homer.png",
+      "name": "homer",
+      "note": "This container requires a yml file within the config volume. See the documentation here https://github.com/bastienwirtz/homer",
+      "platform": "linux",
+      "ports": [
+        "8902:8080/tcp"
+      ],
+      "restart_policy": "unless-stopped",
+      "title": "Homer",
+      "type": 1,
+      "volumes": [
+        {
+          "bind": "/portainer/Files/AppData/Config/Homer/assets",
+          "container": "/www/assets"
+        },
+        {
+          "bind": "/portainer/Files/AppData/Config/Homer",
+          "container": "/www/config.yml"
+        }
+      ],
+      "maintainer": " https://github.com/mycroftwilde/portainer_templates/"
+    },
+    {
+      "id": 105,
+      "categories": [
+        "Taskserver"
+      ],
+      "description": "Create agents that monitor and act on your behalf.",
+      "image": "huginn/huginn:latest",
+      "logo": "https://raw.githubusercontent.com/Qballjos/portainer_templates/master/Images/huginn.png",
+      "name": "huginn",
+      "platform": "linux",
+      "ports": [
+        "3000:3000/tcp"
+      ],
+      "restart_policy": "unless-stopped",
+      "title": "Huginn",
+      "type": 1,
+      "volumes": [
+        {
+          "bind": "/portainer/Files/AppData/Config/huginn",
+          "container": "/var/lib/mysql"
+        }
+      ],
+      "maintainer": " https://github.com/mycroftwilde/portainer_templates/"
+    },
+    {
+      "id": 106,
+      "categories": [
+        "Mediaserver"
+      ],
+      "description": "Jellyfin is a Free Software Media System that puts you in control of managing and streaming your media. It is an alternative to the proprietary Emby and Plex, to provide media from a dedicated server to end-user devices via multiple apps.",
+      "env": [
+        {
+          "default": "1000",
+          "label": "PUID",
+          "name": "PUID"
+        },
+        {
+          "default": "100",
+          "label": "PGID",
+          "name": "PGID"
+        },
+        {
+          "label": "TZ",
+          "name": "TZ"
+        }
+      ],
+      "image": "linuxserver/jellyfin:latest",
+      "logo": "https://raw.githubusercontent.com/Qballjos/portainer_templates/master/Images/jellyfin.png",
+      "name": "jellyfin",
+      "platform": "linux",
+      "ports": [
+        "8096:8096/tcp",
+        "8920:8920/tcp"
+      ],
+      "restart_policy": "unless-stopped",
+      "title": "Jellyfin",
+      "type": 1,
+      "volumes": [
+        {
+          "bind": "/portainer/Files/AppData/Config/Jellyfin",
+          "container": "/config"
+        },
+        {
+          "bind": "/portainer/TV",
+          "container": "/data/tvshows"
+        },
+        {
+          "bind": "/portainer/Movies",
+          "container": "/data/movies"
+        }
+      ],
+      "maintainer": " https://github.com/mycroftwilde/portainer_templates/"
+    },
+    {
+      "id": 107,
+      "categories": [
+        "Mediaserver"
+      ],
+      "description": "Headless installation of Kodi™ (formerly known as XBMC™), to enable library updates.",
+      "env": [
+        {
+          "default": "1000",
+          "label": "PUID",
+          "name": "PUID"
+        },
+        {
+          "default": "100",
+          "label": "PGID",
+          "name": "PGID"
+        }
+      ],
+      "image": "linuxserver/kodi-headless:latest",
+      "logo": "https://raw.githubusercontent.com/Qballjos/portainer_templates/master/Images/kodi-icon.png",
+      "name": "kodi-headless",
+      "platform": "linux",
+      "ports": [
+        "8080/tcp",
+        "9777/udp"
+      ],
+      "restart_policy": "unless-stopped",
+      "title": "Kodi Headless",
+      "type": 1,
+      "volumes": [
+        {
+          "bind": "/portainer/Files/AppData/Config/Kodi",
+          "container": "/config"
+        }
+      ],
+      "maintainer": " https://github.com/mycroftwilde/portainer_templates/"
+    },
+    {
+      "id": 108,
+      "categories": [
+        "Libraryserver"
+      ],
+      "description": "LazyLibrarian is a program to follow authors and grab metadata for all your digital reading needs.",
+      "env": [
+        {
+          "default": "1000",
+          "label": "PUID",
+          "name": "PUID"
+        },
+        {
+          "default": "100",
+          "label": "PGID",
+          "name": "PGID"
+        }
+      ],
+      "image": "linuxserver/lazylibrarian:latest",
+      "logo": "https://raw.githubusercontent.com/Qballjos/portainer_templates/master/Images/lazylibrarian-icon.png",
+      "name": "lazylibrarian",
+      "platform": "linux",
+      "ports": [
+        "5299:5299/tcp"
+      ],
+      "restart_policy": "unless-stopped",
+      "title": "LazyLibrarian",
+      "type": 1,
+      "volumes": [
+        {
+          "container": "/config"
+        },
+        {
+          "container": "/downloads"
+        },
+        {
+          "container": "/books"
+        }
+      ],
+      "maintainer": " https://github.com/mycroftwilde/portainer_templates/"
+    },
+    {
+      "id": 109,
+      "categories": [
+        "Proxyserver"
+      ],
+      "description": "This container sets up an Nginx webserver and reverse proxy with php support and a built-in letsencrypt client that automates free SSL server certificate generation and renewal processes. It also contains fail2ban for intrusion prevention.",
+      "env": [
+        {
+          "label": "EMAIL",
+          "name": "EMAIL",
+          "set": "-Xms256m -Xmx512m"
+        },
+        {
+          "label": "URL",
+          "name": "URL",
+          "set": "-Xms256m -Xmx512m"
+        },
+        {
+          "label": "SUBDOMAINS",
+          "name": "SUBDOMAINS",
+          "set": "www,"
+        },
+        {
+          "label": "ONLY_SUBDOMAINS",
+          "name": "ONLY_SUBDOMAINS",
+          "set": "false"
+        },
+        {
+          "label": "DHLEVEL",
+          "name": "DHLEVEL",
+          "set": "2048"
+        },
+        {
+          "default": "1000",
+          "label": "PUID",
+          "name": "PUID"
+        },
+        {
+          "default": "100",
+          "label": "PGID",
+          "name": "PGID"
+        },
+        {
+          "label": "VALIDATION",
+          "name": "VALIDATION",
+          "set": "http"
+        },
+        {
+          "label": "DNSPLUGIN",
+          "name": "DNSPLUGIN",
+          "set": "http"
+        }
+      ],
+      "image": "linuxserver/swag:latest",
+      "logo": "https://raw.githubusercontent.com/Qballjos/portainer_templates/master/Images/letsencrypt.png",
+      "name": "letsencrypt / SWAG",
+      "note": "Before running this container, make sure that the url and subdomains are properly forwarded to this container's host.<ul><li>- Port 443 on the internet side of the router should be forwarded to this container's port 443.</li><li>- If you need a dynamic dns provider, you can use the free provider duckdns.org where the url will be yoursubdomain.duckdns.org and the subdomains can be www,ftp,cloud</li><li>- The container detects changes to url and subdomains, revokes existing certs and generates new ones during start.</li><li>- It also detects changes to the DHLEVEL parameter and replaces the dhparams file.</li><li>- If you'd like to password protect your sites, you can use htpasswd. Run the following command on your host to generate the htpasswd file <code>docker exec -it letsencrypt htpasswd -c /config/nginx/.htpasswd &lt;username&gt;</code>",
+      "platform": "linux",
+      "ports": [
+        "80/tcp",
+        "443/tcp"
+      ],
+      "restart_policy": "unless-stopped",
+      "title": "Let's Encrypt / SWAG",
+      "type": 1,
+      "volumes": [
+        {
+          "bind": "/portainer/Files/AppData/Config/LetsEncrypt",
+          "container": "/config"
+        }
+      ],
+      "maintainer": " https://github.com/mycroftwilde/portainer_templates/"
+    },
+    {
+      "id": 110,
+      "categories": [
+        "Usenetserver"
+      ],
+      "description": "Lidarr is a music collection manager for Usenet and BitTorrent users.",
+      "env": [
+        {
+          "default": "1000",
+          "label": "PUID",
+          "name": "PUID"
+        },
+        {
+          "default": "100",
+          "label": "PGID",
+          "name": "PGID"
+        }
+      ],
+      "image": "hotio/lidarr:release",
+      "logo": "https://raw.githubusercontent.com/Qballjos/portainer_templates/master/Images/lidarr.png",
+      "name": "lidarr",
+      "platform": "linux",
+      "ports": [
+        "8686:8686/tcp"
+      ],
+      "restart_policy": "unless-stopped",
+      "title": "Lidarr",
+      "type": 1,
+      "volumes": [
+        {
+          "bind": "/portainer/Files/AppData/Config/Lidarr",
+          "container": "/config"
+        },
+        {
+          "bind": "/portainer/Downloads",
+          "container": "/downloads"
+        },
+        {
+          "bind": "/portainer/Music",
+          "container": "/music"
+        }
+      ],
+      "maintainer": " https://github.com/mycroftwilde/portainer_templates/"
+    },
+    {
+      "id": 111,
+      "categories": [
+        "Photos"
+      ],
+      "description": "Lychee is a free photo-management tool, which runs on your server or web-space. Installing is a matter of seconds. Upload, manage and share photos like from a native application. Lychee comes with everything you need and all your photos are stored securely.",
+      "env": [
+        {
+          "default": "1000",
+          "label": "PUID",
+          "name": "PUID"
+        },
+        {
+          "default": "100",
+          "label": "PGID",
+          "name": "PGID"
+        }
+      ],
+      "image": "linuxserver/lychee:latest",
+      "logo": "https://raw.githubusercontent.com/Qballjos/portainer_templates/master/Images/lychee-icon.png",
+      "name": "lychee",
+      "platform": "linux",
+      "ports": [
+        "80/tcp"
+      ],
+      "restart_policy": "unless-stopped",
+      "title": "Lychee",
+      "type": 1,
+      "volumes": [
+        {
+          "bind": "/portainer/Files/AppData/Config/Lychee",
+          "container": "/config"
+        },
+        {
+          "bind": "/portainer/Pictures",
+          "container": "/pictures"
+        }
+      ],
+      "maintainer": " https://github.com/mycroftwilde/portainer_templates/"
+    },
+    {
+      "id": 112,
+      "categories": [
+        "Databaseserver"
+      ],
+      "description": "An Enhanced drop in replacement for Mysql.",
+      "env": [
+        {
+          "default": "1000",
+          "label": "PUID",
+          "name": "PUID"
+        },
+        {
+          "default": "100",
+          "label": "PGID",
+          "name": "PGID"
+        },
+        {
+          "label": "MYSQL_ROOT_PASSWORD",
+          "name": "MYSQL_ROOT_PASSWORD",
+          "set": ""
+        }
+      ],
+      "image": "linuxserver/mariadb:latest",
+      "logo": "https://raw.githubusercontent.com/Qballjos/portainer_templates/master/Images/mariadb-icon.png",
+      "name": "mariadb",
+      "platform": "linux",
+      "ports": [
+        "3306:3306/tcp"
+      ],
+      "restart_policy": "unless-stopped",
+      "title": "MariaDB",
+      "type": 1,
+      "volumes": [
+        {
+          "bind": "/portainer/Files/AppData/Config/Mariadb",
+          "container": "/config"
+        }
+      ],
+      "maintainer": " https://github.com/mycroftwilde/portainer_templates/"
+    },
+    {
+      "id": 113,
+      "categories": [
+        "Musicserver"
+      ],
+      "description": "Mstream is a personal music streaming server. You can use mStream to stream your music from your home computer to any device, anywhere. There are mobile apps available for both Android and iPhone.",
+      "image": "linuxserver/mstream:latest",
+      "logo": "https://raw.githubusercontent.com/Qballjos/portainer_templates/master/Images/mstream.png",
+      "name": "mstream",
+      "platform": "linux",
+      "ports": [
+        "3000:3000/tcp"
+      ],
+      "restart_policy": "unless-stopped",
+      "title": "Mstream",
+      "type": 1,
+      "volumes": [
+        {
+          "bind": "/portainer/Files/AppData/Config/Mstream",
+          "container": "/config"
+        },
+        {
+          "bind": "/portainer/Downloads",
+          "container": "/music"
+        }
+      ],
+      "maintainer": " https://github.com/mycroftwilde/portainer_templates/"
+    },
+    {
+      "id": 114,
+      "categories": [
+        "Chatserver"
+      ],
+      "description": "Mumble is a voicechat program for gamers written on top of Qt and Opus. Murmur is the server backend for Mumble.",
+      "env": [
+        {
+          "default": "1000",
+          "label": "PUID",
+          "name": "PUID"
+        },
+        {
+          "default": "100",
+          "label": "PGID",
+          "name": "PGID"
+        },
+        {
+          "label": "TZ",
+          "name": "TZ"
+        }
+      ],
+      "image": "goofball222/murmur:latest",
+      "logo": "https://raw.githubusercontent.com/Qballjos/portainer_templates/master/Images/Mumble-logo.png",
+      "name": "murmur",
+      "platform": "linux",
+      "ports": [
+        "64738:64738/tcp",
+        "64738:64738/udp"
+      ],
+      "restart_policy": "unless-stopped",
+      "title": "Murmur",
+      "type": 1,
+      "volumes": [
+        {
+          "bind": "/etc/localtime:ro",
+          "container": "/etc/localtime"
+        },
+        {
+          "bind": "/portainer/Files/Config/Murmur",
+          "container": "/opt/murmur/config"
+        },
+        {
+          "bind": "/portainer/Files/Murmur/data",
+          "container": "/opt/murmur/data"
+        },
+        {
+          "bind": "/portainer/Files/Murmur/log",
+          "container": "/opt/murmur/log"
+        }
+      ],
+      "maintainer": " https://github.com/mycroftwilde/portainer_templates/"
+    },
+    {
+      "id": 115,
+      "categories": [
+        "Musicserver"
+      ],
+      "description": "MusicBrainz is an open music encyclopedia that collects music metadata and makes it available to the public.",
+      "env": [
+        {
+          "label": "BRAINZCODE",
+          "name": "BRAINZCODE",
+          "set": ""
+        },
+        {
+          "default": "1000",
+          "label": "PUID",
+          "name": "PUID"
+        },
+        {
+          "default": "100",
+          "label": "PGID",
+          "name": "PGID"
+        }
+      ],
+      "image": "linuxserver/musicbrainz:latest",
+      "logo": "https://raw.githubusercontent.com/Qballjos/portainer_templates/master/Images/musicbrainz-icon.png",
+      "name": "musicbrainz",
+      "platform": "linux",
+      "ports": [
+        "5000:5000/tcp"
+      ],
+      "restart_policy": "unless-stopped",
+      "title": "MusicBrainz",
+      "type": 1,
+      "volumes": [
+        {
+          "bind": "/portainer/Files/AppData/Config/MusicBrainz",
+          "container": "/config"
+        },
+        {
+          "bind": "/portainer/Files/AppData/MusicBrainz",
+          "container": "/data"
+        }
+      ],
+      "maintainer": " https://github.com/mycroftwilde/portainer_templates/"
+    },
+    {
+      "id": 116,
+      "categories": [
+        "Dashboardserver"
+      ],
+      "description": "A lightweight portal to view, manage your HTPC apps without having to run anything more than a PHP enabled webserver. With Muximux you don't need to keep multiple tabs open, or bookmark the URL to all of your apps.",
+      "env": [
+        {
+          "default": "1000",
+          "label": "PUID",
+          "name": "PUID"
+        },
+        {
+          "default": "100",
+          "label": "PGID",
+          "name": "PGID"
+        }
+      ],
+      "image": "linuxserver/muximux:latest",
+      "logo": "https://raw.githubusercontent.com/Qballjos/portainer_templates/master/Images/muximux-icon.png",
+      "name": "muximux",
+      "platform": "linux",
+      "ports": [
+        "80/tcp"
+      ],
+      "restart_policy": "unless-stopped",
+      "title": "Muximux",
+      "type": 1,
+      "volumes": [
+        {
+          "bind": "/portainer/Files/AppData/Config/Muximux",
+          "container": "/config"
+        }
+      ],
+      "maintainer": " https://github.com/mycroftwilde/portainer_templates/"
+    },
+    {
+      "id": 117,
+      "categories": [
+        "Usenetserver"
+      ],
+      "description": "An automated Comic Book downloader (cbr/cbz) for use with SABnzbd, NZBGet and torrents.",
+      "env": [
+        {
+          "default": "1000",
+          "label": "PUID",
+          "name": "PUID"
+        },
+        {
+          "default": "100",
+          "label": "PGID",
+          "name": "PGID"
+        }
+      ],
+      "image": "linuxserver/mylar:latest",
+      "logo": "https://raw.githubusercontent.com/Qballjos/portainer_templates/master/Images/mylar-icon.png",
+      "name": "mylar",
+      "platform": "linux",
+      "ports": [
+        "8090:8090/tcp"
+      ],
+      "restart_policy": "unless-stopped",
+      "title": "Mylar",
+      "type": 1,
+      "volumes": [
+        {
+          "bind": "/portainer/Files/AppData/Config/Mylar",
+          "container": "/config"
+        },
+        {
+          "bind": "/portainer/Downloads",
+          "container": "/downloads"
+        },
+        {
+          "bind": "/portainer/Comics",
+          "container": "/comics"
+        }
+      ],
+      "maintainer": " https://github.com/mycroftwilde/portainer_templates/"
+    },
+    {
+      "id": 118,
+      "categories": [
+        "Usenetserver"
+      ],
+      "description": "NZBGet is a usenet downloader, written in C++ and designed with performance in mind to achieve maximum download speed by using very little system resources. It supports all platforms including Windows, Mac, Linux and works on all devices including PC, NAS, WLAN routers and media players.",
+      "env": [
+        {
+          "default": "1000",
+          "label": "PUID",
+          "name": "PUID"
+        },
+        {
+          "default": "100",
+          "label": "PGID",
+          "name": "PGID"
+        }
+      ],
+      "image": "linuxserver/nzbget:latest",
+      "logo": "https://raw.githubusercontent.com/Qballjos/portainer_templates/master/Images/nzbget-icon.png",
+      "name": "nzbget",
+      "platform": "linux",
+      "ports": [
+        "6789:6789/tcp"
+      ],
+      "restart_policy": "unless-stopped",
+      "title": "NZBGet",
+      "type": 1,
+      "volumes": [
+        {
+          "bind": "/portainer/Files/AppData/Config/Nzbget",
+          "container": "/config"
+        },
+        {
+          "bind": "/portainer/Downloads",
+          "container": "/downloads"
+        }
+      ],
+      "maintainer": " https://github.com/mycroftwilde/portainer_templates/"
+    },
+    {
+      "id": 119,
+      "categories": [
+        "Proxyserver"
+      ],
+      "description": "NZBHydra is a meta search for NZB indexers and the \"spiritual successor\" to NZBmegasearcH. It provides easy access to a number of raw and newznab based indexers.",
+      "env": [
+        {
+          "default": "1000",
+          "label": "PUID",
+          "name": "PUID"
+        },
+        {
+          "default": "100",
+          "label": "PGID",
+          "name": "PGID"
+        }
+      ],
+      "image": "linuxserver/nzbhydra2:latest",
+      "logo": "https://raw.githubusercontent.com/Qballjos/portainer_templates/master/Images/hydra-icon.png",
+      "name": "nzbhydra2",
+      "platform": "linux",
+      "ports": [
+        "5076:5076/tcp"
+      ],
+      "restart_policy": "unless-stopped",
+      "title": "NZBHydra 2",
+      "type": 1,
+      "volumes": [
+        {
+          "bind": "/portainer/Files/AppData/Config/Nzbhydra2",
+          "container": "/config"
+        },
+        {
+          "bind": "/portainer/Downloads",
+          "container": "/downloads"
+        }
+      ],
+      "maintainer": " https://github.com/mycroftwilde/portainer_templates/"
+    },
+    {
+      "id": 120,
+      "categories": [
+        "Familyappserver"
+      ],
+      "description": "Where are your photos and documents? With Nextcloud you pick a server of your choice, at home, in a data center or at a provider. And that is where your files will be. Nextcloud runs on that server, protecting your data and giving you access from your desktop or mobile devices.",
+      "env": [
+        {
+          "default": "1000",
+          "label": "PUID",
+          "name": "PUID"
+        },
+        {
+          "default": "100",
+          "label": "PGID",
+          "name": "PGID"
+        },
+        {
+          "label": "TZ",
+          "name": "TZ"
+        },
+        {
+          "label": "DATABASE_PASSWORD",
+          "name": "DATABASE_PASSWORD"
+        },
+        {
+          "label": "MYSQL_ROOT_PASSWORD",
+          "name": "MYSQL_ROOT_PASSWORD"
+        },
+        {
+          "label": "PORT",
+          "name": "PORT"
+        }
+      ],
+      "logo": "https://raw.githubusercontent.com/Qballjos/portainer_templates/master/Images/nextcloud-icon.png",
+      "name": "nextcloud",
+      "note": "The database user is nextcloud and the database is nextcloud_db. The host of the database will be located at the bottom of the DB conotainer in portainer.",
+      "platform": "linux",
+      "repository": {
+        "stackfile": "Template/Stack/nextcloud.yml",
+        "url": "https://github.com/Qballjos/portainer_templates"
+      },
+      "title": "Nextcloud",
+      "type": 3,
+      "maintainer": " https://github.com/mycroftwilde/portainer_templates/"
+    },
+    {
+      "id": 121,
+      "categories": [
+        "Proxyserver"
+      ],
+      "description": "Nginx is a web server with a strong focus on high concurrency, performance and low memory usage. It can also act as a reverse proxy server for HTTP, HTTPS, SMTP, POP3, and IMAP protocols, as well as a load balancer and an HTTP cache.",
+      "env": [
+        {
+          "default": "1000",
+          "label": "PUID",
+          "name": "PUID"
+        },
+        {
+          "default": "100",
+          "label": "PGID",
+          "name": "PGID"
+        }
+      ],
+      "image": "linuxserver/nginx:latest",
+      "logo": "https://raw.githubusercontent.com/Qballjos/portainer_templates/master/Images/nginx-icon.png",
+      "name": "nginx",
+      "platform": "linux",
+      "ports": [
+        "80/tcp",
+        "443/tcp"
+      ],
+      "restart_policy": "unless-stopped",
+      "title": "Nginx",
+      "type": 1,
+      "volumes": [
+        {
+          "bind": "/portainer/Files/AppData/Config/Nginx",
+          "container": "/config"
+        }
+      ],
+      "maintainer": " https://github.com/mycroftwilde/portainer_templates/"
+    },
+    {
+      "id": 122,
+      "categories": [
+        "Proxyserver"
+      ],
+      "description": "Nginx Proxy Manager enables you to easily forward to your websites running at home or otherwise, including free SSL, without having to know too much about Nginx or Letsencrypt.",
+      "image": "jc21/nginx-proxy-manager",
+      "logo": "https://raw.githubusercontent.com/Qballjos/portainer_templates/master/Images/proxy_mgr.png",
+      "name": "nginx-proxy-manager",
+      "platform": "linux",
+      "env": [
+        {
+          "label": "DB_SQLITE_FILE",
+          "name": "DB_SQLITE_FILE",
+          "default": "/data/database.sqlite"
+        }
+      ],
+      "ports": [
+        "80:80/tcp",
+        "81:81/tcp",
+        "443:443/tcp"
+      ],
+      "restart_policy": "unless-stopped",
+      "title": "Nginx Proxy Manager",
+      "type": 1,
+      "volumes": [
+        {
+          "bind": "/portainer/Files/AppData/Config/Nginx-Proxy/data",
+          "container": "/data"
+        },
+        {
+          "bind": "/portainer/Files/AppData/Config/Nginx-Proxy/letsencrypt",
+          "container": "/etc/letsencrypt"
+        }
+      ],
+      "maintainer": " https://github.com/mycroftwilde/portainer_templates/"
+    },
+    {
+      "id": 123,
+      "categories": [
+        "Vpnserver"
+      ],
+      "description": "OpenVPN Access Server is a full featured secure network tunneling VPN software solution that integrates OpenVPN server capabilities, enterprise management capabilities, simplified OpenVPN Connect UI, and OpenVPN Client software packages that accommodate Windows, MAC, Linux, Android, and iOS environments.",
+      "env": [
+        {
+          "label": "INTERFACE",
+          "name": "INTERFACE",
+          "set": "eth0"
+        },
+        {
+          "default": "1000",
+          "label": "PUID",
+          "name": "PUID"
+        },
+        {
+          "default": "100",
+          "label": "PGID",
+          "name": "PGID"
+        }
+      ],
+      "image": "linuxserver/openvpn-as:latest",
+      "logo": "https://raw.githubusercontent.com/Qballjos/portainer_templates/master/Images/openvpn-as-icon.png",
+      "name": "openvpn-as",
+      "platform": "linux",
+      "ports": [
+        "943:943/tcp",
+        "9443:9443/tcp",
+        "1194:1194/udp"
+      ],
+      "restart_policy": "unless-stopped",
+      "title": "OpenVPN Access Server",
+      "type": 1,
+      "volumes": [
+        {
+          "bind": "/portainer/Files/AppData/Config/OpenVPN-AS",
+          "container": "/config"
+        }
+      ],
+      "maintainer": " https://github.com/mycroftwilde/portainer_templates/"
+    },
+    {
+      "id": 124,
+      "categories": [
+        "Dashboardserver"
+      ],
+      "description": "Organizr allows you to setup Tabs that will be loaded all in one webpage. You can then work on your server with ease.",
+      "env": [
+        {
+          "default": "1000",
+          "label": "PUID",
+          "name": "PUID"
+        },
+        {
+          "default": "100",
+          "label": "PGID",
+          "name": "PGID"
+        }
+      ],
+      "image": "organizr/organizr:latest",
+      "logo": "https://raw.githubusercontent.com/Qballjos/portainer_templates/master/Images/organizr-icon.png",
+      "name": "organizr-v2",
+      "platform": "linux",
+      "ports": [
+        "80/tcp"
+      ],
+      "restart_policy": "unless-stopped",
+      "title": "Organizr",
+      "type": 1,
+      "volumes": [
+        {
+          "bind": "/portainer/Files/AppData/Config/Organizr",
+          "container": "/config"
+        }
+      ],
+      "maintainer": " https://github.com/mycroftwilde/portainer_templates/"
+    },
+    {
+      "id": 125,
+      "categories": [
+        "Familyappserver"
+      ],
+      "description": "ownCloud is a self-hosted file sync and share server. It provides access to your data through a web interface, sync clients or WebDAV while providing a platform to view, sync and share across devices easily—all under your control. ownCloud’s open architecture is extensible via a simple but powerful API for applications and plugins and it works with any storage.",
+      "env": [
+        {
+          "default": "1000",
+          "label": "PUID",
+          "name": "PUID"
+        },
+        {
+          "default": "100",
+          "label": "PGID",
+          "name": "PGID"
+        },
+        {
+          "label": "TZ",
+          "name": "TZ"
+        },
+        {
+          "label": "OWNCLOUD_DOMAIN",
+          "name": "OWNCLOUD_DOMAIN"
+        },
+        {
+          "label": "DB_PASSWORD",
+          "name": "DB_PASSWORD"
+        },
+        {
+          "label": "ADMIN_USERNAME",
+          "name": "ADMIN_USERNAME"
+        },
+        {
+          "label": "ADMIN_PASSWORD",
+          "name": "ADMIN_PASSWORD"
+        },
+        {
+          "label": "PORT",
+          "name": "PORT"
+        }
+      ],
+      "logo": "https://raw.githubusercontent.com/docker-library/docs/9d36b4ed7cabc35dbd3849272ba2bd7abe482172/owncloud/logo.png",
+      "name": "Owncloud",
+      "note": "The database user is owncloud and the database is owncloud.",
+      "platform": "linux",
+      "repository": {
+        "stackfile": "Template/Stack/owncloud.yml",
+        "url": "https://github.com/Qballjos/portainer_templates"
+      },
+      "title": "Owncloud",
+      "type": 3,
+      "maintainer": " https://github.com/mycroftwilde/portainer_templates/"
+    },
+    {
+      "id": 126,
+      "categories": [
+        "Mediaserver"
+      ],
+      "description": "Petio is a third party companion app available to Plex server owners to allow their users to request, review and discover content.",
+      "env": [
+        {
+          "default": "1000",
+          "label": "PUID",
+          "name": "PUID"
+        },
+        {
+          "default": "100",
+          "label": "PGID",
+          "name": "PGID"
+        },
+        {
+          "label": "TZ",
+          "name": "TZ"
+        },
+        {
+          "label": "PORT",
+          "name": "PORT"
+        }
+      ],
+      "logo": "https://raw.githubusercontent.com/Qballjos/portainer_templates/master/Images/petio-icon.png",
+      "name": "Petio",
+      "platform": "linux",
+      "repository": {
+        "stackfile": "Template/Stack/petio.yml",
+        "url": "https://github.com/Qballjos/portainer_templates"
+      },
+      "title": "Petio",
+      "type": 3,
+      "maintainer": " https://github.com/mycroftwilde/portainer_templates/"
+    },
+    {
+      "id": 127,
+      "categories": [
+        "Photos"
+      ],
+      "description": "A simple, easy way to turn a photo album into a webgallery.",
+      "env": [
+        {
+          "default": "1000",
+          "label": "PUID",
+          "name": "PUID"
+        },
+        {
+          "default": "100",
+          "label": "PGID",
+          "name": "PGID"
+        }
+      ],
+      "image": "linuxserver/photoshow:latest",
+      "logo": "https://raw.githubusercontent.com/Qballjos/portainer_templates/master/Images/photoshow-icon.png",
+      "name": "photoshow",
+      "platform": "linux",
+      "ports": [
+        "80/tcp"
+      ],
+      "restart_policy": "unless-stopped",
+      "title": "PhotoShow",
+      "type": 1,
+      "volumes": [
+        {
+          "bind": "/portainer/Pictures",
+          "container": "/Pictures"
+        },
+        {
+          "bind": "/portainer/Files/AppData/Photoshow/Thumbs",
+          "container": "/Thumbs"
+        },
+        {
+          "bind": "/portainer/Files/AppData/Config/PhotoShow",
+          "container": "/config"
+        }
+      ],
+      "maintainer": " https://github.com/mycroftwilde/portainer_templates/"
+    },
+    {
+      "id": 128,
+      "categories": [
+        "Dns"
+      ],
+      "description": "A Linux network-level advertisement and Internet tracker blocking application which acts as a DNS sinkhole.",
+      "image": "pihole/pihole:latest",
+      "logo": "https://raw.githubusercontent.com/Qballjos/portainer_templates/master/Images/pihole.png",
+      "name": "pihole",
+      "note": "When the installation is complete, navigate to your.ip.goes.here:1010/admin. Follow the article <a href='https://medium.com/@niktrix/getting-rid-of-systemd-resolved-consuming-port-53-605f0234f32f'>here</a> if you run into issues binding to port 53.",
+      "platform": "linux",
+      "ports": [
+        "53:53/tcp",
+        "53:53/udp",
+        "67:67/udp",
+        "1010:80/tcp",
+        "4443:443/tcp"
+      ],
+      "restart_policy": "unless-stopped",
+      "title": "Pi-Hole",
+      "type": 1,
+      "volumes": [
+        {
+          "bind": "/portainer/Files/AppData/Config/PiHole",
+          "container": "/etc/pihole"
+        },
+        {
+          "bind": "/portainer/Files/AppData/Config/PiHole/DNS",
+          "container": "/etc/dnsmasq.d"
+        }
+      ],
+      "maintainer": " https://github.com/mycroftwilde/portainer_templates/"
+    },
+    {
+      "id": 129,
+      "categories": [
+        "Photos"
+      ],
+      "description": "Piwigo is photo gallery software for the web, built by an active community of users and developers.",
+      "env": [
+        {
+          "default": "1000",
+          "label": "PUID",
+          "name": "PUID"
+        },
+        {
+          "default": "100",
+          "label": "PGID",
+          "name": "PGID"
+        }
+      ],
+      "image": "linuxserver/piwigo:latest",
+      "logo": "https://raw.githubusercontent.com/Qballjos/portainer_templates/master/Images/piwigo-icon.png",
+      "name": "piwigo",
+      "platform": "linux",
+      "ports": [
+        "80/tcp"
+      ],
+      "restart_policy": "unless-stopped",
+      "title": "Piwigo",
+      "type": 1,
+      "volumes": [
+        {
+          "bind": "/portainer/Files/AppData/Config/PiWigo",
+          "container": "/config"
+        }
+      ],
+      "maintainer": " https://github.com/mycroftwilde/portainer_templates/"
+    },
+    {
+      "id": 130,
+      "categories": [
+        "Mediaserver"
+      ],
+      "description": "Your favorite movies, TV, music, web shows, podcasts, and more, all streamed to your favorite screens.",
+      "env": [
+        {
+          "default": "1000",
+          "label": "PUID",
+          "name": "PUID"
+        },
+        {
+          "default": "100",
+          "label": "PGID",
+          "name": "PGID"
+        },
+        {
+          "label": "VERSION",
+          "name": "VERSION",
+          "set": "latest"
+        }
+      ],
+      "image": "linuxserver/plex:latest",
+      "logo": "https://raw.githubusercontent.com/Qballjos/portainer_templates/master/Images/plex-icon.png",
+      "name": "plex",
+      "network": "host",
+      "platform": "linux",
+      "restart_policy": "unless-stopped",
+      "title": "Plex",
+      "type": 1,
+      "volumes": [
+        {
+          "bind": "/portainer/Files/AppData/Config/Plex",
+          "container": "/config"
+        },
+        {
+          "bind": "/portainer/TV",
+          "container": "/tv"
+        },
+        {
+          "bind": "/portainer/Movies",
+          "container": "/movies"
+        }
+      ],
+      "maintainer": " https://github.com/mycroftwilde/portainer_templates/"
+    },
+    {
+      "id": 131,
+      "categories": [
+        "Email"
+      ],
+      "description": "This is an unofficial Docker container of the ProtonMail Bridge. Some of the scripts are based on Hendrik Meyer's work.",
+      "image": "shenxn/protonmail-bridge:latest",
+      "logo": "https://raw.githubusercontent.com/Qballjos/portainer_templates/master/Images/protonmail-bridge.png",
+      "name": "protonmail-bridge",
+      "note": "Please refer to the documentation <a href='https://hub.docker.com/r/shenxn/protonmail-bridge'/>here</a> to set this up.",
+      "platform": "linux",
+      "ports": [
+        "143/tcp",
+        "25/tcp"
+      ],
+      "restart_policy": "unless-stopped",
+      "title": "ProtonMail Bridge",
+      "type": 1,
+      "volumes": [
+        {
+          "bind": "/portainer/Files/AppData/ProtonMail-Bridge",
+          "container": "/root"
+        }
+      ],
+      "maintainer": " https://github.com/mycroftwilde/portainer_templates/"
+    },
+    {
+      "id": 132,
+      "categories": [
+        "Torrentserver"
+      ],
+      "description": "The qBittorrent project aims to provide an open-source software alternative to µTorrent. qBittorrent is based on the Qt toolkit and libtorrent-rasterbar library.",
+      "env": [
+        {
+          "default": "1000",
+          "label": "PUID",
+          "name": "PUID"
+        },
+        {
+          "default": "100",
+          "label": "PGID",
+          "name": "PGID"
+        }
+      ],
+      "image": "linuxserver/qbittorrent:latest",
+      "logo": "https://raw.githubusercontent.com/Qballjos/portainer_templates/master/Images/qbittorrent-icon.png",
+      "name": "qbittorrent",
+      "platform": "linux",
+      "ports": [
+        "6881:6881/tcp",
+        "6881:6881/udp",
+        "8080:8080/tcp"
+      ],
+      "restart_policy": "unless-stopped",
+      "title": "qBittorrent",
+      "type": 1,
+      "volumes": [
+        {
+          "bind": "/portainer/Files/AppData/Config/qBittorrent",
+          "container": "/config"
+        },
+        {
+          "bind": "/portainer/Downloads",
+          "container": "/downloads"
+        }
+      ],
+      "maintainer": " https://github.com/mycroftwilde/portainer_templates/"
+    },
+    {
+      "id": 133,
+      "categories": [
+        "Usenetserver"
+      ],
+      "description": "SABnzbd makes Usenet as simple and streamlined as possible by automating everything we can. All you have to do is add an .nzb. SABnzbd takes over from there, where it will be automatically downloaded, verified, repaired, extracted and filed away with zero human interaction.",
+      "env": [
+        {
+          "default": "1000",
+          "label": "PUID",
+          "name": "PUID"
+        },
+        {
+          "default": "100",
+          "label": "PGID",
+          "name": "PGID"
+        }
+      ],
+      "image": "linuxserver/sabnzbd:latest",
+      "logo": "https://raw.githubusercontent.com/Qballjos/portainer_templates/master/Images/sabnzbd-icon.png",
+      "name": "sabnzbd",
+      "platform": "linux",
+      "ports": [
+        "8080:8080/tcp",
+        "9090:9090/tcp"
+      ],
+      "restart_policy": "unless-stopped",
+      "title": "SABnzbd",
+      "type": 1,
+      "volumes": [
+        {
+          "bind": "/portainer/Files/AppData/Config/Sabnzbd",
+          "container": "/config"
+        },
+        {
+          "bind": "/portainer/Downloads",
+          "container": "/downloads"
+        },
+        {
+          "bind": "/portainer/Downloads/incomplete",
+          "container": "/incomplete-downloads"
+        }
+      ],
+      "maintainer": " https://github.com/mycroftwilde/portainer_templates/"
+    },
+    {
+      "id": 134,
+      "categories": [
+        "Familyappserver"
+      ],
+      "description": "Shiori is a simple bookmarks manager written in Go language. Intended as a simple clone of Pocket. You can use it as command line application or as web application.",
+      "image": "radhifadlillah/shiori:latest",
+      "logo": "https://raw.githubusercontent.com/Qballjos/portainer_templates/master/Images/shiori-icon.png",
+      "name": "shiori",
+      "platform": "linux",
+      "ports": [
+        "8080/tcp"
+      ],
+      "restart_policy": "unless-stopped",
+      "title": "Shiori",
+      "type": 1,
+      "volumes": [
+        {
+          "bind": "/portainer/Files/AppData/Config/Shiori",
+          "container": "/srv/shiori"
+        }
+      ],
+      "maintainer": " https://github.com/mycroftwilde/portainer_templates/"
+    },
+    {
+      "id": 135,
+      "categories": [
+        "Taskserver"
+      ],
+      "description": "SmokePing is a latency logging and graphing and alerting system. It consists of a daemon process which organizes the latency measurements and a CGI which presents the graphs.",
+      "env": [
+        {
+          "default": "1000",
+          "label": "PUID",
+          "name": "PUID"
+        },
+        {
+          "default": "100",
+          "label": "PGID",
+          "name": "PGID"
+        }
+      ],
+      "image": "linuxserver/smokeping:latest",
+      "logo": "https://raw.githubusercontent.com/Qballjos/portainer_templates/master/Images/smokeping-icon.png",
+      "name": "smokeping",
+      "platform": "linux",
+      "ports": [
+        "80/tcp"
+      ],
+      "restart_policy": "unless-stopped",
+      "title": "SmokePing",
+      "type": 1,
+      "volumes": [
+        {
+          "bind": "/portainer/Files/AppData/Config/Smokeping",
+          "container": "/config"
+        },
+        {
+          "bind": "/portainer/Files/AppData/Smokeping",
+          "container": "/data"
+        }
+      ],
+      "maintainer": " https://github.com/mycroftwilde/portainer_templates/"
+    },
+    {
+      "id": 136,
+      "categories": [
+        "Codeserver"
+      ],
+      "description": "Self-hosted snippet manager.",
+      "image": "snowmean/snibox-sqlite:latest",
+      "logo": "https://raw.githubusercontent.com/Qballjos/portainer_templates/master/Images/snibox.png",
+      "name": "Snibox",
+      "note": "Label-oriented interface with search. Supports various programming languages, markdown, plain text.",
+      "platform": "linux",
+      "ports": [
+        "3010:3000/tcp"
+      ],
+      "restart_policy": "unless-stopped",
+      "title": "Snibox",
+      "type": 1,
+      "volumes": [
+        {
+          "bind": "/portainer/Files/AppData/Config/Snibox",
+          "container": "/app/db/database"
+        }
+      ],
+      "maintainer": " https://github.com/mycroftwilde/portainer_templates/"
+    },
+    {
+      "id": 137,
+      "categories": [
+        "Backupandsyncserver"
+      ],
+      "description": "Syncthing is a continuous file synchronization program. It synchronizes files between two or more computers in real time, safely protected from prying eyes.",
+      "env": [
+        {
+          "default": "1000",
+          "label": "PUID",
+          "name": "PUID"
+        },
+        {
+          "default": "100",
+          "label": "PGID",
+          "name": "PGID"
+        }
+      ],
+      "image": "linuxserver/syncthing:latest",
+      "logo": "https://raw.githubusercontent.com/Qballjos/portainer_templates/master/Images/syncthing-icon.png",
+      "name": "syncthing",
+      "platform": "linux",
+      "ports": [
+        "8384:8384/tcp",
+        "21027:21027/udp",
+        "22000:22000/tcp"
+      ],
+      "restart_policy": "unless-stopped",
+      "title": "SyncThing",
+      "type": 1,
+      "volumes": [
+        {
+          "bind": "/portainer/Files/AppData/Config/Syncthing",
+          "container": "/config"
+        },
+        {
+          "container": "/sync"
+        }
+      ],
+      "maintainer": " https://github.com/mycroftwilde/portainer_templates/"
+    },
+    {
+      "id": 138,
+      "categories": [
+        "Notesserver"
+      ],
+      "description": "A unique, non-linear notebook wiki.",
+      "image": "mazzolino/tiddlywiki:latest",
+      "logo": "https://raw.githubusercontent.com/Qballjos/portainer_templates/master/Images/tiddlywiki.png",
+      "name": "tiddlywiki",
+      "platform": "linux",
+      "ports": [
+        "8080:8080/tcp"
+      ],
+      "restart_policy": "unless-stopped",
+      "title": "TiddlyWiki",
+      "type": 1,
+      "volumes": [
+        {
+          "bind": "/portainer/Files/AppData/Config/TiddlyWiki",
+          "container": "/var/lib/tiddlywiki"
+        }
+      ],
+      "maintainer": " https://github.com/mycroftwilde/portainer_templates/"
+    },
+    {
+      "id": 139,
+      "categories": [
+        "Smarthome"
+      ],
+      "description": "Tiny Tiny RSS is an open source web-based news feed (RSS/Atom) reader and aggregator, designed to allow you to read news from any location, while feeling as close to a real desktop application as possible.",
+      "env": [
+        {
+          "default": "1000",
+          "label": "PUID",
+          "name": "PUID"
+        },
+        {
+          "default": "100",
+          "label": "PGID",
+          "name": "PGID"
+        }
+      ],
+      "image": "lunik1/tt-rss:latest",
+      "logo": "https://raw.githubusercontent.com/Qballjos/portainer_templates/master/Images/tt-rss-icon.png",
+      "name": "tt-rss",
+      "platform": "linux",
+      "ports": [
+        "80/tcp"
+      ],
+      "restart_policy": "unless-stopped",
+      "title": "Tiny Tiny RSS",
+      "type": 1,
+      "volumes": [
+        {
+          "bind": "/portainer/Files/AppData/Config/tt-rss",
+          "container": "/config"
+        }
+      ],
+      "maintainer": " https://github.com/mycroftwilde/portainer_templates/"
+    },
+    {
+      "id": 140,
+      "categories": [
+        "Torrentserver"
+      ],
+      "description": "Transmission is designed for easy, powerful use. Transmission has the features you want from a BitTorrent client: encryption, a web interface, peer exchange, magnet links, DHT, µTP, UPnP and NAT-PMP port forwarding, webseed support, watch directories, tracker editing, global and per-torrent speed limits, and more.",
+      "env": [
+        {
+          "default": "1000",
+          "label": "PUID",
+          "name": "PUID"
+        },
+        {
+          "default": "100",
+          "label": "PGID",
+          "name": "PGID"
+        }
+      ],
+      "image": "linuxserver/transmission:latest",
+      "logo": "https://raw.githubusercontent.com/Qballjos/portainer_templates/master/Images/transmission-icon.png",
+      "name": "transmission",
+      "platform": "linux",
+      "ports": [
+        "9091:9091/tcp",
+        "51413:51413/tcp"
+      ],
+      "restart_policy": "unless-stopped",
+      "title": "Transmission",
+      "type": 1,
+      "volumes": [
+        {
+          "bind": "/portainer/Files/AppData/Config/Transmission",
+          "container": "/config"
+        },
+        {
+          "bind": "/portainer/Files/Downloads",
+          "container": "/downloads"
+        },
+        {
+          "container": "/watch"
+        }
+      ],
+      "maintainer": " https://github.com/mycroftwilde/portainer_templates/"
+    },
+    {
+      "id": 141,
+      "categories": [
+        "Torrentserver"
+      ],
+      "description": "This container contains OpenVPN and Transmission with a configuration where Transmission is running only when OpenVPN has an active tunnel. It bundles configuration files for many popular VPN providers to make the setup easier.",
+      "env": [
+        {
+          "default": "1000",
+          "label": "PUID",
+          "name": "PUID"
+        },
+        {
+          "default": "100",
+          "label": "PGID",
+          "name": "PGID"
+        },
+        {
+          "default": "MULLVAD",
+          "description": "https://haugene.github.io/docker-transmission-openvpn/supported-providers/",
+          "label": "OPENVPN_PROVIDER",
+          "name": "OPENVPN_PROVIDER"
+        },
+        {
+          "default": "",
+          "label": "OPENVPN_USERNAME",
+          "name": "OPENVPN_USERNAME"
+        },
+        {
+          "default": "",
+          "label": "OPENVPN_PASSWORD",
+          "name": "OPENVPN_PASSWORD"
+        },
+        {
+          "default": "192.168.0.0/24",
+          "label": "LOCAL_NETWORK",
+          "name": "LOCAL_NETWORK"
+        }
+      ],
+      "image": "haugene/transmission-openvpn:latest",
+      "logo": "https://raw.githubusercontent.com/Qballjos/portainer_templates/master/Images/transmission-icon.png",
+      "name": "transmission-openvpn",
+      "note": "List of supported providers available <a href='https://haugene.github.io/docker-transmission-openvpn/supported-providers'/>here</a>.",
+      "platform": "linux",
+      "ports": [
+        "9091:9091/tcp"
+      ],
+      "restart_policy": "unless-stopped",
+      "title": "Transmission-OpenVPN",
+      "type": 1,
+      "volumes": [
+        {
+          "bind": "/portainer/Downloads",
+          "container": "/data"
+        },
+        {
+          "bind": "/etc/localtime",
+          "container": "/etc/localtime"
+        }
+      ],
+      "maintainer": " https://github.com/mycroftwilde/portainer_templates/"
+    },
+    {
+      "id": 142,
+      "categories": [
+        "Libraryserver"
+      ],
+      "description": "Ubooquity is a free, lightweight and easy-to-use home server for your comics and ebooks. Use it to access your files from anywhere, with a tablet, an e-reader, a phone or a computer.",
+      "env": [
+        {
+          "label": "MAXMEM",
+          "name": "MAXMEM",
+          "set": "512"
+        },
+        {
+          "default": "1000",
+          "label": "PUID",
+          "name": "PUID"
+        },
+        {
+          "default": "100",
+          "label": "PGID",
+          "name": "PGID"
+        }
+      ],
+      "image": "linuxserver/ubooquity:latest",
+      "logo": "https://raw.githubusercontent.com/Qballjos/portainer_templates/master/Images/ubooquity-icon.png",
+      "name": "ubooquity",
+      "platform": "linux",
+      "ports": [
+        "2202:2202/tcp",
+        "2203:2203/tcp"
+      ],
+      "restart_policy": "unless-stopped",
+      "title": "Ubooquity",
+      "type": 1,
+      "volumes": [
+        {
+          "container": "/books"
+        },
+        {
+          "container": "/comics"
+        },
+        {
+          "container": "/config"
+        }
+      ],
+      "maintainer": " https://github.com/mycroftwilde/portainer_templates/"
+    },
+    {
+      "id": 143,
+      "categories": [
+        "Smarthome"
+      ],
+      "description": "The Unifi-controller Controller software is a powerful, enterprise wireless software engine ideal for high-density client deployments requiring low latency and high uptime performance.",
+      "env": [
+        {
+          "default": "1000",
+          "label": "PUID",
+          "name": "PUID"
+        },
+        {
+          "default": "100",
+          "label": "PGID",
+          "name": "PGID"
+        }
+      ],
+      "image": "linuxserver/unifi-controller:latest",
+      "logo": "https://raw.githubusercontent.com/Qballjos/portainer_templates/master/Images/unifi-icon.png",
+      "name": "unifi-controller",
+      "platform": "linux",
+      "ports": [
+        "3478:3478/udp",
+        "10001:10001/udp",
+        "8080:8080/tcp",
+        "8081:8081/tcp",
+        "8443:8443/tcp",
+        "8843:8843/tcp",
+        "8880:8880/tcp",
+        "6789:6789/tcp"
+      ],
+      "restart_policy": "unless-stopped",
+      "title": "UniFi Controller",
+      "type": 1,
+      "volumes": [
+        {
+          "bind": "/portainer/Files/AppData/Config/Unifi",
+          "container": "/config"
+        }
+      ],
+      "maintainer": " https://github.com/mycroftwilde/portainer_templates/"
+    },
+    {
+      "id": 144,
+      "categories": [
+        "Downloaders"
+      ],
+      "description": "WebGrab+Plus is a multi-site incremental xmltv epg grabber. It collects tv-program guide data from selected tvguide sites for your favourite channels.",
+      "env": [
+        {
+          "default": "1000",
+          "label": "PUID",
+          "name": "PUID"
+        },
+        {
+          "default": "100",
+          "label": "PGID",
+          "name": "PGID"
+        }
+      ],
+      "image": "linuxserver/webgrabplus:latest",
+      "logo": "https://raw.githubusercontent.com/Qballjos/portainer_templates/master/Images/webgrabplus.png",
+      "name": "webgrabplus",
+      "note": "Configuration <ul><li><b>/config</b> - This is where WebGrab+Plus will store it's configuration</li><li><b>/data</b> - This is where tv_grab_wg script in the Tvheadend container looks for the guide.xml file.</li></ul>",
+      "platform": "linux",
+      "restart_policy": "unless-stopped",
+      "title": "WebGrab+Plus",
+      "type": 1,
+      "volumes": [
+        {
+          "bind": "/portainer/Files/AppData/Config/WebGrabPlus",
+          "container": "/config"
+        },
+        {
+          "bind": "/portainer/Files/AppData/WebGrabPlus",
+          "container": "/data"
+        }
+      ],
+      "maintainer": " https://github.com/mycroftwilde/portainer_templates/"
+    },
+    {
+      "id": 145,
+      "categories": [
+        "Familyappserver"
+      ],
+      "description": "Self-hosted, ad-free, privacy-respecting Google metasearch engine.",
+      "image": "benbusby/whoogle-search:latest",
+      "logo": "https://raw.githubusercontent.com/Qballjos/portainer_templates/master/Images/whoogle.png",
+      "name": "whoogle",
+      "platform": "linux",
+      "ports": [
+        "5001:5000/tcp"
+      ],
+      "restart_policy": "unless-stopped",
+      "title": "Whoogle",
+      "type": 1,
+      "volumes": [
+        {
+          "bind": "/portainer/Files/AppData/Config/Whoogle",
+          "container": "/config"
+        }
+      ],
+      "maintainer": " https://github.com/mycroftwilde/portainer_templates/"
+    },
+    {
+      "id": 146,
+      "categories": [
+        "Notesserver"
+      ],
+      "description": "Wikijs A modern, lightweight and powerful wiki app built on NodeJS.",
+      "image": "linuxserver/wikijs:latest",
+      "logo": "https://raw.githubusercontent.com/Qballjos/portainer_templates/master/Images/wikijs.png",
+      "name": "Wikijs",
+      "platform": "linux",
+      "ports": [
+        "3100:3000/tcp"
+      ],
+      "restart_policy": "unless-stopped",
+      "title": "Wikijs",
+      "type": 1,
+      "volumes": [
+        {
+          "bind": "/portainer/Files/AppData/Config/Wikijs",
+          "container": "/config"
+        },
+        {
+          "bind": "/portainer/Files/AppData/Config/Wikijs/data",
+          "container": "/data"
+        }
+      ],
+      "maintainer": " https://github.com/mycroftwilde/portainer_templates/"
+    },
+    {
+      "id": 147,
+      "categories": [
+        "Dashboardserver"
+      ],
+      "description": "A web interface for managing docker containers with an emphasis on templating to provide 1 click deployments. Think of it like a decentralized app store for servers that anyone can make packages for.",
+      "image": "selfhostedpro/yacht:latest",
+      "logo": "https://raw.githubusercontent.com/SelfhostedPro/Yacht/master/readme_media/Yacht_logo_1_dark.png",
+      "name": "yacht",
+      "platform": "linux",
+      "ports": [
+        "8001:8000/tcp"
+      ],
+      "restart_policy": "unless-stopped",
+      "title": "Yacht",
+      "type": 1,
+      "volumes": [
+        {
+          "bind": "yacht",
+          "container": "/config"
+        },
+        {
+          "bind": "/var/run/docker.sock",
+          "container": "/var/run/docker.sock"
+        }
+      ],
+      "maintainer": " https://github.com/mycroftwilde/portainer_templates/"
+    },
+    {
+      "id": 148,
+      "type": 1,
+      "categories": [
+        "Tools"
+      ],
+      "title": "Audacity",
+      "name": "Audacity",
+      "note": "Portainer App Templates by <a href='https://www.technorabilia.com' target='_blank'>Technorabilia</a> based on data provided by <a href='https://www.linuxserver.io' target='_blank'>LinuxServer.io</a>.</p><p>Don't forget to create the volume directories on the host file system.</p><p>mkdir -p /volume1/docker/audacity/config</p>",
+      "description": "[Audacity](https://www.audacityteam.org/) is an easy-to-use, multi-track audio editor and recorder. Developed by a group of volunteers as open source.",
+      "platform": "linux",
+      "logo": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/audacity-logo.png",
+      "image": "linuxserver/audacity:latest",
+      "env": [
+        {
+          "name": "PUID",
+          "label": "PUID",
+          "default": "1024",
+          "description": "for GroupID"
+        },
+        {
+          "name": "PGID",
+          "label": "PGID",
+          "default": "100",
+          "description": "for UserID"
+        },
+        {
+          "name": "TZ",
+          "label": "TZ",
+          "default": "Europe/Amsterdam",
+          "description": "Specify a timezone to use for example Europe/Amsterdam"
+        }
+      ],
+      "ports": [
+        "3000:3000/tcp"
+      ],
+      "volumes": [
+        {
+          "container": "/config",
+          "bind": "/volume1/docker/audacity/config"
+        }
+      ],
+      "restart_policy": "unless-stopped",
+      "maintainer": " https://github.com/mycroftwilde/portainer_templates/"
+    },
+    {
+      "id": 149,
+      "type": 1,
+      "categories": [
+        "Libraryserver"
+      ],
+      "title": "Booksonic-air",
+      "name": "Booksonic-air",
+      "note": "Portainer App Templates by <a href='https://www.technorabilia.com' target='_blank'>Technorabilia</a> based on data provided by <a href='https://www.linuxserver.io' target='_blank'>LinuxServer.io</a>.</p><p>Don't forget to create the volume directories on the host file system.</p><p>mkdir -p /volume1/docker/booksonic-air/config<br>mkdir -p /volume1/docker/booksonic-air/audiobooks<br>mkdir -p /volume1/docker/booksonic-air/podcasts<br>mkdir -p /volume1/docker/booksonic-air/othermedia</p>",
+      "description": "[Booksonic-air](http://booksonic.org) is a platform for accessing the audibooks you own wherever you are. At the moment the platform consists of Booksonic Air - A server for streaming your audiobooks, successor to the original Booksonic server and based on Airsonic. Booksonic App - An DSub based Android app for connection to Booksonic-Air servers. .",
+      "platform": "linux",
+      "logo": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/booksonic-air.png",
+      "image": "linuxserver/booksonic-air:latest",
+      "env": [
+        {
+          "name": "PUID",
+          "label": "PUID",
+          "default": "1024",
+          "description": "for GroupID"
+        },
+        {
+          "name": "PGID",
+          "label": "PGID",
+          "default": "100",
+          "description": "for UserID"
+        },
+        {
+          "name": "TZ",
+          "label": "TZ",
+          "default": "Europe/Amsterdam",
+          "description": "Specify a timezone to use for example Europe/Amsterdam"
+        },
+        {
+          "name": "CONTEXT_PATH",
+          "label": "CONTEXT_PATH",
+          "default": "url-base",
+          "description": "Base url for use with reverse proxies etc."
+        }
+      ],
+      "ports": [
+        "4040:4040/tcp"
+      ],
+      "volumes": [
+        {
+          "container": "/config",
+          "bind": "/volume1/docker/booksonic-air/config"
+        },
+        {
+          "container": "/audiobooks",
+          "bind": "/volume1/docker/booksonic-air/audiobooks"
+        },
+        {
+          "container": "/podcasts",
+          "bind": "/volume1/docker/booksonic-air/podcasts"
+        },
+        {
+          "container": "/othermedia",
+          "bind": "/volume1/docker/booksonic-air/othermedia"
+        }
+      ],
+      "restart_policy": "unless-stopped",
+      "maintainer": " https://github.com/mycroftwilde/portainer_templates/"
+    },
+    {
+      "id": 150,
+      "type": 1,
+      "categories": [
+        "Codeserver"
+      ],
+      "title": "Cloud9",
+      "name": "Cloud9",
+      "note": "Portainer App Templates by <a href='https://www.technorabilia.com' target='_blank'>Technorabilia</a> based on data provided by <a href='https://www.linuxserver.io' target='_blank'>LinuxServer.io</a>.</p><p>Don't forget to create the volume directories on the host file system.</p><p>mkdir -p /volume1/docker/cloud9/config<br>mkdir -p /volume1/docker/cloud9/code<br></p>",
+      "description": "[Cloud9](https://github.com/c9/core) Cloud9 is a complete web based IDE with terminal access. This container is for running their core SDK locally and developing plugins.",
+      "platform": "linux",
+      "logo": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/cloud9.png",
+      "image": "linuxserver/cloud9:latest",
+      "env": [
+        {
+          "name": "PUID",
+          "label": "PUID",
+          "default": "1024",
+          "description": "for GroupID"
+        },
+        {
+          "name": "PGID",
+          "label": "PGID",
+          "default": "100",
+          "description": "for UserID"
+        },
+        {
+          "name": "TZ",
+          "label": "TZ",
+          "default": "Europe/Amsterdam",
+          "description": "Specify a timezone to use for example Europe/Amsterdam"
+        },
+        {
+          "name": "GITURL",
+          "label": "GITURL",
+          "default": "https://github.com/linuxserver/docker-cloud9.git",
+          "description": "Specify a git repo to checkout on first startup"
+        },
+        {
+          "name": "USERNAME",
+          "label": "USERNAME",
+          "default": "",
+          "description": "Optionally specify a username for http auth"
+        },
+        {
+          "name": "PASSWORD",
+          "label": "PASSWORD",
+          "default": "",
+          "description": "Optionally specify a password for http auth (if USERNAME and PASSWORD are not set, there will be no http auth)"
+        }
+      ],
+      "ports": [
+        "8000:8000/tcp"
+      ],
+      "volumes": [
+        {
+          "container": "/config",
+          "bind": "/volume1/docker/cloud9/config"
+        },
+        {
+          "container": "/code",
+          "bind": "/volume1/docker/cloud9/code"
+        },
+        {
+          "container": "/var/run/docker.sock",
+          "bind": "/var/run/docker.sock"
+        }
+      ],
+      "restart_policy": "unless-stopped",
+      "maintainer": " https://github.com/mycroftwilde/portainer_templates/"
+    },
+    {
+      "id": 151,
+      "type": 1,
+      "categories": [
+        "Notesserver"
+      ],
+      "title": "Dokuwiki",
+      "name": "Dokuwiki",
+      "note": "Portainer App Templates by <a href='https://www.technorabilia.com' target='_blank'>Technorabilia</a> based on data provided by <a href='https://www.linuxserver.io' target='_blank'>LinuxServer.io</a>.</p><p>Don't forget to create the volume directories on the host file system.</p><p>mkdir -p /volume1/docker/dokuwiki/config</p>",
+      "description": "[Dokuwiki](https://www.dokuwiki.org/dokuwiki/) is a simple to use and highly versatile Open Source wiki software that doesn't require a database. It is loved by users for its clean and readable syntax. The ease of maintenance, backup and integration makes it an administrator's favorite. Built in access controls and authentication connectors make DokuWiki especially useful in the enterprise context and the large number of plugins contributed by its vibrant community allow for a broad range of use cases beyond a traditional wiki.",
+      "platform": "linux",
+      "logo": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/dokuwiki-icon.png",
+      "image": "linuxserver/dokuwiki:latest",
+      "env": [
+        {
+          "name": "PUID",
+          "label": "PUID",
+          "default": "1024",
+          "description": "for GroupID"
+        },
+        {
+          "name": "PGID",
+          "label": "PGID",
+          "default": "100",
+          "description": "for UserID"
+        },
+        {
+          "name": "TZ",
+          "label": "TZ",
+          "default": "Europe/Amsterdam",
+          "description": "Specify a timezone to use for example Europe/Amsterdam"
+        }
+      ],
+      "ports": [
+        "80:80/tcp",
+        "443:443/tcp"
+      ],
+      "volumes": [
+        {
+          "container": "/config",
+          "bind": "/volume1/docker/dokuwiki/config"
+        }
+      ],
+      "restart_policy": "unless-stopped",
+      "maintainer": " https://github.com/mycroftwilde/portainer_templates/"
+    },
+    {
+      "id": 152,
+      "type": 1,
+      "categories": [
+        "Gamingserver"
+      ],
+      "title": "Emulatorjs",
+      "name": "Emulatorjs",
+      "note": "Portainer App Templates by <a href='https://www.technorabilia.com' target='_blank'>Technorabilia</a> based on data provided by <a href='https://www.linuxserver.io' target='_blank'>LinuxServer.io</a>.</p><p>Don't forget to create the volume directories on the host file system.</p><p>mkdir -p /volume1/docker/emulatorjs/config<br>mkdir -p /volume1/docker/emulatorjs/data</p>",
+      "description": "[Emulatorjs](https://github.com/linuxserver/emulatorjs) - In browser web based emulation portable to nearly any device for many retro consoles. A mix of emulators is used between Libretro and EmulatorJS.",
+      "platform": "linux",
+      "logo": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/emulatorjs-logo.png",
+      "image": "linuxserver/emulatorjs:latest",
+      "env": [
+        {
+          "name": "PUID",
+          "label": "PUID",
+          "default": "1024",
+          "description": "for GroupID"
+        },
+        {
+          "name": "PGID",
+          "label": "PGID",
+          "default": "100",
+          "description": "for UserID"
+        },
+        {
+          "name": "TZ",
+          "label": "TZ",
+          "default": "Europe/Amsterdam",
+          "description": "Specify a timezone to use for example Europe/Amsterdam"
+        },
+        {
+          "name": "SUBFOLDER",
+          "label": "SUBFOLDER",
+          "default": "/",
+          "description": "Specify a subfolder for reverse proxies IE '/FOLDER/'"
+        }
+      ],
+      "ports": [
+        "3000:3000/tcp",
+        "80:80/tcp",
+        "4001:4001/tcp"
+      ],
+      "volumes": [
+        {
+          "container": "/config",
+          "bind": "/volume1/docker/emulatorjs/config"
+        },
+        {
+          "container": "/data",
+          "bind": "/volume1/docker/emulatorjs/data"
+        }
+      ],
+      "restart_policy": "unless-stopped",
+      "maintainer": " https://github.com/mycroftwilde/portainer_templates/"
+    },
+    {
+      "id": 153,
+      "type": 1,
+      "categories": [
+        "Tools"
+      ],
+      "title": "Endlessh",
+      "name": "Endlessh",
+      "note": "Portainer App Templates by <a href='https://www.technorabilia.com' target='_blank'>Technorabilia</a> based on data provided by <a href='https://www.linuxserver.io' target='_blank'>LinuxServer.io</a>.</p><p>Don't forget to create the volume directories on the host file system.</p><p>mkdir -p /volume1/docker/endlessh/config</p>",
+      "description": "[Endlessh](https://github.com/skeeto/endlessh) is an SSH tarpit that very slowly sends an endless, random SSH banner. It keeps SSH clients locked up for hours or even days at a time. The purpose is to put your real SSH server on another port and then let the script kiddies get stuck in this tarpit instead of bothering a real server.",
+      "platform": "linux",
+      "logo": "https://github.com/linuxserver/docker-templates/raw/master/linuxserver.io/img/openssh-server-logo.png",
+      "image": "linuxserver/endlessh:latest",
+      "env": [
+        {
+          "name": "PUID",
+          "label": "PUID",
+          "default": "1024",
+          "description": "for GroupID"
+        },
+        {
+          "name": "PGID",
+          "label": "PGID",
+          "default": "100",
+          "description": "for UserID"
+        },
+        {
+          "name": "TZ",
+          "label": "TZ",
+          "default": "Europe/Amsterdam",
+          "description": "Specify a timezone to use for example Europe/Amsterdam"
+        },
+        {
+          "name": "MSDELAY",
+          "label": "MSDELAY",
+          "default": "10000",
+          "description": "The endless banner is sent one line at a time. This is the delay in milliseconds between individual lines."
+        },
+        {
+          "name": "MAXLINES",
+          "label": "MAXLINES",
+          "default": "32",
+          "description": "The length of each line is randomized. This controls the maximum length of each line. Shorter lines may keep clients on for longer if they give up after a certain number of bytes."
+        },
+        {
+          "name": "MAXCLIENTS",
+          "label": "MAXCLIENTS",
+          "default": "4096",
+          "description": "Maximum number of connections to accept at a time. Connections beyond this are not immediately rejected, but will wait in the queue."
+        },
+        {
+          "name": "LOGFILE",
+          "label": "LOGFILE",
+          "default": "false",
+          "description": "By default, the app logs to container log. If this is set to `true`, the log will be output to file under `/config/logs/endlessh` (`/config` needs to be mapped)."
+        },
+        {
+          "name": "BINDFAMILY",
+          "label": "BINDFAMILY",
+          "default": "",
+          "description": "By default, the app binds to IPv4 and IPv6 addresses. Set it to `4` or `6` to bind to IPv4 only or IPv6 only, respectively. Leave blank to bind to both."
+        }
+      ],
+      "ports": [
+        "22:2222/tcp"
+      ],
+      "volumes": [
+        {
+          "container": "/config",
+          "bind": "/volume1/docker/endlessh/config"
+        }
+      ],
+      "restart_policy": "unless-stopped",
+      "maintainer": " https://github.com/mycroftwilde/portainer_templates/"
+    },
+    {
+      "id": 154,
+      "type": 1,
+      "categories": [
+        "Mediaserver"
+      ],
+      "title": "Ffmpeg",
+      "name": "Ffmpeg",
+      "note": "Portainer App Templates by <a href='https://www.technorabilia.com' target='_blank'>Technorabilia</a> based on data provided by <a href='https://www.linuxserver.io' target='_blank'>LinuxServer.io</a>.</p><p>Don't forget to create the volume directories on the host file system.</p><p>mkdir -p /volume1/docker/ffmpeg/config</p>",
+      "description": "This container needs special attention. Please check https://hub.docker.com/r/linuxserver/ffmpeg for details.",
+      "platform": "linux",
+      "logo": "",
+      "image": "linuxserver/ffmpeg:latest",
+      "env": [
+        {
+          "name": "PUID",
+          "label": "PUID",
+          "default": "1024",
+          "description": "for GroupID"
+        },
+        {
+          "name": "PGID",
+          "label": "PGID",
+          "default": "100",
+          "description": "for UserID"
+        },
+        {
+          "name": "TZ",
+          "label": "TZ",
+          "default": "Europe/Amsterdam",
+          "description": "Specify a timezone to use for example Europe/Amsterdam"
+        }
+      ],
+      "ports": [
+        "80:80/tcp"
+      ],
+      "volumes": [
+        {
+          "container": "/config",
+          "bind": "/volume1/docker/ffmpeg/config"
+        }
+      ],
+      "restart_policy": "unless-stopped",
+      "maintainer": " https://github.com/mycroftwilde/portainer_templates/"
+    },
+    {
+      "id": 155,
+      "type": 1,
+      "categories": [
+        "Ftpserver"
+      ],
+      "title": "Filezilla",
+      "name": "Filezilla",
+      "note": "Portainer App Templates by <a href='https://www.technorabilia.com' target='_blank'>Technorabilia</a> based on data provided by <a href='https://www.linuxserver.io' target='_blank'>LinuxServer.io</a>.</p><p>Don't forget to create the volume directories on the host file system.</p><p>mkdir -p /volume1/docker/filezilla/config</p>",
+      "description": "[FIleZilla](https://filezilla-project.org/) Client is a fast and reliable cross-platform FTP, FTPS and SFTP client with lots of useful features and an intuitive graphical user interface.",
+      "platform": "linux",
+      "logo": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/filezilla-logo.png",
+      "image": "linuxserver/filezilla:latest",
+      "env": [
+        {
+          "name": "PUID",
+          "label": "PUID",
+          "default": "1024",
+          "description": "for GroupID"
+        },
+        {
+          "name": "PGID",
+          "label": "PGID",
+          "default": "100",
+          "description": "for UserID"
+        },
+        {
+          "name": "TZ",
+          "label": "TZ",
+          "default": "Europe/Amsterdam",
+          "description": "Specify a timezone to use for example Europe/Amsterdam"
+        }
+      ],
+      "ports": [
+        "3000:3000/tcp"
+      ],
+      "volumes": [
+        {
+          "container": "/config",
+          "bind": "/volume1/docker/filezilla/config"
+        }
+      ],
+      "restart_policy": "unless-stopped",
+      "maintainer": " https://github.com/mycroftwilde/portainer_templates/"
+    },
+    {
+      "id": 156,
+      "type": 1,
+      "categories": [
+        "Smarthome"
+      ],
+      "title": "Homeassistant",
+      "name": "Homeassistant",
+      "note": "Portainer App Templates by <a href='https://www.technorabilia.com' target='_blank'>Technorabilia</a> based on data provided by <a href='https://www.linuxserver.io' target='_blank'>LinuxServer.io</a>.</p><p>Don't forget to create the volume directories on the host file system.</p><p>mkdir -p /volume1/docker/homeassistant/config</p>",
+      "description": "[Home Assistant Core](https://www.home-assistant.io/) - Open source home automation that puts local control and privacy first. Powered by a worldwide community of tinkerers and DIY enthusiasts. Perfect to run on a Raspberry Pi or a local server.",
+      "platform": "linux",
+      "logo": "https://github.com/home-assistant/home-assistant.io/raw/next/source/images/favicon-192x192-full.png",
+      "image": "linuxserver/homeassistant:latest",
+      "network": "host",
+      "env": [
+        {
+          "name": "PUID",
+          "label": "PUID",
+          "default": "1024",
+          "description": "for GroupID"
+        },
+        {
+          "name": "PGID",
+          "label": "PGID",
+          "default": "100",
+          "description": "for UserID"
+        },
+        {
+          "name": "TZ",
+          "label": "TZ",
+          "default": "Europe/Amsterdam",
+          "description": "Specify a timezone to use for example Europe/Amsterdam"
+        }
+      ],
+      "ports": [
+        "8123:8123/tcp"
+      ],
+      "volumes": [
+        {
+          "container": "/config",
+          "bind": "/volume1/docker/homeassistant/config"
+        }
+      ],
+      "restart_policy": "unless-stopped",
+      "maintainer": " https://github.com/mycroftwilde/portainer_templates/"
+    },
+    {
+      "id": 157,
+      "type": 1,
+      "categories": [
+        "Mediaserver"
+      ],
+      "title": "Kanzi",
+      "name": "Kanzi",
+      "note": "Portainer App Templates by <a href='https://www.technorabilia.com' target='_blank'>Technorabilia</a> based on data provided by <a href='https://www.linuxserver.io' target='_blank'>LinuxServer.io</a>.</p><p>Don't forget to create the volume directories on the host file system.</p><p>mkdir -p /volume1/docker/kanzi/config</p>",
+      "description": "[Kanzi](https://lexigr.am/), formerly titled Kodi-Alexa, this custom skill is the ultimate voice remote control for navigating Kodi. It can do anything you can think of (100+ intents). This container also contains lexigram-cli to setup Kanzi with an Amazon Developer Account and automatically deploy it to Amazon.",
+      "platform": "linux",
+      "logo": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/kanzi.png",
+      "image": "linuxserver/kanzi:latest",
+      "env": [
+        {
+          "name": "PUID",
+          "label": "PUID",
+          "default": "1024",
+          "description": "for GroupID"
+        },
+        {
+          "name": "PGID",
+          "label": "PGID",
+          "default": "100",
+          "description": "for UserID"
+        },
+        {
+          "name": "TZ",
+          "label": "TZ",
+          "default": "Europe/Amsterdam",
+          "description": "Specify a timezone to use for example Europe/Amsterdam"
+        },
+        {
+          "name": "INVOCATION_NAME",
+          "label": "INVOCATION_NAME",
+          "default": "kanzi",
+          "description": "Specify an invocation name for this skill, use either kanzi or kod."
+        },
+        {
+          "name": "URL_ENDPOINT",
+          "label": "URL_ENDPOINT",
+          "default": "https://server.com/kanzi/",
+          "description": "Specify the URL at which the webserver is reachable either `https://kanzi.server.com/` or `https://server.com/kanzi/` Note the trailing slash **MUST** be included."
+        }
+      ],
+      "ports": [
+        "8000:8000/tcp"
+      ],
+      "volumes": [
+        {
+          "container": "/config",
+          "bind": "/volume1/docker/kanzi/config"
+        }
+      ],
+      "restart_policy": "unless-stopped",
+      "maintainer": " https://github.com/mycroftwilde/portainer_templates/"
+    },
+    {
+      "id": 158,
+      "type": 1,
+      "categories": [
+        "Proxyserver"
+      ],
+      "title": "Ldap-auth",
+      "name": "Ldap-auth",
+      "note": "Portainer App Templates by <a href='https://www.technorabilia.com' target='_blank'>Technorabilia</a> based on data provided by <a href='https://www.linuxserver.io' target='_blank'>LinuxServer.io</a>.</p><p>Don't forget to create the volume directories on the host file system.</p>",
+      "description": "[Ldap-auth](https://github.com/nginxinc/nginx-ldap-auth) software is for authenticating users who request protected resources from servers proxied by nginx. It includes a daemon (ldap-auth) that communicates with an authentication server, and a webserver daemon that generates an authentication cookie based on the user’s credentials. The daemons are written in Python for use with a Lightweight Directory Access Protocol (LDAP) authentication server (OpenLDAP or Microsoft Windows Active Directory 2003 and 2012).",
+      "platform": "linux",
+      "logo": "https://jumpcloud.com/wp-content/uploads/2016/12/LDAP_Logo-1420591101.jpg",
+      "image": "linuxserver/ldap-auth:latest",
+      "env": [
+        {
+          "name": "TZ",
+          "label": "TZ",
+          "default": "Europe/Amsterdam",
+          "description": "Specify a timezone to use for example Europe/Amsterdam"
+        },
+        {
+          "name": "FERNETKEY",
+          "label": "FERNETKEY",
+          "default": "",
+          "description": "Optionally define a custom fernet key, has to be base64-encoded 32-byte (only needed if container is frequently recreated, or if using multi-node setups, invalidating previous authentications)"
+        },
+        {
+          "name": "CERTFILE",
+          "label": "CERTFILE",
+          "default": "",
+          "description": "Point this to a certificate file to enable HTTP over SSL (HTTPS) for the ldap auth daemon"
+        },
+        {
+          "name": "KEYFILE",
+          "label": "KEYFILE",
+          "default": "",
+          "description": "Point this to the private key file, matching the certificate file referred to in CERTFILE"
+        }
+      ],
+      "ports": [
+        "8888:8888/tcp",
+        "9000:9000/tcp"
+      ],
+      "restart_policy": "unless-stopped",
+      "maintainer": " https://github.com/mycroftwilde/portainer_templates/"
+    },
+    {
+      "id": 159,
+      "type": 1,
+      "categories": [
+        "Familyappserver"
+      ],
+      "title": "Libreoffice",
+      "name": "Libreoffice",
+      "note": "Portainer App Templates by <a href='https://www.technorabilia.com' target='_blank'>Technorabilia</a> based on data provided by <a href='https://www.linuxserver.io' target='_blank'>LinuxServer.io</a>.</p><p>Don't forget to create the volume directories on the host file system.</p><p>mkdir -p /volume1/docker/libreoffice/config</p>",
+      "description": "[LibreOffice](https://www.libreoffice.org/) is a free and powerful office suite, and a successor to OpenOffice.org (commonly known as OpenOffice). Its clean interface and feature-rich tools help you unleash your creativity and enhance your productivity.",
+      "platform": "linux",
+      "logo": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/libreoffice-logo.png",
+      "image": "linuxserver/libreoffice:latest",
+      "env": [
+        {
+          "name": "PUID",
+          "label": "PUID",
+          "default": "1024",
+          "description": "for GroupID"
+        },
+        {
+          "name": "PGID",
+          "label": "PGID",
+          "default": "100",
+          "description": "for UserID"
+        },
+        {
+          "name": "TZ",
+          "label": "TZ",
+          "default": "Europe/Amsterdam",
+          "description": "Specify a timezone to use for example Europe/Amsterdam"
+        }
+      ],
+      "ports": [
+        "3000:3000/tcp"
+      ],
+      "volumes": [
+        {
+          "container": "/config",
+          "bind": "/volume1/docker/libreoffice/config"
+        }
+      ],
+      "restart_policy": "unless-stopped",
+      "maintainer": " https://github.com/mycroftwilde/portainer_templates/"
+    },
+    {
+      "id": 160,
+      "type": 1,
+      "categories": [
+        "Codeserver"
+      ],
+      "title": "Limnoria",
+      "name": "Limnoria",
+      "note": "Portainer App Templates by <a href='https://www.technorabilia.com' target='_blank'>Technorabilia</a> based on data provided by <a href='https://www.linuxserver.io' target='_blank'>LinuxServer.io</a>.</p><p>Don't forget to create the volume directories on the host file system.</p><p>mkdir -p /volume1/docker/limnoria/config</p>",
+      "description": "[Limnoria](https://github.com/ProgVal/limnoria) A robust, full-featured, and user/programmer-friendly Python IRC bot, with many existing plugins. Successor of the well-known Supybot.",
+      "platform": "linux",
+      "logo": "https://raw.githubusercontent.com/linuxserver/docker-limnoria/master/logo.png",
+      "image": "linuxserver/limnoria:latest",
+      "env": [
+        {
+          "name": "PUID",
+          "label": "PUID",
+          "default": "1024",
+          "description": "for GroupID"
+        },
+        {
+          "name": "PGID",
+          "label": "PGID",
+          "default": "100",
+          "description": "for UserID"
+        },
+        {
+          "name": "TZ",
+          "label": "TZ",
+          "default": "Europe/Amsterdam",
+          "description": "Specify a timezone to use for example Europe/Amsterdam"
+        }
+      ],
+      "ports": [
+        "8080:8080/tcp"
+      ],
+      "volumes": [
+        {
+          "container": "/config",
+          "bind": "/volume1/docker/limnoria/config"
+        }
+      ],
+      "restart_policy": "unless-stopped",
+      "maintainer": " https://github.com/mycroftwilde/portainer_templates/"
+    },
+    {
+      "id": 161,
+      "type": 1,
+      "categories": [
+        "Tools"
+      ],
+      "title": "Nano",
+      "name": "Nano",
+      "note": "Portainer App Templates by <a href='https://www.technorabilia.com' target='_blank'>Technorabilia</a> based on data provided by <a href='https://www.linuxserver.io' target='_blank'>LinuxServer.io</a>.</p><p>Don't forget to create the volume directories on the host file system.</p><p>mkdir -p /volume1/docker/nano/config</p>",
+      "description": "[Nano](https://nano.org/) is a digital payment protocol designed to be accessible and lightweight, with a focus on removing inefficiencies present in other cryptocurrencies. With ultrafast transactions and zero fees on a secure, green and decentralized network, this makes Nano ideal for everyday transactions.",
+      "platform": "linux",
+      "logo": "https://upload.wikimedia.org/wikipedia/commons/thumb/1/18/Nano_logo.png/640px-Nano_logo.png",
+      "image": "linuxserver/nano:latest",
+      "env": [
+        {
+          "name": "PUID",
+          "label": "PUID",
+          "default": "1024",
+          "description": "for GroupID"
+        },
+        {
+          "name": "PGID",
+          "label": "PGID",
+          "default": "100",
+          "description": "for UserID"
+        },
+        {
+          "name": "TZ",
+          "label": "TZ",
+          "default": "Europe/Amsterdam",
+          "description": "Specify a timezone to use for example Europe/Amsterdam"
+        },
+        {
+          "name": "PEER_HOST",
+          "label": "PEER_HOST",
+          "default": "localhost",
+          "description": "Default peer host (can be overidden with an array by command line options)"
+        },
+        {
+          "name": "LIVE_GENESIS_PUB",
+          "label": "LIVE_GENESIS_PUB",
+          "default": "GENESIS_PUBLIC",
+          "description": "Genesis block public key"
+        },
+        {
+          "name": "LIVE_GENESIS_ACCOUNT",
+          "label": "LIVE_GENESIS_ACCOUNT",
+          "default": "nano_xxxxxx",
+          "description": "Genesis block account"
+        },
+        {
+          "name": "LIVE_GENESIS_WORK",
+          "label": "LIVE_GENESIS_WORK",
+          "default": "WORK_FOR_BLOCK",
+          "description": "Genesis block proof of work"
+        },
+        {
+          "name": "LIVE_GENESIS_SIG",
+          "label": "LIVE_GENESIS_SIG",
+          "default": "BLOCK_SIGNATURE",
+          "description": "Genesis block signature"
+        },
+        {
+          "name": "CLI_OPTIONS",
+          "label": "CLI_OPTIONS",
+          "default": "--config node.enable_voting=true",
+          "description": "Node run command cli args"
+        },
+        {
+          "name": "LMDB_BOOTSTRAP_URL",
+          "label": "LMDB_BOOTSTRAP_URL",
+          "default": "http://example.com/Nano_64_version_20.7z",
+          "description": "HTTP/HTTPS endpoint to download a 7z file with the data.ldb to bootstrap to this node"
+        }
+      ],
+      "ports": [
+        "8075:8075/tcp",
+        "7076:3000/tcp",
+        "7077:3001/tcp"
+      ],
+      "volumes": [
+        {
+          "container": "/config",
+          "bind": "/volume1/docker/nano/config"
+        }
+      ],
+      "restart_policy": "unless-stopped",
+      "maintainer": " https://github.com/mycroftwilde/portainer_templates/"
+    },
+    {
+      "id": 162,
+      "type": 1,
+      "categories": [
+        "Tools"
+      ],
+      "title": "Nano-wallet",
+      "name": "Nano-wallet",
+      "note": "Portainer App Templates by <a href='https://www.technorabilia.com' target='_blank'>Technorabilia</a> based on data provided by <a href='https://www.linuxserver.io' target='_blank'>LinuxServer.io</a>.</p><p>Don't forget to create the volume directories on the host file system.</p>",
+      "description": "[Nano-wallet](https://nano.org/) is a digital payment protocol designed to be accessible and lightweight, with a focus on removing inefficiencies present in other cryptocurrencies. With ultrafast transactions and zero fees on a secure, green and decentralized network, this makes Nano ideal for everyday transactions. This container is a simple nginx wrapper for the light wallet located [here](https://github.com/linuxserver/nano-wallet). You will need to pass a valid RPC host when accessing this container.",
+      "platform": "linux",
+      "logo": "https://upload.wikimedia.org/wikipedia/commons/thumb/1/18/Nano_logo.png/640px-Nano_logo.png",
+      "image": "linuxserver/nano-wallet:latest",
+      "ports": [
+        "80:80/tcp"
+      ],
+      "restart_policy": "unless-stopped",
+      "maintainer": " https://github.com/mycroftwilde/portainer_templates/"
+    },
+    {
+      "id": 163,
+      "type": 1,
+      "categories": [
+        "Managementutilityserver"
+      ],
+      "title": "Netbox",
+      "name": "Netbox",
+      "note": "Portainer App Templates by <a href='https://www.technorabilia.com' target='_blank'>Technorabilia</a> based on data provided by <a href='https://www.linuxserver.io' target='_blank'>LinuxServer.io</a>.</p><p>Don't forget to create the volume directories on the host file system.</p><p>mkdir -p /volume1/docker/netbox/config</p>",
+      "description": "[Netbox](https://github.com/netbox-community/netbox) is an IP address management (IPAM) and data center infrastructure management (DCIM) tool. Initially conceived by the network engineering team at DigitalOcean, NetBox was developed specifically to address the needs of network and infrastructure engineers. It is intended to function as a domain-specific source of truth for network operations.",
+      "platform": "linux",
+      "logo": "https://raw.githubusercontent.com/netbox-community/netbox/develop/docs/netbox_logo.png",
+      "image": "linuxserver/netbox:latest",
+      "env": [
+        {
+          "name": "PUID",
+          "label": "PUID",
+          "default": "1024",
+          "description": "for GroupID"
+        },
+        {
+          "name": "PGID",
+          "label": "PGID",
+          "default": "100",
+          "description": "for UserID"
+        },
+        {
+          "name": "TZ",
+          "label": "TZ",
+          "default": "Europe/Amsterdam",
+          "description": "Specify a timezone to use for example Europe/Amsterdam"
+        },
+        {
+          "name": "SUPERUSER_EMAIL",
+          "label": "SUPERUSER_EMAIL",
+          "default": "<SUPERUSER_EMAIL>",
+          "description": "Email address for `admin` account"
+        },
+        {
+          "name": "SUPERUSER_PASSWORD",
+          "label": "SUPERUSER_PASSWORD",
+          "default": "<SUPERUSER_PASSWORD>",
+          "description": "Password for `admin` account"
+        },
+        {
+          "name": "ALLOWED_HOST",
+          "label": "ALLOWED_HOST",
+          "default": "<ALLOWED_HOST>",
+          "description": "The hostname you will use to access the app (i.e., netbox.example.com)"
+        },
+        {
+          "name": "DB_NAME",
+          "label": "DB_NAME",
+          "default": "<DB_NAME>",
+          "description": "Database name (default: netbox)"
+        },
+        {
+          "name": "DB_USER",
+          "label": "DB_USER",
+          "default": "<DB_USER>",
+          "description": "Database user"
+        },
+        {
+          "name": "DB_PASSWORD",
+          "label": "DB_PASSWORD",
+          "default": "<DB_PASSWORD>",
+          "description": "Database password"
+        },
+        {
+          "name": "DB_HOST",
+          "label": "DB_HOST",
+          "default": "<DB_HOST>",
+          "description": "Database host (default: postgres)"
+        },
+        {
+          "name": "DB_PORT",
+          "label": "DB_PORT",
+          "default": "<DB_PORT>",
+          "description": "Database port (defaul: 5432)"
+        },
+        {
+          "name": "REDIS_HOST",
+          "label": "REDIS_HOST",
+          "default": "<REDIS_HOST>",
+          "description": "Redis host (default: redis)"
+        },
+        {
+          "name": "REDIS_PORT",
+          "label": "REDIS_PORT",
+          "default": "<REDIS_PORT>",
+          "description": "Redis port number (default: 6379)"
+        },
+        {
+          "name": "REDIS_PASSWORD",
+          "label": "REDIS_PASSWORD",
+          "default": "<REDIS_PASSWORD>",
+          "description": "Redis password (default: none)"
+        },
+        {
+          "name": "REDIS_DB_TASK",
+          "label": "REDIS_DB_TASK",
+          "default": "<REDIS_DB_TASK>",
+          "description": "Redis database ID for tasks (default: 0)"
+        },
+        {
+          "name": "REDIS_DB_CACHE",
+          "label": "REDIS_DB_CACHE",
+          "default": "<REDIS_DB_CACHE>",
+          "description": "Redis database ID for caching (default: 1)"
+        },
+        {
+          "name": "BASE_PATH",
+          "label": "BASE_PATH",
+          "default": "<BASE_PATH>",
+          "description": "The path you will use to access the app (i.e., /netbox, optional, default: none)"
+        },
+        {
+          "name": "REMOTE_AUTH_ENABLED",
+          "label": "REMOTE_AUTH_ENABLED",
+          "default": "<REMOTE_AUTH_ENABLED>",
+          "description": "Enable remote authentication (optional, default: False)"
+        },
+        {
+          "name": "REMOTE_AUTH_BACKEND",
+          "label": "REMOTE_AUTH_BACKEND",
+          "default": "<REMOTE_AUTH_BACKEND>",
+          "description": "Python path to the custom Django authentication backend to use for external user authentication (optional, default: netbox.authentication.RemoteUserBackend)"
+        },
+        {
+          "name": "REMOTE_AUTH_HEADER",
+          "label": "REMOTE_AUTH_HEADER",
+          "default": "<REMOTE_AUTH_HEADER>",
+          "description": "Name of the HTTP header which informs NetBox of the currently authenticated user. (optional, default: HTTP_REMOTE_USER)"
+        },
+        {
+          "name": "REMOTE_AUTH_AUTO_CREATE_USER",
+          "label": "REMOTE_AUTH_AUTO_CREATE_USER",
+          "default": "<REMOTE_AUTH_AUTO_CREATE_USER>",
+          "description": "If true, NetBox will automatically create local accounts for users authenticated via a remote service (optional, default: False)"
+        },
+        {
+          "name": "REMOTE_AUTH_DEFAULT_GROUPS",
+          "label": "REMOTE_AUTH_DEFAULT_GROUPS",
+          "default": "<REMOTE_AUTH_DEFAULT_GROUPS>",
+          "description": "The list of groups to assign a new user account when created using remote authentication (optional, default: [])"
+        },
+        {
+          "name": "REMOTE_AUTH_DEFAULT_PERMISSIONS",
+          "label": "REMOTE_AUTH_DEFAULT_PERMISSIONS",
+          "default": "<REMOTE_AUTH_DEFAULT_PERMISSIONS>",
+          "description": "A mapping of permissions to assign a new user account when created using remote authentication (optional, default: {})"
+        }
+      ],
+      "ports": [
+        "8000:8000/tcp"
+      ],
+      "volumes": [
+        {
+          "container": "/config",
+          "bind": "/volume1/docker/netbox/config"
+        }
+      ],
+      "restart_policy": "unless-stopped",
+      "maintainer": " https://github.com/mycroftwilde/portainer_templates/"
+    },
+    {
+      "id": 164,
+      "type": 1,
+      "categories": [
+        "Managementutilityserver"
+      ],
+      "title": "Openssh-server",
+      "name": "Openssh-server",
+      "note": "Portainer App Templates by <a href='https://www.technorabilia.com' target='_blank'>Technorabilia</a> based on data provided by <a href='https://www.linuxserver.io' target='_blank'>LinuxServer.io</a>.</p><p>Don't forget to create the volume directories on the host file system.</p><p>mkdir -p /volume1/docker/openssh-server/config</p>",
+      "description": "[Openssh-server](https://www.openssh.com/) is a sandboxed environment that allows ssh access without giving keys to the entire server. Giving ssh access via private key often means giving full access to the server. This container creates a limited and sandboxed environment that others can ssh into. The users only have access to the folders mapped and the processes running inside this container.",
+      "platform": "linux",
+      "logo": "https://upload.wikimedia.org/wikipedia/en/6/65/OpenSSH_logo.png",
+      "image": "linuxserver/openssh-server:latest",
+      "env": [
+        {
+          "name": "PUID",
+          "label": "PUID",
+          "default": "1024",
+          "description": "for GroupID"
+        },
+        {
+          "name": "PGID",
+          "label": "PGID",
+          "default": "100",
+          "description": "for UserID"
+        },
+        {
+          "name": "TZ",
+          "label": "TZ",
+          "default": "Europe/Amsterdam",
+          "description": "Specify a timezone to use for example Europe/Amsterdam"
+        },
+        {
+          "name": "PUBLIC_KEY",
+          "label": "PUBLIC_KEY",
+          "default": "yourpublickey",
+          "description": "Optional ssh public key, which will automatically be added to authorized_keys."
+        },
+        {
+          "name": "PUBLIC_KEY_FILE",
+          "label": "PUBLIC_KEY_FILE",
+          "default": "/path/to/file",
+          "description": "Optionally specify a file containing the public key (works with docker secrets)."
+        },
+        {
+          "name": "PUBLIC_KEY_DIR",
+          "label": "PUBLIC_KEY_DIR",
+          "default": "/path/to/directory/containing/_only_/pubkeys",
+          "description": "Optionally specify a directory containing the public keys (works with docker secrets)."
+        },
+        {
+          "name": "PUBLIC_KEY_URL",
+          "label": "PUBLIC_KEY_URL",
+          "default": "https://github.com/username.keys",
+          "description": "Optionally specify a URL containing the public key."
+        },
+        {
+          "name": "SUDO_ACCESS",
+          "label": "SUDO_ACCESS",
+          "default": "false",
+          "description": "Set to `true` to allow `linuxserver.io`, the ssh user, sudo access. Without `USER_PASSWORD` set, this will allow passwordless sudo access."
+        },
+        {
+          "name": "PASSWORD_ACCESS",
+          "label": "PASSWORD_ACCESS",
+          "default": "false",
+          "description": "Set to `true` to allow user/password ssh access. You will want to set `USER_PASSWORD` or `USER_PASSWORD_FILE` as well."
+        },
+        {
+          "name": "USER_PASSWORD",
+          "label": "USER_PASSWORD",
+          "default": "password",
+          "description": "Optionally set a sudo password for `linuxserver.io`, the ssh user. If this or `USER_PASSWORD_FILE` are not set but `SUDO_ACCESS` is set to true, the user will have passwordless sudo access."
+        },
+        {
+          "name": "USER_PASSWORD_FILE",
+          "label": "USER_PASSWORD_FILE",
+          "default": "/path/to/file",
+          "description": "Optionally specify a file that contains the password. This setting supersedes the `USER_PASSWORD` option (works with docker secrets)."
+        },
+        {
+          "name": "USER_NAME",
+          "label": "USER_NAME",
+          "default": "linuxserver.io",
+          "description": "Optionally specify a user name (Default:`linuxserver.io`)"
+        }
+      ],
+      "ports": [
+        "2222:2222/tcp"
+      ],
+      "volumes": [
+        {
+          "container": "/config",
+          "bind": "/volume1/docker/openssh-server/config"
+        }
+      ],
+      "restart_policy": "unless-stopped",
+      "maintainer": " https://github.com/mycroftwilde/portainer_templates/"
+    },
+    {
+      "id": 165,
+      "type": 1,
+      "categories": [
+        "Familyappserver"
+      ],
+      "title": "Paperless-ng",
+      "name": "Paperless-ng",
+      "note": "Portainer App Templates by <a href='https://www.technorabilia.com' target='_blank'>Technorabilia</a> based on data provided by <a href='https://www.linuxserver.io' target='_blank'>LinuxServer.io</a>.</p><p>Don't forget to create the volume directories on the host file system.</p><p>mkdir -p /volume1/docker/paperless-ng/config<br>mkdir -p /volume1/docker/paperless-ng/data</p>",
+      "description": "[Paperless-ng](https://github.com/jonaswinkler/paperless-ng) is an application by Daniel Quinn and contributors that indexes your scanned documents and allows you to easily search for documents and store metadata alongside your documents.'",
+      "platform": "linux",
+      "logo": "https://raw.githubusercontent.com/jonaswinkler/paperless-ng/master/resources/logo/web/png/Color%20logo%20with%20background.png",
+      "image": "linuxserver/paperless-ng:latest",
+      "env": [
+        {
+          "name": "PUID",
+          "label": "PUID",
+          "default": "1024",
+          "description": "for GroupID"
+        },
+        {
+          "name": "PGID",
+          "label": "PGID",
+          "default": "100",
+          "description": "for UserID"
+        },
+        {
+          "name": "TZ",
+          "label": "TZ",
+          "default": "Europe/Amsterdam",
+          "description": "Specify a timezone to use for example Europe/Amsterdam"
+        },
+        {
+          "name": "REDIS_URL",
+          "label": "REDIS_URL",
+          "default": "",
+          "description": "Specify an external redis instance to use. Can optionally include a port (`redis:6379`) and/or db (`redis/foo`). If left blank or not included, will use a built-in redis instance. If changed after initial setup will also require manual modification of /config/settings.py"
+        }
+      ],
+      "ports": [
+        "8000:8000/tcp"
+      ],
+      "volumes": [
+        {
+          "container": "/config",
+          "bind": "/volume1/docker/paperless-ng/config"
+        },
+        {
+          "container": "/data",
+          "bind": "/volume1/docker/paperless-ng/data"
+        }
+      ],
+      "restart_policy": "unless-stopped",
+      "maintainer": " https://github.com/mycroftwilde/portainer_templates/"
+    },
+    {
+      "id": 166,
+      "type": 1,
+      "categories": [
+        "Familyappserver"
+      ],
+      "title": "Papermerge",
+      "name": "Papermerge",
+      "note": "Portainer App Templates by <a href='https://www.technorabilia.com' target='_blank'>Technorabilia</a> based on data provided by <a href='https://www.linuxserver.io' target='_blank'>LinuxServer.io</a>.</p><p>Don't forget to create the volume directories on the host file system.</p><p>mkdir -p /volume1/docker/papermerge/config<br>mkdir -p /volume1/docker/papermerge/data</p>",
+      "description": "[Papermerge](https://www.papermerge.com/) is an open source document management system (DMS) primarily designed for archiving and retrieving your digital documents. Instead of having piles of paper documents all over your desk, office or drawers - you can quickly scan them and configure your scanner to directly upload to Papermerge DMS.'",
+      "platform": "linux",
+      "logo": "https://raw.githubusercontent.com/ciur/papermerge/master/artwork/logo.png",
+      "image": "linuxserver/papermerge:latest",
+      "env": [
+        {
+          "name": "PUID",
+          "label": "PUID",
+          "default": "1024",
+          "description": "for GroupID"
+        },
+        {
+          "name": "PGID",
+          "label": "PGID",
+          "default": "100",
+          "description": "for UserID"
+        },
+        {
+          "name": "TZ",
+          "label": "TZ",
+          "default": "Europe/Amsterdam",
+          "description": "Specify a timezone to use for example Europe/Amsterdam"
+        },
+        {
+          "name": "REDIS_URL",
+          "label": "REDIS_URL",
+          "default": "",
+          "description": "Specify an external redis instance to use. Can optionally include a port (`redis:6379`) and/or db (`redis/foo`). If left blank or not included, will use a built-in redis instance. If changed after initial setup will also require manual modification of /config/settings.py"
+        }
+      ],
+      "ports": [
+        "8000:8000/tcp"
+      ],
+      "volumes": [
+        {
+          "container": "/config",
+          "bind": "/volume1/docker/papermerge/config"
+        },
+        {
+          "container": "/data",
+          "bind": "/volume1/docker/papermerge/data"
+        }
+      ],
+      "restart_policy": "unless-stopped",
+      "maintainer": " https://github.com/mycroftwilde/portainer_templates/"
+    },
+    {
+      "id": 167,
+      "type": 1,
+      "categories": [
+        "Chatserver"
+      ],
+      "title": "Pidgin",
+      "name": "Pidgin",
+      "note": "Portainer App Templates by <a href='https://www.technorabilia.com' target='_blank'>Technorabilia</a> based on data provided by <a href='https://www.linuxserver.io' target='_blank'>LinuxServer.io</a>.</p><p>Don't forget to create the volume directories on the host file system.</p><p>mkdir -p /volume1/docker/pidgin/config</p>",
+      "description": "[Pidgin](https://pidgin.im/) is a chat program which lets you log into accounts on multiple chat networks simultaneously. This means that you can be chatting with friends on XMPP and sitting in an IRC channel at the same time.",
+      "platform": "linux",
+      "logo": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/pidgin-logo.png",
+      "image": "linuxserver/pidgin:latest",
+      "env": [
+        {
+          "name": "PUID",
+          "label": "PUID",
+          "default": "1024",
+          "description": "for GroupID"
+        },
+        {
+          "name": "PGID",
+          "label": "PGID",
+          "default": "100",
+          "description": "for UserID"
+        },
+        {
+          "name": "TZ",
+          "label": "TZ",
+          "default": "Europe/Amsterdam",
+          "description": "Specify a timezone to use for example Europe/Amsterdam"
+        }
+      ],
+      "ports": [
+        "3000:3000/tcp"
+      ],
+      "volumes": [
+        {
+          "container": "/config",
+          "bind": "/volume1/docker/pidgin/config"
+        }
+      ],
+      "restart_policy": "unless-stopped",
+      "maintainer": " https://github.com/mycroftwilde/portainer_templates/"
+    },
+    {
+      "id": 168,
+      "type": 1,
+      "categories": [
+        "Managementutilityserver"
+      ],
+      "title": "Rdesktop",
+      "name": "Rdesktop",
+      "note": "Portainer App Templates by <a href='https://www.technorabilia.com' target='_blank'>Technorabilia</a> based on data provided by <a href='https://www.linuxserver.io' target='_blank'>LinuxServer.io</a>.</p><p>Don't forget to create the volume directories on the host file system.</p><p><br>mkdir -p /volume1/docker/rdesktop/config</p>",
+      "description": "[Rdesktop](http://xrdp.org/) - Ubuntu based containers containing full desktop environments in officially supported flavors accessible via RDP.",
+      "platform": "linux",
+      "logo": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/rdesktop.png",
+      "image": "linuxserver/rdesktop:latest",
+      "privileged": true,
+      "env": [
+        {
+          "name": "PUID",
+          "label": "PUID",
+          "default": "1024",
+          "description": "for GroupID"
+        },
+        {
+          "name": "PGID",
+          "label": "PGID",
+          "default": "100",
+          "description": "for UserID"
+        },
+        {
+          "name": "TZ",
+          "label": "TZ",
+          "default": "Europe/Amsterdam",
+          "description": "Specify a timezone to use for example Europe/Amsterdam"
+        }
+      ],
+      "ports": [
+        "3389:3389/tcp"
+      ],
+      "volumes": [
+        {
+          "container": "/var/run/docker.sock",
+          "bind": "/var/run/docker.sock"
+        },
+        {
+          "container": "/config",
+          "bind": "/volume1/docker/rdesktop/config"
+        }
+      ],
+      "restart_policy": "unless-stopped",
+      "maintainer": " https://github.com/mycroftwilde/portainer_templates/"
+    },
+    {
+      "id": 169,
+      "type": 1,
+      "categories": [
+        "Backupandsyncserver"
+      ],
+      "title": "Rsnapshot",
+      "name": "Rsnapshot",
+      "note": "Portainer App Templates by <a href='https://www.technorabilia.com' target='_blank'>Technorabilia</a> based on data provided by <a href='https://www.linuxserver.io' target='_blank'>LinuxServer.io</a>.</p><p>Don't forget to create the volume directories on the host file system.</p><p>mkdir -p /volume1/docker/rsnapshot/config<br>mkdir -p /volume1/docker/rsnapshot/.snapshots<br>mkdir -p /volume1/docker/rsnapshot/data</p>",
+      "description": "[Rsnapshot](http://www.rsnapshot.org/) is a filesystem snapshot utility based on rsync. rsnapshot makes it easy to make periodic snapshots of local machines, and remote machines over ssh. The code makes extensive use of hard links whenever possible, to greatly reduce the disk space required.'",
+      "platform": "linux",
+      "logo": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/rsnapshot.png",
+      "image": "linuxserver/rsnapshot:latest",
+      "env": [
+        {
+          "name": "PUID",
+          "label": "PUID",
+          "default": "1024",
+          "description": "for GroupID"
+        },
+        {
+          "name": "PGID",
+          "label": "PGID",
+          "default": "100",
+          "description": "for UserID"
+        },
+        {
+          "name": "TZ",
+          "label": "TZ",
+          "default": "Europe/Amsterdam",
+          "description": "Specify a timezone to use for example Europe/Amsterdam"
+        }
+      ],
+      "ports": [
+        "80:80/tcp"
+      ],
+      "volumes": [
+        {
+          "container": "/config",
+          "bind": "/volume1/docker/rsnapshot/config"
+        },
+        {
+          "container": "/.snapshots",
+          "bind": "/volume1/docker/rsnapshot/.snapshots"
+        },
+        {
+          "container": "/data",
+          "bind": "/volume1/docker/rsnapshot/data"
+        }
+      ],
+      "restart_policy": "unless-stopped",
+      "maintainer": " https://github.com/mycroftwilde/portainer_templates/"
+    },
+    {
+      "id": 170,
+      "type": 1,
+      "categories": [
+        "Familyappserver"
+      ],
+      "title": "Snapdrop",
+      "name": "Snapdrop",
+      "note": "Portainer App Templates by <a href='https://www.technorabilia.com' target='_blank'>Technorabilia</a> based on data provided by <a href='https://www.linuxserver.io' target='_blank'>LinuxServer.io</a>.</p><p>Don't forget to create the volume directories on the host file system.</p><p>mkdir -p /volume1/docker/snapdrop/config</p>",
+      "description": "[Snapdrop](https://github.com/RobinLinus/snapdrop) A local file sharing in your browser. Inspired by Apple's Airdrop.",
+      "platform": "linux",
+      "logo": "https://raw.githubusercontent.com/RobinLinus/snapdrop/master/client/images/logo_transparent_512x512.png",
+      "image": "linuxserver/snapdrop:latest",
+      "env": [
+        {
+          "name": "PUID",
+          "label": "PUID",
+          "default": "1024",
+          "description": "for GroupID"
+        },
+        {
+          "name": "PGID",
+          "label": "PGID",
+          "default": "100",
+          "description": "for UserID"
+        },
+        {
+          "name": "TZ",
+          "label": "TZ",
+          "default": "Europe/Amsterdam",
+          "description": "Specify a timezone to use for example Europe/Amsterdam"
+        }
+      ],
+      "ports": [
+        "80:80/tcp",
+        "443:443/tcp"
+      ],
+      "volumes": [
+        {
+          "container": "/config",
+          "bind": "/volume1/docker/snapdrop/config"
+        }
+      ],
+      "restart_policy": "unless-stopped",
+      "maintainer": " https://github.com/mycroftwilde/portainer_templates/"
+    },
+    {
+      "id": 171,
+      "type": 1,
+      "title": "Webtop",
+      "name": "Webtop",
+      "note": "Portainer App Templates by <a href='https://www.technorabilia.com' target='_blank'>Technorabilia</a> based on data provided by <a href='https://www.linuxserver.io' target='_blank'>LinuxServer.io</a>.</p><p>Don't forget to create the volume directories on the host file system.</p><p>mkdir -p /volume1/docker/webtop/config<br></p>",
+      "description": "[Webtop](https://github.com/linuxserver/docker-webtop) - Alpine, Ubuntu, Fedora, and Arch based containers containing full desktop environments in officially supported flavors accessible via any modern web browser.",
+      "categories": [
+        "Managementutilityserver"
+      ],
+      "platform": "linux",
+      "logo": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/webtop-logo.png",
+      "image": "linuxserver/webtop:latest",
+      "privileged": true,
+      "env": [
+        {
+          "name": "PUID",
+          "label": "PUID",
+          "default": "1024",
+          "description": "for GroupID"
+        },
+        {
+          "name": "PGID",
+          "label": "PGID",
+          "default": "100",
+          "description": "for UserID"
+        },
+        {
+          "name": "TZ",
+          "label": "TZ",
+          "default": "Europe/Amsterdam",
+          "description": "Specify a timezone to use for example Europe/Amsterdam"
+        },
+        {
+          "name": "SUBFOLDER",
+          "label": "SUBFOLDER",
+          "default": "/",
+          "description": "Specify a subfolder to use with reverse proxies, IE `/subfolder/`"
+        }
+      ],
+      "ports": [
+        "3000:3000/tcp"
+      ],
+      "volumes": [
+        {
+          "container": "/config",
+          "bind": "/volume1/docker/webtop/config"
+        },
+        {
+          "container": "/var/run/docker.sock",
+          "bind": "/var/run/docker.sock"
+        }
+      ],
+      "restart_policy": "unless-stopped",
+      "maintainer": " https://github.com/mycroftwilde/portainer_templates/"
+    },
+    {
+      "id": 172,
+      "type": 1,
+      "categories": [
+        "Vpnserver"
+      ],
+      "title": "Wireguard",
+      "name": "Wireguard",
+      "note": "Portainer App Templates by <a href='https://www.technorabilia.com' target='_blank'>Technorabilia</a> based on data provided by <a href='https://www.linuxserver.io' target='_blank'>LinuxServer.io</a>.</p><p>Don't forget to create the volume directories on the host file system.</p><p>mkdir -p /volume1/docker/wireguard/config<br></p>",
+      "description": "[WireGuard®](https://www.wireguard.com/) is an extremely simple yet fast and modern VPN that utilizes state-of-the-art cryptography. It aims to be faster, simpler, leaner, and more useful than IPsec, while avoiding the massive headache. It intends to be considerably more performant than OpenVPN. WireGuard is designed as a general purpose VPN for running on embedded interfaces and super computers alike, fit for many different circumstances. Initially released for the Linux kernel, it is now cross-platform (Windows, macOS, BSD, iOS, Android) and widely deployable. It is currently under heavy development, but already it might be regarded as the most secure, easiest to use, and simplest VPN solution in the industry.",
+      "platform": "linux",
+      "logo": "https://upload.wikimedia.org/wikipedia/commons/thumb/9/93/Logo_of_WireGuard.png/320px-Logo_of_WireGuard.png",
+      "image": "linuxserver/wireguard:latest",
+      "env": [
+        {
+          "name": "PUID",
+          "label": "PUID",
+          "default": "1024",
+          "description": "for GroupID"
+        },
+        {
+          "name": "PGID",
+          "label": "PGID",
+          "default": "100",
+          "description": "for UserID"
+        },
+        {
+          "name": "TZ",
+          "label": "TZ",
+          "default": "Europe/Amsterdam",
+          "description": "Specify a timezone to use for example Europe/Amsterdam"
+        },
+        {
+          "name": "SERVERURL",
+          "label": "SERVERURL",
+          "default": "wireguard.domain.com",
+          "description": "External IP or domain name for docker host. Used in server mode. If set to `auto`, the container will try to determine and set the external IP automatically"
+        },
+        {
+          "name": "SERVERPORT",
+          "label": "SERVERPORT",
+          "default": "51820",
+          "description": "External port for docker host. Used in server mode."
+        },
+        {
+          "name": "PEERS",
+          "label": "PEERS",
+          "default": "1",
+          "description": "Number of peers to create confs for. Required for server mode. Can also be a list of names: `myPC,myPhone,myTablet` (alphanumeric only)"
+        },
+        {
+          "name": "PEERDNS",
+          "label": "PEERDNS",
+          "default": "auto",
+          "description": "DNS server set in peer/client configs (can be set as `8.8.8.8`). Used in server mode. Defaults to `auto`, which uses wireguard docker host's DNS via included CoreDNS forward."
+        },
+        {
+          "name": "INTERNAL_SUBNET",
+          "label": "INTERNAL_SUBNET",
+          "default": "10.13.13.0",
+          "description": "Internal subnet for the wireguard and server and peers (only change if it clashes). Used in server mode."
+        },
+        {
+          "name": "ALLOWEDIPS",
+          "label": "ALLOWEDIPS",
+          "default": "0.0.0.0/0",
+          "description": "The IPs/Ranges that the peers will be able to reach using the VPN connection. If not specified the default value is: '0.0.0.0/0, ::0/0' This will cause ALL traffic to route through the VPN, if you want split tunneling, set this to only the IPs you would like to use the tunnel AND the ip of the server's WG ip, such as 10.13.13.1."
+        }
+      ],
+      "ports": [
+        "51820:51820/udp"
+      ],
+      "volumes": [
+        {
+          "container": "/config",
+          "bind": "/volume1/docker/wireguard/config"
+        },
+        {
+          "container": "/lib/modules",
+          "bind": "/lib/modules"
+        }
+      ],
+      "restart_policy": "unless-stopped",
+      "maintainer": " https://github.com/mycroftwilde/portainer_templates/"
+    },
+    {
+      "id": 173,
+      "categories": [
+        "Managementutilityserver"
+      ],
+      "type": 1,
+      "title": "Wireshark",
+      "name": "Wireshark",
+      "note": "Portainer App Templates by <a href='https://www.technorabilia.com' target='_blank'>Technorabilia</a> based on data provided by <a href='https://www.linuxserver.io' target='_blank'>LinuxServer.io</a>.</p><p>Don't forget to create the volume directories on the host file system.</p><p>mkdir -p /volume1/docker/wireshark/config</p>",
+      "description": "[Wireshark](https://www.wireshark.org/) is the world’s foremost and widely-used network protocol analyzer. It lets you see what’s happening on your network at a microscopic level and is the de facto (and often de jure) standard across many commercial and non-profit enterprises, government agencies, and educational institutions. Wireshark development thrives thanks to the volunteer contributions of networking experts around the globe and is the continuation of a project started by Gerald Combs in 1998.",
+      "platform": "linux",
+      "logo": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/wireshark-icon.png",
+      "image": "linuxserver/wireshark:latest",
+      "network": "host",
+      "env": [
+        {
+          "name": "PUID",
+          "label": "PUID",
+          "default": "1024",
+          "description": "for GroupID"
+        },
+        {
+          "name": "PGID",
+          "label": "PGID",
+          "default": "100",
+          "description": "for UserID"
+        },
+        {
+          "name": "TZ",
+          "label": "TZ",
+          "default": "Europe/Amsterdam",
+          "description": "Specify a timezone to use for example Europe/Amsterdam"
+        }
+      ],
+      "ports": [
+        "3000:3000/tcp"
+      ],
+      "volumes": [
+        {
+          "container": "/config",
+          "bind": "/volume1/docker/wireshark/config"
+        }
+      ],
+      "restart_policy": "unless-stopped",
+      "maintainer": " https://github.com/mycroftwilde/portainer_templates/"
+    },
+    {
+      "id": 174,
+      "type": 1,
+      "title": "Airsonic-advanced",
+      "name": "Airsonic-advanced",
+      "categories": [
+        "Musicserver"
+      ],
+      "note": "Portainer App Templates by <a href='https://www.technorabilia.com' target='_blank'>Technorabilia</a> based on data provided by <a href='https://www.linuxserver.io' target='_blank'>LinuxServer.io</a>.</p><p>Don't forget to create the volume directories on the host file system.</p><p>mkdir -p /volume1/docker/airsonic-advanced/config<br>mkdir -p /volume1/docker/airsonic-advanced/music<br>mkdir -p /volume1/docker/airsonic-advanced/playlists<br>mkdir -p /volume1/docker/airsonic-advanced/podcasts<br>mkdir -p /volume1/docker/airsonic-advanced/media</p>",
+      "description": "[Airsonic-advanced](https://github.com/airsonic-advanced/airsonic-advanced) is a free, web-based media streamer, providing ubiquitious access to your music. Use it to share your music with friends, or to listen to your own music while at work. You can stream to multiple players simultaneously, for instance to one player in your kitchen and another in your living room.",
+      "platform": "linux",
+      "logo": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/airsonic-banner.png",
+      "image": "linuxserver/airsonic-advanced:latest",
+      "env": [
+        {
+          "name": "PUID",
+          "label": "PUID",
+          "default": "1024",
+          "description": "for GroupID"
+        },
+        {
+          "name": "PGID",
+          "label": "PGID",
+          "default": "100",
+          "description": "for UserID"
+        },
+        {
+          "name": "TZ",
+          "label": "TZ",
+          "default": "Europe/Amsterdam",
+          "description": "Specify a timezone to use for example Europe/Amsterdam"
+        },
+        {
+          "name": "CONTEXT_PATH",
+          "label": "CONTEXT_PATH",
+          "default": "<URL_BASE>",
+          "description": "For setting url-base in reverse proxy setups."
+        },
+        {
+          "name": "JAVA_OPTS",
+          "label": "JAVA_OPTS",
+          "default": "<options>",
+          "description": "For passing additional java options."
+        }
+      ],
+      "ports": [
+        "4040:4040/tcp"
+      ],
+      "volumes": [
+        {
+          "container": "/config",
+          "bind": "/volume1/docker/airsonic-advanced/config"
+        },
+        {
+          "container": "/music",
+          "bind": "/volume1/docker/airsonic-advanced/music"
+        },
+        {
+          "container": "/playlists",
+          "bind": "/volume1/docker/airsonic-advanced/playlists"
+        },
+        {
+          "container": "/podcasts",
+          "bind": "/volume1/docker/airsonic-advanced/podcasts"
+        },
+        {
+          "container": "/media",
+          "bind": "/volume1/docker/airsonic-advanced/media"
+        }
+      ],
+      "restart_policy": "unless-stopped",
+      "maintainer": " https://github.com/mycroftwilde/portainer_templates/"
+    },
+    {
+      "id": 175,
+      "type": 1,
+      "title": "Phpmyadmin",
+      "name": "Phpmyadmin",
+      "note": "Portainer App Templates by <a href='https://www.technorabilia.com' target='_blank'>Technorabilia</a> based on data provided by <a href='https://www.linuxserver.io' target='_blank'>LinuxServer.io</a>.</p><p>Don't forget to create the volume directories on the host file system.</p><p>mkdir -p /volume1/docker/phpmyadmin/config</p>",
+      "description": "[Phpmyadmin](https://github.com/phpmyadmin/phpmyadmin/) is a free software tool written in PHP, intended to handle the administration of MySQL over the Web. phpMyAdmin supports a wide range of operations on MySQL and MariaDB.",
+      "categories": [
+        "Databaseserver"
+      ],
+      "platform": "linux",
+      "logo": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/phpmyadmin-logo.png",
+      "image": "linuxserver/phpmyadmin:latest",
+      "env": [
+        {
+          "name": "PUID",
+          "label": "PUID",
+          "default": "1024",
+          "description": "for GroupID"
+        },
+        {
+          "name": "PGID",
+          "label": "PGID",
+          "default": "100",
+          "description": "for UserID"
+        },
+        {
+          "name": "TZ",
+          "label": "TZ",
+          "default": "Europe/Amsterdam",
+          "description": "Specify a timezone to use for example Europe/Amsterdam"
+        },
+        {
+          "name": "PMA_ARBITRARY",
+          "label": "PMA_ARBITRARY",
+          "default": "1",
+          "description": "Set to `1` to allow you to connect to any server. Setting to `0` will only allow you to connect to specified hosts (See Application Setup)"
+        },
+        {
+          "name": "PMA_ABSOLUTE_URI",
+          "label": "PMA_ABSOLUTE_URI",
+          "default": "https://phpmyadmin.example.com",
+          "description": "Set the URL you will use to access the web frontend"
+        }
+      ],
+      "ports": [
+        "80:80/tcp"
+      ],
+      "volumes": [
+        {
+          "container": "/config",
+          "bind": "/volume1/docker/phpmyadmin/config"
+        }
+      ],
+      "restart_policy": "unless-stopped",
+      "maintainer": " https://github.com/mycroftwilde/portainer_templates/"
+    },
+    {
+      "id": 176,
+      "type": 1,
+      "title": "Pixapop",
+      "name": "Pixapop",
+      "note": "Portainer App Templates by <a href='https://www.technorabilia.com' target='_blank'>Technorabilia</a> based on data provided by <a href='https://www.linuxserver.io' target='_blank'>LinuxServer.io</a>.</p><p>Don't forget to create the volume directories on the host file system.</p><p>mkdir -p /volume1/docker/pixapop/config<br>mkdir -p /volume1/docker/pixapop/photos</p>",
+      "description": "[Pixapop](https://github.com/bierdok/pixapop) is an open-source single page application to view your photos in the easiest way possible.",
+      "categories": [
+        "Photos"
+      ],
+      "platform": "linux",
+      "logo": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/pixapop.png",
+      "image": "linuxserver/pixapop:latest",
+      "env": [
+        {
+          "name": "PUID",
+          "label": "PUID",
+          "default": "1024",
+          "description": "for GroupID"
+        },
+        {
+          "name": "PGID",
+          "label": "PGID",
+          "default": "100",
+          "description": "for UserID"
+        },
+        {
+          "name": "TZ",
+          "label": "TZ",
+          "default": "Europe/Amsterdam",
+          "description": "Specify a timezone to use for example Europe/Amsterdam"
+        },
+        {
+          "name": "APP_USERNAME",
+          "label": "APP_USERNAME",
+          "default": "admin",
+          "description": "Specify a username to enable authentication."
+        },
+        {
+          "name": "APP_PASSWORD",
+          "label": "APP_PASSWORD",
+          "default": "admin",
+          "description": "Specify a password to enable authentication."
+        }
+      ],
+      "ports": [
+        "80:80/tcp"
+      ],
+      "volumes": [
+        {
+          "container": "/config",
+          "bind": "/volume1/docker/pixapop/config"
+        },
+        {
+          "container": "/photos",
+          "bind": "/volume1/docker/pixapop/photos"
+        }
+      ],
+      "restart_policy": "unless-stopped",
+      "maintainer": " https://github.com/mycroftwilde/portainer_templates/"
+    },
+    {
+      "id": 177,
+      "type": 1,
+      "title": "Syslog-ng",
+      "name": "Syslog-ng",
+      "note": "Portainer App Templates by <a href='https://www.technorabilia.com' target='_blank'>Technorabilia</a> based on data provided by <a href='https://www.linuxserver.io' target='_blank'>LinuxServer.io</a>.</p><p>Don't forget to create the volume directories on the host file system.</p><p>mkdir -p /volume1/docker/syslog-ng/config<br></p>",
+      "description": "[syslog-ng](https://www.syslog-ng.com/products/open-source-log-management/) allows you to flexibly collect, parse, classify, rewrite and correlate logs from across your infrastructure and store or route them to log analysis tools.",
+      "categories": [
+        "Taskserver"
+      ],
+      "platform": "linux",
+      "logo": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/syslog-ng-logo.png",
+      "image": "linuxserver/syslog-ng:latest",
+      "env": [
+        {
+          "name": "PUID",
+          "label": "PUID",
+          "default": "1024",
+          "description": "for GroupID"
+        },
+        {
+          "name": "PGID",
+          "label": "PGID",
+          "default": "100",
+          "description": "for UserID"
+        },
+        {
+          "name": "TZ",
+          "label": "TZ",
+          "default": "Europe/Amsterdam",
+          "description": "Specify a timezone to use for example Europe/Amsterdam"
+        }
+      ],
+      "ports": [
+        "514:5514/udp",
+        "601:6601/tcp",
+        "6514:6514/tcp"
+      ],
+      "volumes": [
+        {
+          "container": "/config",
+          "bind": "/volume1/docker/syslog-ng/config"
+        },
+        {
+          "container": "/var/log",
+          "bind": "/var/log"
+        }
+      ],
+      "restart_policy": "unless-stopped",
+      "maintainer": " https://github.com/mycroftwilde/portainer_templates/"
+    },
+    {
+      "id": 178,
+      "type": 1,
+      "title": "Wowza",
+      "description": "Streaming media server",
+      "categories": [
+        "Mediaserver"
+      ],
+      "platform": "linux",
+      "logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/wowza.png",
+      "image": "sameersbn/wowza:4.1.2-8",
+      "env": [
+        {
+          "name": "WOWZA_ACCEPT_LICENSE",
+          "label": "Agree to Wowza EULA",
+          "set": "yes"
+        },
+        {
+          "name": "WOWZA_KEY",
+          "label": "License key"
+        }
+      ],
+      "ports": [
+        "1935/tcp",
+        "8086/tcp",
+        "8087/tcp",
+        "8088/tcp"
+      ],
+      "volumes": [
+        {
+          "container": "/var/lib/wowza"
+        }
+      ],
+      "maintainer": " https://github.com/mycroftwilde/portainer_templates/"
+    },
+    {
+      "id": 179,
+      "type": 1,
+      "title": "MySQL",
+      "description": "The most popular open-source database",
+      "categories": [
+        "Databaseserver"
+      ],
+      "platform": "linux",
+      "logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/mysql.png",
+      "image": "mysql:latest",
+      "env": [
+        {
+          "name": "MYSQL_ROOT_PASSWORD",
+          "label": "Root password"
+        }
+      ],
+      "ports": [
+        "3306/tcp"
+      ],
+      "volumes": [
+        {
+          "container": "/var/lib/mysql"
+        }
+      ],
+      "maintainer": " https://github.com/mycroftwilde/portainer_templates/"
+    },
+    {
+      "id": 180,
+      "type": 1,
+      "title": "Gitlab CE",
+      "description": "Open-source end-to-end software development platform",
+      "note": "Default username is <b>root</b>. Check the <a href=\"https://docs.gitlab.com/omnibus/docker/README.html#after-starting-a-container\" target=\"_blank\">Gitlab documentation</a> to get started.",
+      "categories": [
+        "Codeserver"
+      ],
+      "platform": "linux",
+      "logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/gitlab_ce.png",
+      "image": "gitlab/gitlab-ce:latest",
+      "ports": [
+        "80/tcp",
+        "443/tcp",
+        "22/tcp"
+      ],
+      "volumes": [
+        {
+          "container": "/etc/gitlab"
+        },
+        {
+          "container": "/var/log/gitlab"
+        },
+        {
+          "container": "/var/opt/gitlab"
+        }
+      ],
+      "maintainer": " https://github.com/mycroftwilde/portainer_templates/"
+    },
+    {
+      "id": 181,
+      "categories": [
+        "Downloaders"
+      ],
+      "description": "YoutubeDL-Material is a Material Design frontend for youtube-dl. It's coded using Angular 9 for the frontend, and Node.js on the backend.",
+      "image": "tzahi12345/youtubedl-material:latest",
+      "logo": "https://raw.githubusercontent.com/Qballjos/portainer_templates/master/Images/ytdlm.png",
+      "name": "youtubedl-material",
+      "platform": "linux",
+      "ports": [
+        "17442:17442/tcp"
+      ],
+      "restart_policy": "unless-stopped",
+      "title": "YouTubeDL-Material",
+      "type": 1,
+      "volumes": [
+        {
+          "bind": "/portainer/Files/AppData/Config/YTDLM",
+          "container": "/app/appdata"
+        },
+        {
+          "bind": "/portainer/Files/AppData/Youtube/Video",
+          "container": "/app/video"
+        },
+        {
+          "bind": "/portainer/Files/AppData/Youtube/Subscriptions",
+          "container": "/app/subscriptions"
+        },
+        {
+          "bind": "/portainer/Files/AppData/Youtube/Users",
+          "container": "/app/users"
+        },
+        {
+          "bind": "/portainer/Files/AppData/Youtube/Audio",
+          "container": "/app/audio"
+        }
+      ],
+      "maintainer": " https://github.com/mycroftwilde/portainer_templates/"
+    },
+    {
+      "id": 182,
+      "categories": [
+        "Music"
+      ],
+      "description": "Airsonic is a free, web-based media streamer, providing ubiqutious access to your music. Use it to share your music with friends, or to listen to your own music while at work. You can stream to multiple players simultaneously, for instance to one player in your kitchen and another in your living room.",
+      "env": [
+        {
+          "default": "1000",
+          "label": "PUID",
+          "name": "PUID"
+        },
+        {
+          "default": "100",
+          "label": "PGID",
+          "name": "PGID"
+        },
+        {
+          "label": "CONTEXT_PATH",
+          "name": "CONTEXT_PATH",
+          "set": "airsonic"
+        },
+        {
+          "label": "JAVA_OPTS",
+          "name": "JAVA_OPTS",
+          "set": "-Xms256m -Xmx512m"
+        }
+      ],
+      "image": "linuxserver/airsonic:latest",
+      "logo": "https://raw.githubusercontent.com/SelfhostedPro/selfhosted_templates/master/Images/airsonic-logo.png",
+      "name": "airsonic",
+      "platform": "linux",
+      "ports": [
+        "4040:4040/tcp"
+      ],
+      "restart_policy": "unless-stopped",
+      "title": "Airsonic",
+      "type": 1,
+      "volumes": [
+        {
+          "bind": "/portainer/Music",
+          "container": "/music"
+        },
+        {
+          "bind": "/portainer/Files/AppData/Airsonic/Playlists",
+          "container": "/playlists"
+        },
+        {
+          "bind": "/portainer/Podcasts",
+          "container": "/podcasts"
+        },
+        {
+          "bind": "/portainer/Files/AppData/Airsonic/Media",
+          "container": "/media"
+        },
+        {
+          "bind": "/portainer/Files/AppData/Config/Airsonic/",
+          "container": "/config"
+        }
+      ],
+      "maintainer": " https://github.com/SelfhostedPro/selfhosted_templates/"
+    },
+    {
+      "id": 183,
+      "categories": [
+        "Other",
+        "Tools"
+      ],
+      "description": "This is a Bitwarden server API implementation written in Rust compatible with upstream Bitwarden clients*, perfect for self-hosted deployment where running the official resource-heavy service might not be ideal..",
+      "image": "bitwardenrs/server:latest",
+      "logo": "https://raw.githubusercontent.com/SelfhostedPro/selfhosted_templates/master/Images/bitwarden.png",
+      "name": "bitwardenrs",
+      "note": "This project is not associated with the Bitwarden project nor 8bit Solutions LLC.",
+      "platform": "linux",
+      "ports": [
+        "80/tcp"
+      ],
+      "restart_policy": "unless-stopped",
+      "title": "Bitwarden RS",
+      "type": 1,
+      "volumes": [
+        {
+          "bind": "/portainer/Files/AppData/Config/Bitwarden-rs",
+          "container": "/config"
+        }
+      ],
+      "maintainer": " https://github.com/SelfhostedPro/selfhosted_templates/"
+    },
+    {
+      "id": 184,
+      "categories": [
+        "Cloud",
+        "Productivity",
+        "Tools",
+        "Other",
+        "Web"
+      ],
+      "description": "Invoices, Expenses and Tasks built with Laravel and Flutter.",
+      "env": [
+        {
+          "default": "invoice.my.domain",
+          "label": "URL",
+          "name": "URL"
+        },
+        {
+          "label": "APP_KEY",
+          "name": "APP_KEY"
+        },
+        {
+          "label": "TZ",
+          "name": "TZ"
+        },
+        {
+          "label": "DATABASE_PASSWORD",
+          "name": "DATABASE_PASSWORD"
+        },
+        {
+          "label": "MYSQL_ROOT_PASSWORD",
+          "name": "MYSQL_ROOT_PASSWORD"
+        },
+        {
+          "label": "PORT",
+          "name": "PORT"
+        }
+      ],
+      "logo": "https://raw.githubusercontent.com/SelfhostedPro/selfhosted_templates/master/Images/invoice_ninja.png",
+      "name": "invoice_ninja",
+      "note": "The database user is invoice_ninja and the database is ninja_db. Please generate an app key following the documentation <a href='https://github.com/invoiceninja/dockerfiles'>here</a>. ",
+      "platform": "linux",
+      "repository": {
+        "stackfile": "Template/Stack/invoice-ninja.yml",
+        "url": "https://github.com/SelfhostedPro/selfhosted_templates"
+      },
+      "title": "Invoice Ninja",
+      "type": 3,
+      "maintainer": " https://github.com/SelfhostedPro/selfhosted_templates/"
+    },
+    {
+      "id": 185,
+      "categories": [
+        "Tools",
+        "Web"
+      ],
+      "description": "This container sets up an Nginx webserver and reverse proxy with php support and a built-in letsencrypt client that automates free SSL server certificate generation and renewal processes. It also contains fail2ban for intrusion prevention.\r\n  \r\n  Before running this container, make sure that the url and subdomains are properly forwarded to this container's host.\r\n  \r\n  - Port 443 on the internet side of the router should be forwarded to this container's port 443.\r\n  - If you need a dynamic dns provider, you can use the free provider duckdns.org where the url will be yoursubdomain.duckdns.org and the subdomains    can be www,ftp,cloud\r\n  - The container detects changes to url and subdomains, revokes existing certs and generates new ones during start. \r\n  - It also detects changes to the DHLEVEL parameter and replaces the dhparams file.\r\n  \r\n  - If you'd like to password protect your sites, you can use htpasswd. Run the following command on your host to generate the htpasswd file docker exec -it letsencrypt htpasswd -c /config/nginx/.htpasswd &lt;username&gt;",
+      "env": [
+        {
+          "label": "EMAIL",
+          "name": "EMAIL",
+          "set": "-Xms256m -Xmx512m"
+        },
+        {
+          "label": "URL",
+          "name": "URL",
+          "set": "-Xms256m -Xmx512m"
+        },
+        {
+          "label": "SUBDOMAINS",
+          "name": "SUBDOMAINS",
+          "set": "www,"
+        },
+        {
+          "label": "ONLY_SUBDOMAINS",
+          "name": "ONLY_SUBDOMAINS",
+          "set": "false"
+        },
+        {
+          "label": "DHLEVEL",
+          "name": "DHLEVEL",
+          "set": "2048"
+        },
+        {
+          "default": "1000",
+          "label": "PUID",
+          "name": "PUID"
+        },
+        {
+          "default": "100",
+          "label": "PGID",
+          "name": "PGID"
+        },
+        {
+          "label": "VALIDATION",
+          "name": "VALIDATION",
+          "set": "http"
+        },
+        {
+          "label": "DNSPLUGIN",
+          "name": "DNSPLUGIN",
+          "set": "http"
+        }
+      ],
+      "image": "linuxserver/letsencrypt:latest",
+      "logo": "https://raw.githubusercontent.com/SelfhostedPro/selfhosted_templates/master/Images/letsencrypt.png",
+      "name": "letsencrypt",
+      "platform": "linux",
+      "ports": [
+        "80/tcp",
+        "443/tcp"
+      ],
+      "restart_policy": "unless-stopped",
+      "title": "Let's Encrypt",
+      "type": 1,
+      "volumes": [
+        {
+          "bind": "/portainer/Files/AppData/Config/LetsEncrypt",
+          "container": "/config"
+        }
+      ],
+      "maintainer": " https://github.com/SelfhostedPro/selfhosted_templates/"
+    },
+    {
+      "id": 186,
+      "categories": [
+        "Other"
+      ],
+      "description": "McMyAdmin 2 is the leading web control panel and administration console for Minecraft servers.",
+      "env": [
+        {
+          "default": "1000",
+          "label": "PUID",
+          "name": "PUID"
+        },
+        {
+          "default": "100",
+          "label": "PGID",
+          "name": "PGID"
+        }
+      ],
+      "image": "linuxserver/mcmyadmin2:latest",
+      "logo": "https://raw.githubusercontent.com/SelfhostedPro/selfhosted_templates/master/Images/mcmyadmin-icon.png",
+      "name": "mcmyadmin2",
+      "platform": "linux",
+      "ports": [
+        "8080:8080/tcp",
+        "25565:25565/tcp"
+      ],
+      "restart_policy": "unless-stopped",
+      "title": "McMyAdmin 2",
+      "type": 1,
+      "volumes": [
+        {
+          "container": "/minecraft"
+        }
+      ],
+      "maintainer": " https://github.com/SelfhostedPro/selfhosted_templates/"
+    },
+    {
+      "id": 187,
+      "categories": [
+        "Downloaders",
+        "Video"
+      ],
+      "description": "Medusa, automatic Video Library Manager for TV Shows. It watches for new episodes of your favorite shows, and when they are posted it does its magic.",
+      "env": [
+        {
+          "default": "1000",
+          "label": "PUID",
+          "name": "PUID"
+        },
+        {
+          "default": "100",
+          "label": "PGID",
+          "name": "PGID"
+        }
+      ],
+      "image": "linuxserver/medusa:latest",
+      "logo": "https://raw.githubusercontent.com/SelfhostedPro/selfhosted_templates/master/Images/medusa-icon.png",
+      "name": "medusa",
+      "platform": "linux",
+      "ports": [
+        "8081:8081/tcp"
+      ],
+      "restart_policy": "unless-stopped",
+      "title": "Medusa",
+      "type": 1,
+      "volumes": [
+        {
+          "bind": "/portainer/Files/AppData/Config/Medusa",
+          "container": "/config"
+        },
+        {
+          "bind": "/portainer/TV",
+          "container": "/tv"
+        },
+        {
+          "bind": "/portainer/Downloads",
+          "container": "/downloads"
+        }
+      ],
+      "maintainer": " https://github.com/SelfhostedPro/selfhosted_templates/"
+    },
+    {
+      "id": 188,
+      "categories": [
+        "Other"
+      ],
+      "description": "Server version of minetest, a free, open source alternative to minecraft.",
+      "env": [
+        {
+          "default": "1000",
+          "label": "PUID",
+          "name": "PUID"
+        },
+        {
+          "default": "100",
+          "label": "PGID",
+          "name": "PGID"
+        }
+      ],
+      "image": "linuxserver/minetest:latest",
+      "logo": "https://raw.githubusercontent.com/linuxserver/beta-templates/master/lsiodev/img/minetest-icon.png",
+      "name": "minetest",
+      "platform": "linux",
+      "ports": [
+        "30000:30000/udp"
+      ],
+      "restart_policy": "unless-stopped",
+      "title": "Minetest",
+      "type": 1,
+      "volumes": [
+        {
+          "container": "/config/.minetest"
+        }
+      ],
+      "maintainer": " https://github.com/SelfhostedPro/selfhosted_templates/"
+    },
+    {
+      "id": 189,
+      "categories": [
+        "Video",
+        "Other",
+        "Tools"
+      ],
+      "description": "Minisatip is a multi-threaded satip server version 1.2 that runs under Linux and it was tested with DVB-S, DVB-S2, DVB-T, DVB-T2, DVB-C, DVB-C2, ATSC and ISDB-T cards.\n\n  The application is designed to stream the requested data to multiple clients (even with one dvb card) at the same time while opening different pids.\n  ",
+      "env": [
+        {
+          "default": "1000",
+          "label": "PUID",
+          "name": "PUID"
+        },
+        {
+          "default": "100",
+          "label": "PGID",
+          "name": "PGID"
+        }
+      ],
+      "image": "linuxserver/minisatip:latest",
+      "logo": "https://raw.githubusercontent.com/SelfhostedPro/selfhosted_templates/master/Images/minisatip-icon.png",
+      "name": "minisatip",
+      "platform": "linux",
+      "ports": [
+        "8875:8875/tcp",
+        "554:554/tcp",
+        "1900:1900/udp"
+      ],
+      "restart_policy": "unless-stopped",
+      "title": "Minisatip",
+      "type": 1,
+      "maintainer": " https://github.com/SelfhostedPro/selfhosted_templates/"
+    },
+    {
+      "id": 190,
+      "categories": [
+        "Other",
+        "Tools"
+      ],
+      "description": "Organizr allows you to setup Tabs that will be loaded all in one webpage. You can then work on your server with ease.",
+      "env": [
+        {
+          "default": "1000",
+          "label": "PUID",
+          "name": "PUID"
+        },
+        {
+          "default": "100",
+          "label": "PGID",
+          "name": "PGID"
+        }
+      ],
+      "image": "organizrtools/organizr-v2:php-fpm",
+      "logo": "https://raw.githubusercontent.com/SelfhostedPro/selfhosted_templates/master/Images/organizr-icon.png",
+      "name": "organizr-v2",
+      "platform": "linux",
+      "ports": [
+        "80/tcp"
+      ],
+      "restart_policy": "unless-stopped",
+      "title": "Organizr v2",
+      "type": 1,
+      "volumes": [
+        {
+          "bind": "/portainer/Files/AppData/Config/Organizr",
+          "container": "/config"
+        }
+      ],
+      "maintainer": " https://github.com/SelfhostedPro/selfhosted_templates/"
+    },
+    {
+      "id": 191,
+      "categories": [
+        "Other"
+      ],
+      "description": "OScam is a softcam, software to be used to decrypt digital television channels on a settopbox (receiver), as an alternative for a conditional access module\n  (CAM). OScam is, compared with other softcams (CCcam, mgcamd, etc.), open source. Hence, the name Open Source Conditional Access Module (OScam). OScam is based on the\n  not so well known softcam MpCS. The main features of OSCam are next to its softcam capabilities, that it is able to function as a cardserver.",
+      "env": [
+        {
+          "default": "1000",
+          "label": "PUID",
+          "name": "PUID"
+        },
+        {
+          "default": "100",
+          "label": "PGID",
+          "name": "PGID"
+        }
+      ],
+      "image": "linuxserver/oscam:latest",
+      "logo": "http://i.imgur.com/8LadrLg.png",
+      "name": "oscam",
+      "platform": "linux",
+      "ports": [
+        "8888:8888/tcp",
+        "10000:10000/tcp"
+      ],
+      "restart_policy": "unless-stopped",
+      "title": "OScam",
+      "type": 1,
+      "volumes": [
+        {
+          "bind": "/portainer/Files/AppData/Config/OScam",
+          "container": "/config"
+        }
+      ],
+      "maintainer": " https://github.com/SelfhostedPro/selfhosted_templates/"
+    },
+    {
+      "id": 192,
+      "categories": [
+        "Other",
+        "Music"
+      ],
+      "description": "Deemix is a deezer downloader built from the ashes of Deezloader Remix.",
+      "image": "registry.gitlab.com/bockiii/deemix-docker",
+      "logo": "https://raw.githubusercontent.com/SelfhostedPro/selfhosted_templates/master/Images/deemix.png",
+      "name": "deemix",
+      "note": "Deemix may take a few minutes to install. Be sure to check the logs for details. Refer to <a href='https://notabug.org/RemixDevs/DeezloaderRemix/wiki/Login+via+userToken'>this page</a> for userToken details.",
+      "platform": "linux",
+      "ports": [
+        "9666:9666/tcp"
+      ],
+      "restart_policy": "unless-stopped",
+      "title": "DeeMix",
+      "type": 1,
+      "volumes": [
+        {
+          "bind": "/portainer/Files/AppData/Config/DeeMix",
+          "container": "/config"
+        },
+        {
+          "bind": "/portainer/Downloads",
+          "container": "/downloads"
+        }
+      ],
+      "maintainer": " https://github.com/SelfhostedPro/selfhosted_templates/"
+    },
+    {
+      "id": 193,
+      "categories": [
+        "Video",
+        "Music",
+        "Other"
+      ],
+      "description": "HTPC Manaager, a front end for many htpc related applications. Hellowlol version.",
+      "env": [
+        {
+          "default": "1000",
+          "label": "PUID",
+          "name": "PUID"
+        },
+        {
+          "default": "100",
+          "label": "PGID",
+          "name": "PGID"
+        }
+      ],
+      "image": "linuxserver/htpcmanager:latest",
+      "logo": "https://raw.githubusercontent.com/SelfhostedPro/selfhosted_templates/master/Images/htpcmanager-icon.png",
+      "name": "htpcmanager",
+      "platform": "linux",
+      "ports": [
+        "8085:8085/tcp"
+      ],
+      "restart_policy": "unless-stopped",
+      "title": "HTPC Manager",
+      "type": 1,
+      "volumes": [
+        {
+          "bind": "/portainer/Files/AppData/Config/HTPCmanager",
+          "container": "/config"
+        }
+      ],
+      "maintainer": " https://github.com/SelfhostedPro/selfhosted_templates/"
+    },
+    {
+      "id": 194,
+      "categories": [
+        "Cloud",
+        "Productivity",
+        "Tools",
+        "Other"
+      ],
+      "description": "ProjectSend is a self-hosted application that lets you upload files and assign them to specific clients that you create yourself! Secure, private and easy. No more depending on external services or e-mail to send those files!\n  ",
+      "env": [
+        {
+          "default": "1000",
+          "label": "PUID",
+          "name": "PUID"
+        },
+        {
+          "default": "100",
+          "label": "PGID",
+          "name": "PGID"
+        }
+      ],
+      "image": "linuxserver/projectsend:latest",
+      "logo": "https://raw.githubusercontent.com/SelfhostedPro/selfhosted_templates/master/Images/projectsend-logo.png",
+      "name": "projectsend",
+      "platform": "linux",
+      "ports": [
+        "80/tcp"
+      ],
+      "restart_policy": "unless-stopped",
+      "title": "ProjectSend",
+      "type": 1,
+      "volumes": [
+        {
+          "bind": "/portainer/Files/AppData/ProjectSend",
+          "container": "/data"
+        },
+        {
+          "bind": "/portainer/Files/AppData/Config/ProjectSend",
+          "container": "/config"
+        }
+      ],
+      "maintainer": " https://github.com/SelfhostedPro/selfhosted_templates/"
+    },
+    {
+      "id": 195,
+      "categories": [
+        "Vpn",
+        "Tools",
+        "Other",
+        "Web"
+      ],
+      "description": "Pritunl container built on Alpine Linux. Supports IPv6 and running behind a reverse proxy. This container requires an external Mongo DB and should be run via Docker Compose or other orchestration.",
+      "env": [
+        {
+          "default": "false",
+          "label": "REVERSE_PROXY",
+          "name": "REVERSE_PROXY"
+        },
+        {
+          "label": "PRITUNL_OPTS",
+          "name": "PRITUNL_OPTS"
+        },
+        {
+          "default": "mongodb://mongo:27017/pritunl",
+          "label": "MONGODB_URI",
+          "name": "MONGODB_URI"
+        },
+        {
+          "default": "false",
+          "label": "WIREGUARD",
+          "name": "WIREGUARD"
+        }
+      ],
+      "logo": "https://raw.githubusercontent.com/SelfhostedPro/selfhosted_templates/pritunl/Images/pritunl.png",
+      "name": "pritunl",
+      "note": "Documentation on this containier can be found here: <a href=https://hub.docker.com/r/goofball222/pritunl>https://hub.docker.com/r/goofball222/pritunl</a>",
+      "platform": "linux",
+      "repository": {
+        "stackfile": "Template/Stack/pritunl.yml",
+        "url": "https://github.com/SelfhostedPro/selfhosted_templates"
+      },
+      "title": "Pritunl",
+      "type": 3,
+      "maintainer": " https://github.com/SelfhostedPro/selfhosted_templates/"
+    },
+    {
+      "id": 196,
+      "categories": [
+        "Cloud",
+        "Other"
+      ],
+      "description": "Pydio (formerly AjaXplorer) is a mature open source software solution for file sharing and synchronization. With intuitive user interfaces (web / mobile / desktop), Pydio provides enterprise-grade features to gain back control and privacy of your data: user directory connectors, legacy filesystems drivers, comprehensive admin interface, and much more.",
+      "env": [
+        {
+          "default": "1000",
+          "label": "PUID",
+          "name": "PUID"
+        },
+        {
+          "default": "100",
+          "label": "PGID",
+          "name": "PGID"
+        }
+      ],
+      "image": "linuxserver/pydio:latest",
+      "logo": "https://raw.githubusercontent.com/SelfhostedPro/selfhosted_templates/master/Images/pydio-icon.png",
+      "name": "pydio",
+      "platform": "linux",
+      "ports": [
+        "443/tcp"
+      ],
+      "restart_policy": "unless-stopped",
+      "title": "Pydio",
+      "type": 1,
+      "volumes": [
+        {
+          "bind": "/portainer/Files/AppData/Config/Pydio",
+          "container": "/config"
+        },
+        {
+          "bind": "/portainer/Files/AppData/Pydio",
+          "container": "/data"
+        }
+      ],
+      "maintainer": " https://github.com/SelfhostedPro/selfhosted_templates/"
+    },
+    {
+      "id": 197,
+      "categories": [
+        "Messenger"
+      ],
+      "description": "Quassel IRC is a modern, cross-platform, distributed IRC client, meaning that one (or multiple) client(s) can attach to and detach from a central core -- much like the popular combination of screen and a text-based IRC client such as WeeChat, but graphical. Blowfish support and optional web-ui included.",
+      "env": [
+        {
+          "default": "1000",
+          "label": "PUID",
+          "name": "PUID"
+        },
+        {
+          "default": "100",
+          "label": "PGID",
+          "name": "PGID"
+        }
+      ],
+      "image": "linuxserver/quassel-core:latest",
+      "logo": "https://raw.githubusercontent.com/SelfhostedPro/selfhosted_templates/master/Images/quassel-core-icon.png",
+      "name": "quassel-core",
+      "platform": "linux",
+      "ports": [
+        "4242:4242/tcp"
+      ],
+      "restart_policy": "unless-stopped",
+      "title": "Quassel IRC",
+      "type": 1,
+      "volumes": [
+        {
+          "bind": "/portainer/Files/AppData/Config/Quassel-core",
+          "container": "/config"
+        }
+      ],
+      "maintainer": " https://github.com/SelfhostedPro/selfhosted_templates/"
+    },
+    {
+      "id": 198,
+      "categories": [
+        "Other",
+        "Tools"
+      ],
+      "description": "A one-of-a-kind resume builder that's not out to get your data. Completely secure, customizable, portable, open-source and free forever.",
+      "image": "amruthpillai/reactive-resume:latest",
+      "logo": "https://raw.githubusercontent.com/SelfhostedPro/selfhosted_templates/master/Images/reactiveresume.png",
+      "name": "reactive-resume",
+      "platform": "linux",
+      "ports": [
+        "80/tcp"
+      ],
+      "restart_policy": "unless-stopped",
+      "title": "Reactive-Resume",
+      "type": 1,
+      "volumes": [
+        {
+          "bind": "/portainer/Files/AppData/Config/ReactiveResume",
+          "container": "/usr/src/app"
+        }
+      ],
+      "maintainer": " https://github.com/SelfhostedPro/selfhosted_templates/"
+    },
+    {
+      "id": 199,
+      "categories": [
+        "Downloaders",
+        "Video"
+      ],
+      "description": "Automatic Video Library Manager for TV Shows. It watches for new episodes of your favorite shows, and when they are posted it does its magic.",
+      "env": [
+        {
+          "default": "1000",
+          "label": "PUID",
+          "name": "PUID"
+        },
+        {
+          "default": "100",
+          "label": "PGID",
+          "name": "PGID"
+        }
+      ],
+      "image": "linuxserver/sickchill:latest",
+      "logo": "https://raw.githubusercontent.com/SelfhostedPro/selfhosted_templates/master/Images/sickchill-icon.png",
+      "name": "sickchill",
+      "platform": "linux",
+      "ports": [
+        "8081:8081/tcp"
+      ],
+      "restart_policy": "unless-stopped",
+      "title": "SickChill",
+      "type": 1,
+      "volumes": [
+        {
+          "bind": "/portainer/Files/AppData/Config/SickChill",
+          "container": "/config"
+        },
+        {
+          "bind": "/portainer/Downloads",
+          "container": "/downloads"
+        },
+        {
+          "bind": "/portainer/TV",
+          "container": "/tv"
+        }
+      ],
+      "maintainer": " https://github.com/SelfhostedPro/selfhosted_templates/"
+    },
+    {
+      "id": 200,
+      "categories": [
+        "Downloaders",
+        "Video"
+      ],
+      "description": "SickGear provides management of TV shows and/or Anime, it detects new episodes, links downloader apps, and more.",
+      "env": [
+        {
+          "default": "1000",
+          "label": "PUID",
+          "name": "PUID"
+        },
+        {
+          "default": "100",
+          "label": "PGID",
+          "name": "PGID"
+        }
+      ],
+      "image": "linuxserver/sickgear:latest",
+      "logo": "https://raw.githubusercontent.com/SelfhostedPro/selfhosted_templates/master/Images/sickgear-icon.png",
+      "name": "sickgear",
+      "platform": "linux",
+      "ports": [
+        "8081:8081/tcp"
+      ],
+      "restart_policy": "unless-stopped",
+      "title": "SickGear",
+      "type": 1,
+      "volumes": [
+        {
+          "bind": "/portainer/Files/AppData/Config/SickGear",
+          "container": "/config"
+        },
+        {
+          "bind": "/portainer/TV",
+          "container": "/tv"
+        },
+        {
+          "bind": "/portainer/Downloads",
+          "container": "/downloads"
+        }
+      ],
+      "maintainer": " https://github.com/SelfhostedPro/selfhosted_templates/"
+    },
+    {
+      "id": 201,
+      "categories": [
+        "Messenger"
+      ],
+      "description": "A self-hosted web IRC client",
+      "env": [
+        {
+          "default": "1000",
+          "label": "PUID",
+          "name": "PUID"
+        },
+        {
+          "default": "100",
+          "label": "PGID",
+          "name": "PGID"
+        }
+      ],
+      "image": "linuxserver/thelounge:latest",
+      "logo": "https://raw.githubusercontent.com/linuxserver/community-templates/master/lsiocommunity/img/shout-icon.png",
+      "name": "thelounge",
+      "platform": "linux",
+      "ports": [
+        "9000:9000/tcp"
+      ],
+      "restart_policy": "unless-stopped",
+      "title": "TheLounge",
+      "type": 1,
+      "volumes": [
+        {
+          "bind": "/portainer/Files/AppData/Config/TheLounge",
+          "container": "/config"
+        }
+      ],
+      "maintainer": " https://github.com/SelfhostedPro/selfhosted_templates/"
+    },
+    {
+      "id": 202,
+      "categories": [
+        "Video",
+        "Other"
+      ],
+      "description": "Tvheadend is a TV streaming server and recorder for Linux, FreeBSD and Android supporting DVB-S, DVB-S2, DVB-C, DVB-T, ATSC, ISDB-T, IPTV, SAT&gt;IP and HDHomeRun as input sources.\r\nTvheadend offers the HTTP (VLC, MPlayer), HTSP (Kodi, Movian) and SAT&gt;IP streaming.\r\nMultiple EPG sources are supported (over-the-air DVB and ATSC including OpenTV DVB extensions, XMLTV, PyXML).",
+      "env": [
+        {
+          "default": "1000",
+          "label": "PUID",
+          "name": "PUID"
+        },
+        {
+          "default": "100",
+          "label": "PGID",
+          "name": "PGID"
+        }
+      ],
+      "image": "linuxserver/tvheadend:latest",
+      "logo": "http://i.imgur.com/zGSUAT4.png",
+      "name": "tvheadend",
+      "platform": "linux",
+      "ports": [
+        "9981:9981/tcp",
+        "9982:9982/tcp"
+      ],
+      "restart_policy": "unless-stopped",
+      "title": "Tvheadend",
+      "type": 1,
+      "volumes": [
+        {
+          "bind": "/portainer/Files/AppData/Config/TVHeadend",
+          "container": "/config"
+        },
+        {
+          "container": "/recordings"
+        }
+      ],
+      "maintainer": " https://github.com/SelfhostedPro/selfhosted_templates/"
+    },
+    {
+      "id": 203,
+      "categories": [
+        "Cctv"
+      ],
+      "description": "UniFi Video is a powerful and flexible, integrated IP video management surveillance system designed to work with Ubiquiti’s UniFi Video Camera product line. UniFi Video has an intuitive, configurable, and feature‑packed user interface with advanced features such as motion detection, auto‑discovery, user‑level security, storage management, reporting, and mobile device support.",
+      "env": [
+        {
+          "default": "99",
+          "label": "PUID",
+          "name": "PUID"
+        },
+        {
+          "default": "100",
+          "label": "PGID",
+          "name": "PGID"
+        },
+        {
+          "default": "002",
+          "label": "UMASK",
+          "name": "UMASK"
+        },
+        {
+          "label": "CONTEXT_PATH",
+          "name": "CONTEXT_PATH",
+          "set": "UniFi Video"
+        }
+      ],
+      "image": "pducharme/unifi-video-controller:latest",
+      "logo": "https://raw.githubusercontent.com/SelfhostedPro/selfhosted_templates/master/Images/UniFiVideo-logo.png",
+      "name": "UniFi Video",
+      "platform": "linux",
+      "ports": [
+        "1935:1935/tcp",
+        "7444:7444/tcp",
+        "7447:7447/tcp",
+        "6666:6666/tcp",
+        "7442:7442/tcp",
+        "7080:7080/tcp",
+        "7443:7443/tcp",
+        "7445:7445/tcp",
+        "7446:7446/tcp"
+      ],
+      "restart_policy": "unless-stopped",
+      "title": "UniFi Video",
+      "type": 1,
+      "volumes": [
+        {
+          "bind": "/portainer/Files/AppData/Config/UnifFiVideo/Recordings/",
+          "container": "/recordings"
+        },
+        {
+          "bind": "/portainer/Files/AppData/Config/UniFiVideo/",
+          "container": "/config"
+        }
+      ],
+      "maintainer": " https://github.com/SelfhostedPro/selfhosted_templates/"
+    },
+    {
+      "id": 204,
+      "categories": [
+        "Messenger"
+      ],
+      "description": "ZNC is an IRC network bouncer or BNC. It can detach the client from the actual IRC server, and also from selected channels. Multiple clients from different locations can connect to a single ZNC account simultaneously and therefore appear under the same nickname on IRC.",
+      "env": [
+        {
+          "default": "1000",
+          "label": "PUID",
+          "name": "PUID"
+        },
+        {
+          "default": "100",
+          "label": "PGID",
+          "name": "PGID"
+        }
+      ],
+      "image": "linuxserver/znc:latest",
+      "logo": "https://raw.githubusercontent.com/SelfhostedPro/selfhosted_templates/master/Images/znc-icon.png",
+      "name": "znc",
+      "platform": "linux",
+      "ports": [
+        "6501:6501/tcp"
+      ],
+      "restart_policy": "unless-stopped",
+      "title": "ZNC",
+      "type": 1,
+      "volumes": [
+        {
+          "bind": "/portainer/Files/AppData/Config/ZNC",
+          "container": "/config"
+        }
+      ],
+      "maintainer": " https://github.com/SelfhostedPro/selfhosted_templates/"
+    },
+    {
+      "id": 205,
+      "categories": [
+        "Other",
+        "Vpn",
+        "Tools"
+      ],
+      "description": "This container contains OpenVPN and Deluge with a configuration where Deluge is running only when OpenVPN has an active tunnel. It bundles configuration files for many popular VPN providers to make the setup easier.",
+      "env": [
+        {
+          "default": "1001",
+          "label": "PUID",
+          "name": "PUID"
+        },
+        {
+          "default": "1001",
+          "label": "PGID",
+          "name": "PUID"
+        },
+        {
+          "default": "MULLVAD",
+          "description": "see https://github.com/sgtsquiggs/docker-deluge-openvpn",
+          "label": "OPENVPN_PROVIDER",
+          "name": "OPENVPN_PROVIDER"
+        },
+        {
+          "label": "OPENVPN_USERNAME",
+          "name": "OPENVPN_USERNAME"
+        },
+        {
+          "label": "OPENVPN_PASSWORD",
+          "name": "OPENVPN_PASSWORD"
+        }
+      ],
+      "image": "sgtsquiggs/deluge-openvpn:latest",
+      "name": "deluge-openvpn",
+      "platform": "linux",
+      "ports": [
+        "8112:8112/tcp"
+      ],
+      "restart_policy": "unless-stopped",
+      "title": "Deluge openvpn",
+      "type": 1,
+      "volumes": [
+        {
+          "bind": "/etc/localtime",
+          "container": "/etc/localtime"
+        },
+        {
+          "bind": "/portainer/Downloads",
+          "container": "/downloads"
+        },
+        {
+          "bind": "/portainer/Files/AppData/Config/DelugeOpenVPN/config",
+          "container": "/config"
+        }
+      ],
+      "maintainer": " https://github.com/SelfhostedPro/selfhosted_templates/"
+    },
+    {
+      "id": 206,
+      "categories": [
+        "Security"
+      ],
+      "description": "Dradis Framework: Collaboration and reporting for IT Security teams http://dradisframework.org",
+      "image": "raesene/dradis:latest",
+      "logo": "https://raw.githubusercontent.com/SelfhostedPro/selfhosted_templates/master/Images/dradis-logo.png",
+      "name": "dradis",
+      "platform": "linux",
+      "ports": [
+        "3000:3000/tcp"
+      ],
+      "restart_policy": "unless-stopped",
+      "title": "Dradis",
+      "type": 1,
+      "maintainer": " https://github.com/SelfhostedPro/selfhosted_templates/"
+    },
+    {
+      "id": 207,
+      "categories": [
+        "Other",
+        "Tools"
+      ],
+      "description": "AdGuard Home is a network-wide software for blocking ads & tracking.",
+      "image": "adguard/adguardhome:latest",
+      "logo": "https://developer.asustor.com/uploadIcons/0020_999_1595573028_AdGuardhome_256.png",
+      "name": "Adguardhome",
+      "platform": "linux",
+      "ports": [
+        "53:53/tcp",
+        "53:53/udp",
+        "67:67/udp",
+        "80:80/tcp",
+        "443:443/tcp",
+        "443:443/udp",
+        "3001:3000/tcp",
+        "853:853/tcp",
+        "784:784/udp",
+        "853:853/udp",
+        "8853:8853/udp",
+        "5443:5443/tcp",
+        "5443:5443/udp"
+      ],
+      "restart_policy": "unless-stopped",
+      "title": "Adguardhome",
+      "type": 1,
+      "volumes": [
+        {
+          "bind": "/portainer/Files/AppData/Config/AdguardHome/config",
+          "container": "/opt/adguardhome/conf"
+        },
+        {
+          "bind": "/portainer/Files/AppData/Config/AdguardHome/work",
+          "container": "/opt/adguardhome/work"
+        }
+      ],
+      "note": "<b>Template created by Pi-Hosted Series</b><br><b>Check our Github page: <a href=\"https://github.com/pi-hosted/pi-hosted\" target=\"_blank\">https://github.com/pi-hosted/pi-hosted</a></b><br><br><b>Official Webpage: </b><a href=\"https://adguard.com/en/adguard-home/overview.html\" target=\"_blank\">https://adguard.com/en/adguard-home/overview.html</a><br><b>Official Docker Documentation: </b><a href=\"https://github.com/AdguardTeam/AdGuardHome/wiki/Docker\" target=\"_blank\">https://github.com/AdguardTeam/AdGuardHome/wiki/Docker</a><br><br><br>",
+      "maintainer": " https://github.com/novaspirit/pi-hosted/"
+    },
+    {
+      "id": 208,
+      "categories": [
+        "Other",
+        "Tools"
+      ],
+      "description": "Alpine xfce4 novnc",
+      "image": "novaspirit/alpine_xfce4_novnc:latest",
+      "logo": "https://raw.githubusercontent.com/pi-hosted/pi-hosted/master/images/novnc.png",
+      "name": "alpine-xfce4-novnc",
+      "note": "<b>Template created by Pi-Hosted Series</b><br><b>Check our Github page: <a href=\"https://github.com/pi-hosted/pi-hosted\" target=\"_blank\">https://github.com/pi-hosted/pi-hosted</a></b><br><br><b>Official Webpage: </b><a href=\"https://github.com/novaspirit/Alpine_xfce4_noVNC\" target=\"_blank\">https://github.com/novaspirit/Alpine_xfce4_noVNC</a><br><b>Official Docker Documentation: </b><a href=\"https://github.com/novaspirit/Alpine_xfce4_noVNC\" target=\"_blank\">https://github.com/novaspirit/Alpine_xfce4_noVNC</a><br><br><br>Default username/password will be alpine/alpine.",
+      "platform": "linux",
+      "ports": [
+        "6080:6080/tcp",
+        "56780:56780/tcp"
+      ],
+      "restart_policy": "unless-stopped",
+      "title": "Alpine Xfce4 noVNC",
+      "type": 1,
+      "volumes": [
+        {
+          "bind": "/portainer/Files/AppData/Config/alpine-xfce4-novnc/home/alpine/downloads",
+          "container": "/home/alpine/downloads"
+        }
+      ],
+      "maintainer": " https://github.com/novaspirit/pi-hosted/"
+    },
+    {
+      "id": 209,
+      "categories": [
+        "Web",
+        "Proxy"
+      ],
+      "description": "The Apache HTTP Server is a free and open-source cross-platform web server software, released under the terms of Apache License 2.0. Apache is developed and maintained by an open community of developers under the auspices of the Apache Software Foundation.",
+      "env": [
+        {
+          "default": "1000",
+          "label": "PUID",
+          "name": "PUID"
+        },
+        {
+          "default": "1000",
+          "label": "PGID",
+          "name": "PGID"
+        }
+      ],
+      "image": "httpd:latest",
+      "logo": "https://raw.githubusercontent.com/pi-hosted/pi-hosted/master/images/apache-httpd.png",
+      "name": "apache-httpd",
+      "platform": "linux",
+      "ports": [
+        "8080:80/tcp",
+        "8443:443/tcp"
+      ],
+      "restart_policy": "unless-stopped",
+      "title": "Apache Httpd",
+      "type": 1,
+      "volumes": [
+        {
+          "bind": "/portainer/Files/AppData/Config/apache-httpd",
+          "container": "/usr/local/apache2/htdocs/"
+        }
+      ],
+      "note": "<b>Template created by Pi-Hosted Series</b><br><b>Check our Github page: <a href=\"https://github.com/pi-hosted/pi-hosted\" target=\"_blank\">https://github.com/pi-hosted/pi-hosted</a></b><br><br><b>Official Webpage: </b><a href=\"https://httpd.apache.org/\" target=\"_blank\">https://httpd.apache.org/</a><br><b>Official Docker Documentation: </b><a href=\"https://hub.docker.com/_/httpd\" target=\"_blank\">https://hub.docker.com/_/httpd</a><br><br><br>",
+      "maintainer": " https://github.com/novaspirit/pi-hosted/"
+    },
+    {
+      "id": 210,
+      "categories": [
+        "Other",
+        "Tools",
+        "Games"
+      ],
+      "description": "C# application with primary purpose of farming Steam cards from multiple accounts simultaneously.",
+      "env": [
+        {
+          "default": "1000",
+          "label": "PUID",
+          "name": "PUID"
+        },
+        {
+          "default": "1000",
+          "label": "PGID",
+          "name": "PGID"
+        }
+      ],
+      "image": "justarchi/archisteamfarm:latest",
+      "logo": "https://raw.githubusercontent.com/JustArchiNET/ArchiSteamFarm/main/resources/ASF_184x184.png",
+      "name": "archisteamfarm",
+      "platform": "linux",
+      "ports": [
+        "1242:1242/tcp"
+      ],
+      "restart_policy": "unless-stopped",
+      "title": "ArchiSteamFarm",
+      "type": 1,
+      "volumes": [
+        {
+          "bind": "/portainer/Files/AppData/Config/ArchiSteamFarm/config",
+          "container": "/app/config"
+        },
+        {
+          "bind": "/portainer/Files/AppData/Config/ArchiSteamFarm/plugins",
+          "container": "/app/plugins"
+        },
+        {
+          "bind": "/portainer/Files/AppData/Config/ArchiSteamFarm/logs",
+          "container": "/app/logs"
+        }
+      ],
+      "note": "<b>Template created by Pi-Hosted Series</b><br><b>Check our Github page: <a href=\"https://github.com/pi-hosted/pi-hosted\" target=\"_blank\">https://github.com/pi-hosted/pi-hosted</a></b><br><br><b>Official Webpage: </b><a href=\"https://github.com/JustArchiNET/ArchiSteamFarm/\" target=\"_blank\">https://github.com/JustArchiNET/ArchiSteamFarm/</a><br><b>Official Docker Documentation: </b><a href=\"https://github.com/JustArchiNET/ArchiSteamFarm/wiki/Docker/\" target=\"_blank\">https://github.com/JustArchiNET/ArchiSteamFarm/wiki/Docker/</a><br><br><br>",
+      "maintainer": " https://github.com/novaspirit/pi-hosted/"
+    },
+    {
+      "id": 211,
+      "categories": [
+        "Other",
+        "Tools"
+      ],
+      "description": "ArchiveBox is a powerful, self-hosted internet archiving solution to collect, save, and view sites you want to preserve offline.",
+      "env": [
+        {
+          "default": "*",
+          "label": "ALLOWED_HOSTS",
+          "name": "ALLOWED_HOSTS"
+        },
+        {
+          "default": "750m",
+          "label": "MEDIA_MAX_SIZE",
+          "name": "MEDIA_MAX_SIZE"
+        },
+        {
+          "default": "true",
+          "label": "PUBLIC_INDEX",
+          "name": "PUBLIC_INDEX"
+        },
+        {
+          "default": "true",
+          "label": "PUBLIC_SNAPSHOTS",
+          "name": "PUBLIC_SNAPSHOTS"
+        },
+        {
+          "default": "false",
+          "label": "PUBLIC_ADD_VIEW",
+          "name": "PUBLIC_ADD_VIEW"
+        }
+      ],
+      "image": "archivebox/archivebox:latest",
+      "logo": "https://raw.githubusercontent.com/pi-hosted/pi-hosted/master/images/archivebox.png",
+      "name": "archivebox",
+      "note": "<b>Template created by Pi-Hosted Series</b><br><b>Check our Github page: <a href=\"https://github.com/pi-hosted/pi-hosted\" target=\"_blank\">https://github.com/pi-hosted/pi-hosted</a></b><br><br><b>Official Webpage: </b><a href=\"https://archivebox.io/\" target=\"_blank\">https://archivebox.io/</a><br><b>Official Docker Documentation: </b><a href=\"https://github.com/ArchiveBox/ArchiveBox/wiki/Docker\" target=\"_blank\">https://github.com/ArchiveBox/ArchiveBox/wiki/Docker</a><br><br><br>By default an admin user is not created. You can do so by launching a shell in the container and executing 'archivebox manage createsuperuser'. Documentation is Available <a href='https://github.com/ArchiveBox/ArchiveBox/wiki'>here</a>.",
+      "platform": "linux",
+      "ports": [
+        "8002:8000/tcp"
+      ],
+      "restart_policy": "unless-stopped",
+      "title": "Archivebox",
+      "type": 1,
+      "volumes": [
+        {
+          "bind": "/portainer/Files/AppData/Config/archivebox",
+          "container": "/data"
+        }
+      ],
+      "maintainer": " https://github.com/novaspirit/pi-hosted/"
+    },
+    {
+      "id": 212,
+      "categories": [
+        "Downloader"
+      ],
+      "description": "AriaNg is a modern web frontend making aria2 easier to use. AriaNg is written in pure html & javascript, thus it does not need any compilers or runtime environment. You can just put AriaNg in your web server and open it in your browser. AriaNg uses responsive layout, and supports any desktop or mobile devices.",
+      "env": [
+        {
+          "default": "1000",
+          "label": "PUID",
+          "name": "PUID"
+        },
+        {
+          "default": "1000",
+          "label": "PGID",
+          "name": "PGID"
+        },
+        {
+          "default": "443",
+          "label": "ARIA2RPCPORT",
+          "name": "ARIA2RPCPORT"
+        }
+      ],
+      "image": "hurlenko/aria2-ariang:latest",
+      "logo": "https://raw.githubusercontent.com/pi-hosted/pi-hosted/master/images/ariang.png",
+      "name": "AriaNG",
+      "platform": "linux",
+      "ports": [
+        "8080:8080/tcp"
+      ],
+      "restart_policy": "unless-stopped",
+      "title": "AriaNG",
+      "type": 1,
+      "volumes": [
+        {
+          "bind": "/portainer/Files/AppData/Config/AriaNG",
+          "container": "/aria2/conf"
+        },
+        {
+          "bind": "/portainer/Downloads",
+          "container": "/aria2/data"
+        }
+      ],
+      "note": "<b>Template created by Pi-Hosted Series</b><br><b>Check our Github page: <a href=\"https://github.com/pi-hosted/pi-hosted\" target=\"_blank\">https://github.com/pi-hosted/pi-hosted</a></b><br><br><b>Official Webpage: </b><a href=\"https://github.com/hurlenko/aria2-ariang-docker\" target=\"_blank\">https://github.com/hurlenko/aria2-ariang-docker</a><br><b>Official Docker Documentation: </b><a href=\"https://github.com/hurlenko/aria2-ariang-docker\" target=\"_blank\">https://github.com/hurlenko/aria2-ariang-docker</a><br><br><br>",
+      "maintainer": " https://github.com/novaspirit/pi-hosted/"
+    },
+    {
+      "id": 213,
+      "categories": [
+        "Tools",
+        "Web",
+        "Webserver"
+      ],
+      "description": "Caddy - The Ultimate Server with Automatic HTTPS.  Need to run tools/install_caddy.sh before installing the template.",
+      "image": "caddy:latest",
+      "logo": "https://raw.githubusercontent.com/pi-hosted/pi-hosted/master/images/caddy.png",
+      "name": "caddy",
+      "note": "<b>Template created by Pi-Hosted Series</b><br><b>Check our Github page: <a href=\"https://github.com/pi-hosted/pi-hosted\" target=\"_blank\">https://github.com/pi-hosted/pi-hosted</a></b><br><br><b>Official Webpage: </b><a href=\"https://caddyserver.com/\" target=\"_blank\">https://caddyserver.com/</a><br><b>Official Docker Documentation: </b><a href=\"https://hub.docker.com/_/caddy\" target=\"_blank\">https://hub.docker.com/_/caddy</a><br><br><h3><b><a href=\"https://github.com/pi-hosted/pi-hosted/blob/master/tools/install_caddy.sh\" target=\"_blank\">Pre-installation script</a> must be RAN before you install: </b>wget -qO- https://raw.githubusercontent.com/pi-hosted/pi-hosted/master/tools/install_caddy.sh | bash</h3><br><br>Caddy 2 is a powerful, enterprise-ready, open source web server with automatic HTTPS written in Go",
+      "platform": "linux",
+      "ports": [
+        "80:80/tcp",
+        "443:443/tcp",
+        "2019:2019/tcp"
+      ],
+      "restart_policy": "unless-stopped",
+      "title": "Caddy",
+      "type": 1,
+      "volumes": [
+        {
+          "bind": "/portainer/Files/AppData/Config/Caddy/Data",
+          "container": "/data"
+        },
+        {
+          "bind": "/portainer/Files/AppData/Config/Caddy/Config",
+          "container": "/config"
+        },
+        {
+          "bind": "/portainer/Files/AppData/Config/Caddy/Caddyfile",
+          "container": "/etc/caddy/Caddyfile"
+        }
+      ],
+      "maintainer": " https://github.com/novaspirit/pi-hosted/"
+    },
+    {
+      "id": 214,
+      "categories": [
+        "Other",
+        "Tools"
+      ],
+      "description": "chrony is a versatile implementation of the Network Time Protocol (NTP). It can synchronise the system clock with NTP servers, reference clocks (e.g. GPS receiver), and manual input using wristwatch and keyboard. It can also operate as an NTPv4 (RFC 5905) server and peer to provide a time service to other computers in the network.",
+      "env": [
+        {
+          "default": "0",
+          "label": "LOG_LEVEL",
+          "name": "LOG_LEVEL"
+        },
+        {
+          "description": "Additional Example: time1.google.com,time2.google.com,time3.google.com,time4.google.com",
+          "default": "time.cloudflare.com",
+          "label": "NTP_SERVERS",
+          "name": "NTP_SERVERS"
+        }
+      ],
+      "image": "cturra/ntp:latest",
+      "logo": "https://raw.githubusercontent.com/pi-hosted/pi-hosted/master/images/chrony.png",
+      "name": "chrony-ntp",
+      "platform": "linux",
+      "ports": [
+        "123:123/udp"
+      ],
+      "restart_policy": "unless-stopped",
+      "title": "Chrony NTP",
+      "type": 1,
+      "note": "<b>Template created by Pi-Hosted Series</b><br><b>Check our Github page: <a href=\"https://github.com/pi-hosted/pi-hosted\" target=\"_blank\">https://github.com/pi-hosted/pi-hosted</a></b><br><br><b>Official Webpage: </b><a href=\"https://github.com/cturra/docker-ntp\" target=\"_blank\">https://github.com/cturra/docker-ntp</a><br><b>Official Docker Documentation: </b><a href=\"https://github.com/cturra/docker-ntp/blob/main/README.md\" target=\"_blank\">https://github.com/cturra/docker-ntp/blob/main/README.md</a><br><br><br>",
+      "maintainer": " https://github.com/novaspirit/pi-hosted/"
+    },
+    {
+      "id": 215,
+      "categories": [
+        "Other",
+        "Anitvirus"
+      ],
+      "description": "ClamAV® is an open source antivirus engine for detecting trojans, viruses, malware & other malicious threats.",
+      "image": "mkodockx/docker-clamav:alpine",
+      "logo": "http://www.clamav.net/assets/clamav-trademark.png",
+      "name": "clamav",
+      "platform": "linux",
+      "ports": [
+        "3310:3310/tcp"
+      ],
+      "restart_policy": "unless-stopped",
+      "title": "Clamav",
+      "type": 1,
+      "volumes": [
+        {
+          "bind": "/etc/timezone",
+          "container": "/etc/timezone"
+        },
+        {
+          "bind": "/etc/localtime",
+          "container": "/etc/localtime"
+        },
+        {
+          "bind": "/portainer/Files/AppData/Config/clamav/config",
+          "container": "/etc/clamav"
+        },
+        {
+          "bind": "/portainer/Files/AppData/Config/clamav/virus_definitions",
+          "container": "/var/lib/clamav"
+        }
+      ],
+      "note": "<b>Template created by Pi-Hosted Series</b><br><b>Check our Github page: <a href=\"https://github.com/pi-hosted/pi-hosted\" target=\"_blank\">https://github.com/pi-hosted/pi-hosted</a></b><br><br><b>Official Webpage: </b><a href=\"https://docs.clamav.net/\" target=\"_blank\">https://docs.clamav.net/</a><br><b>Official Docker Documentation: </b><a href=\"https://hub.docker.com/r/mkodockx/docker-clamav\" target=\"_blank\">https://hub.docker.com/r/mkodockx/docker-clamav</a><br><br><h3><b><a href=\"https://github.com/pi-hosted/pi-hosted/blob/master/tools/install_clamav.sh\" target=\"_blank\">Pre-installation script</a> must be RAN before you install: </b>wget -qO- https://raw.githubusercontent.com/pi-hosted/pi-hosted/master/tools/install_clamav.sh | bash</h3><br><br>",
+      "maintainer": " https://github.com/novaspirit/pi-hosted/"
+    },
+    {
+      "id": 216,
+      "categories": [
+        "Dns",
+        "Tools"
+      ],
+      "description": "A robust Cloudflare DDNS updater with a small footprint. The program will detect your machine's public IP addresses and update DNS records using the Cloudflare API.",
+      "env": [
+        {
+          "default": "",
+          "label": "CLOUDFLARE_API_TOKEN",
+          "name": "CLOUDFLARE_API_TOKEN"
+        },
+        {
+          "default": "",
+          "label": "DOMAINS (Comma Separated List)",
+          "name": "DOMAINS"
+        },
+        {
+          "default": "true",
+          "label": "PROXIED",
+          "name": "PROXIED"
+        }
+      ],
+      "image": "favonia/cloudflare-ddns:latest",
+      "logo": "https://raw.githubusercontent.com/pi-hosted/pi-hosted/master/images/cloudflare-ddns.png",
+      "name": "cloudflare-ddns",
+      "platform": "linux",
+      "restart_policy": "unless-stopped",
+      "title": "Cloudflare DDNS",
+      "type": 1,
+      "note": "<b>Template created by Pi-Hosted Series</b><br><b>Check our Github page: <a href=\"https://github.com/pi-hosted/pi-hosted\" target=\"_blank\">https://github.com/pi-hosted/pi-hosted</a></b><br><br><b>Official Webpage: </b><a href=\"https://www.cloudflare.com/en-gb/learning/dns/glossary/dynamic-dns/\" target=\"_blank\">https://www.cloudflare.com/en-gb/learning/dns/glossary/dynamic-dns/</a><br><b>Official Docker Documentation: </b><a href=\"https://github.com/favonia/cloudflare-ddns/\" target=\"_blank\">https://github.com/favonia/cloudflare-ddns/</a><br><br><br>",
+      "maintainer": " https://github.com/novaspirit/pi-hosted/"
+    },
+    {
+      "id": 217,
+      "categories": [
+        "Tool"
+      ],
+      "description": "DaVinci Resolve Postgresql Server, Davinci requires a specific version of postgres db, this container will install the version needed",
+      "env": [
+        {
+          "default": "1000",
+          "label": "PUID",
+          "name": "PUID"
+        },
+        {
+          "default": "1000",
+          "label": "PGID",
+          "name": "PGID"
+        },
+        {
+          "default": "database",
+          "label": "POSTGRES_DB",
+          "name": "POSTGRES_DB"
+        },
+        {
+          "default": "postgres",
+          "label": "POSTGRES_USER",
+          "name": "POSTGRES_USER"
+        },
+        {
+          "default": "DaVinci",
+          "label": "POSTGRES_PASSWORD",
+          "name": "POSTGRES_PASSWORD"
+        },
+        {
+          "default": "America/New_York",
+          "label": "TZ",
+          "name": "TZ"
+        }
+      ],
+      "image": "postgres:13",
+      "logo": "https://raw.githubusercontent.com/pi-hosted/pi-hosted/master/images/resolve.png",
+      "name": "DaVinci Postgres Server",
+      "platform": "linux",
+      "ports": [
+        "5432:5432/tcp"
+      ],
+      "restart_policy": "unless-stopped",
+      "title": "DaVinci Postgres Server",
+      "type": 1,
+      "volumes": [
+        {
+          "bind": "/portainer/Files/AppData/Config/DavinciServer/",
+          "container": "/var/lib/postgresql/data"
+        }
+      ],
+      "note": "<b>Template created by Pi-Hosted Series</b><br><b>Check our Github page: <a href=\"https://github.com/pi-hosted/pi-hosted\" target=\"_blank\">https://github.com/pi-hosted/pi-hosted</a></b><br><br><b>Official Webpage: </b><a href=\"https://raw.githubusercontent.com/pi-hosted/pi-hosted/master/docs/davinci.md\" target=\"_blank\">https://raw.githubusercontent.com/pi-hosted/pi-hosted/master/docs/davinci.md</a><br><b>Official Docker Documentation: </b><a href=\"https://raw.githubusercontent.com/pi-hosted/pi-hosted/master/docs/davinci.md\" target=\"_blank\">https://raw.githubusercontent.com/pi-hosted/pi-hosted/master/docs/davinci.md</a><br><br><br>",
+      "maintainer": " https://github.com/novaspirit/pi-hosted/"
+    },
+    {
+      "id": 218,
+      "categories": [
+        "Other",
+        "Tools"
+      ],
+      "description": "Eclipse Mosquitto is an open source message broker that implements the MQTT protocol versions 5.0, 3.1.1 and 3.1. Mosquitto is lightweight and is suitable for use on all devices from low power single board computers to full servers.\r\nHave a look on https://mosquitto.org/man/mosquitto_passwd-1.html",
+      "image": "eclipse-mosquitto:latest",
+      "logo": "https://raw.githubusercontent.com/pi-hosted/pi-hosted/master/images/eclipse-mosquitto.png",
+      "name": "eclipse-mosquitto",
+      "platform": "linux",
+      "ports": [
+        "1883:1883/tcp",
+        "9001:9001/tcp"
+      ],
+      "restart_policy": "unless-stopped",
+      "title": "Eclipse Mosquitto MQTT",
+      "type": 1,
+      "volumes": [
+        {
+          "bind": "/portainer/Files/AppData/Config/eclipse-mosquitto/config",
+          "container": "/mosquitto/config"
+        },
+        {
+          "bind": "/portainer/Files/AppData/Config/eclipse-mosquitto/data",
+          "container": "/mosquitto/data"
+        },
+        {
+          "bind": "/portainer/Files/AppData/Config/eclipse-mosquitto/log",
+          "container": "/mosquitto/log"
+        }
+      ],
+      "note": "<b>Template created by Pi-Hosted Series</b><br><b>Check our Github page: <a href=\"https://github.com/pi-hosted/pi-hosted\" target=\"_blank\">https://github.com/pi-hosted/pi-hosted</a></b><br><br><b>Official Webpage: </b><a href=\"https://mosquitto.org/\" target=\"_blank\">https://mosquitto.org/</a><br><b>Official Docker Documentation: </b><a href=\"https://mosquitto.org/\" target=\"_blank\">https://mosquitto.org/</a><br><br><h3><b><a href=\"https://github.com/pi-hosted/pi-hosted/blob/master/tools/install_mosquitto.sh\" target=\"_blank\">Pre-installation script</a> must be RAN before you install: </b>wget -qO- https://raw.githubusercontent.com/pi-hosted/pi-hosted/master/tools/install_mosquitto.sh | bash</h3><br><br>",
+      "maintainer": " https://github.com/novaspirit/pi-hosted/"
+    },
+    {
+      "id": 219,
+      "categories": [
+        "Other",
+        "Tools"
+      ],
+      "description": "Web File Browser which can be used as a middleware or standalone app.",
+      "image": "filebrowser/filebrowser:latest",
+      "logo": "https://raw.githubusercontent.com/pi-hosted/pi-hosted/master/images/filebrowser.png",
+      "name": "filebrowser-latest",
+      "note": "<b>Template created by Pi-Hosted Series</b><br><b>Check our Github page: <a href=\"https://github.com/pi-hosted/pi-hosted\" target=\"_blank\">https://github.com/pi-hosted/pi-hosted</a></b><br><br><b>Official Webpage: </b><a href=\"https://filebrowser.org/\" target=\"_blank\">https://filebrowser.org/</a><br><b>Official Docker Documentation: </b><a href=\"https://filebrowser.org/installation#docker\" target=\"_blank\">https://filebrowser.org/installation#docker</a><br><br><br><b>Youtube Video: </b><a href=https://www.youtube.com/watch?v=30MYRgCObu8&list=PL846hFPMqg3jwkxcScD1xw2bKXrJVvarc&index=4 target=\"_blank\">Novaspirit Tech - Installing JDownloader and File Browser On The Pi Docker Server</a><br><br>The default user and password is admin/admin.",
+      "platform": "linux",
+      "ports": [
+        "8082:80/tcp"
+      ],
+      "restart_policy": "unless-stopped",
+      "title": "FileBrowser latest",
+      "type": 1,
+      "volumes": [
+        {
+          "bind": "/portainer/Downloads",
+          "container": "/srv"
+        },
+        {
+          "bind": "/portainer/Files/AppData/Config/filebrowser/filebrowser.db",
+          "container": "/database/filebrowser.db"
+        },
+        {
+          "bind": "/portainer/Files/AppData/Config/filebrowser/settings.json",
+          "container": "/config/settings.json"
+        }
+      ],
+      "maintainer": " https://github.com/novaspirit/pi-hosted/"
+    },
+    {
+      "id": 220,
+      "categories": [
+        "Other",
+        "Tools"
+      ],
+      "description": "[arm][s6-version] Web File Browser which can be used as a middleware or standalone app.",
+      "image": "filebrowser/filebrowser:s6",
+      "logo": "https://raw.githubusercontent.com/pi-hosted/pi-hosted/master/images/filebrowser.png",
+      "name": "filebrowser",
+      "note": "<b>Template created by Pi-Hosted Series</b><br><b>Check our Github page: <a href=\"https://github.com/pi-hosted/pi-hosted\" target=\"_blank\">https://github.com/pi-hosted/pi-hosted</a></b><br><br><b>Official Webpage: </b><a href=\"https://filebrowser.org/\" target=\"_blank\">https://filebrowser.org/</a><br><b>Official Docker Documentation: </b><a href=\"https://filebrowser.org/installation#docker\" target=\"_blank\">https://filebrowser.org/installation#docker</a><br><br><br><b>Youtube Video: </b><a href=https://www.youtube.com/watch?v=30MYRgCObu8&list=PL846hFPMqg3jwkxcScD1xw2bKXrJVvarc&index=4 target=\"_blank\">Novaspirit Tech - Installing JDownloader and File Browser On The Pi Docker Server</a><br><br>The default user and password is admin/admin.",
+      "platform": "linux",
+      "env": [
+        {
+          "default": "1000",
+          "label": "PUID",
+          "name": "PUID"
+        },
+        {
+          "default": "1000",
+          "label": "PGID",
+          "name": "PGID"
+        }
+      ],
+      "ports": [
+        "8082:80/tcp"
+      ],
+      "restart_policy": "unless-stopped",
+      "title": "FileBrowser S6",
+      "type": 1,
+      "volumes": [
+        {
+          "bind": "/portainer/Downloads",
+          "container": "/srv"
+        },
+        {
+          "bind": "/portainer/Files/AppData/Config/filebrowser/filebrowser.db",
+          "container": "/database/filebrowser.db"
+        },
+        {
+          "bind": "/portainer/Files/AppData/Config/filebrowser/settings.json",
+          "container": "/config/settings.json"
+        }
+      ],
+      "maintainer": " https://github.com/novaspirit/pi-hosted/"
+    },
+    {
+      "id": 221,
+      "categories": [
+        "Other",
+        "Tools"
+      ],
+      "description": "Flame is self-hosted startpage for your server. Its design is inspired (heavily) by SUI. Flame is very easy to setup and use. With built-in editors, it allows you to setup your very own application hub in no time - no file editing necessary.",
+      "env": [
+        {
+          "default": "",
+          "label": "Flame Password",
+          "name": "PASSWORD"
+        }
+      ],
+      "image": "pawelmalak/flame:multiarch",
+      "logo": "https://raw.githubusercontent.com/pi-hosted/pi-hosted/master/images/flame.png",
+      "name": "Flame",
+      "platform": "linux",
+      "ports": [
+        "5005:5005/tcp"
+      ],
+      "restart_policy": "unless-stopped",
+      "title": "Flame",
+      "type": 1,
+      "volumes": [
+        {
+          "bind": "/portainer/Files/AppData/Config/Flame/data",
+          "container": "/app/data"
+        },
+        {
+          "bind": "/var/run/docker.sock",
+          "container": "/var/run/docker.sock"
+        }
+      ],
+      "note": "<b>Template created by Pi-Hosted Series</b><br><b>Check our Github page: <a href=\"https://github.com/pi-hosted/pi-hosted\" target=\"_blank\">https://github.com/pi-hosted/pi-hosted</a></b><br><br><b>Official Webpage: </b><a href=\"https://github.com/pawelmalak/flame\" target=\"_blank\">https://github.com/pawelmalak/flame</a><br><b>Official Docker Documentation: </b><a href=\"https://github.com/pawelmalak/flame#with-docker-recommended\" target=\"_blank\">https://github.com/pawelmalak/flame#with-docker-recommended</a><br><br><br>",
+      "maintainer": " https://github.com/novaspirit/pi-hosted/"
+    },
+    {
+      "id": 222,
+      "categories": [
+        "Other",
+        "Tools"
+      ],
+      "description": "FlareSolverr is a proxy server to bypass Cloudflare and DDoS-GUARD protection.",
+      "env": [
+        {
+          "default": "info",
+          "label": "LOG_LEVEL",
+          "name": "LOG_LEVEL"
+        },
+        {
+          "default": "false",
+          "label": "LOG_HTML",
+          "name": "LOG_HTML"
+        },
+        {
+          "default": "none",
+          "label": "CAPTCHA_SOLVER",
+          "name": "CAPTCHA_SOLVER"
+        },
+        {
+          "default": "America/New_York",
+          "label": "TZ",
+          "name": "TZ"
+        }
+      ],
+      "image": "ghcr.io/flaresolverr/flaresolverr:latest",
+      "logo": "https://raw.githubusercontent.com/FlareSolverr/FlareSolverr/c48d342b9cfb65d7696b96e9867fcff0ae87a0e2/resources/flaresolverr_logo.svg",
+      "name": "FlareSolverr",
+      "platform": "linux",
+      "ports": [
+        "8191:8191/tcp"
+      ],
+      "restart_policy": "unless-stopped",
+      "title": "FlareSolverr",
+      "type": 1,
+      "note": "<b>Template created by Pi-Hosted Series</b><br><b>Check our Github page: <a href=\"https://github.com/pi-hosted/pi-hosted\" target=\"_blank\">https://github.com/pi-hosted/pi-hosted</a></b><br><br><b>Official Docker Documentation: </b><a href=\"https://github.com/FlareSolverr/FlareSolverr#installation\" target=\"_blank\">https://github.com/FlareSolverr/FlareSolverr#installation</a><br><br><br>",
+      "maintainer": " https://github.com/novaspirit/pi-hosted/"
+    },
+    {
+      "id": 223,
+      "categories": [
+        "Other",
+        "Games"
+      ],
+      "description": "This docker image provides the FoundryVTT system for hosting your own virtual table top games.",
+      "env": [
+        {
+          "default": "John",
+          "label": "Foundry Account Name",
+          "name": "FOUNDRY_USERNAME"
+        },
+        {
+          "default": "password",
+          "label": "Foundry Password",
+          "name": "FOUNDRY_PASSWORD"
+        },
+        {
+          "default": "changeme",
+          "label": "Instance Admin Password",
+          "name": "FOUNDRY_ADMIN_KEY"
+        },
+        {
+          "default": "true",
+          "label": "CONTAINER_PRESERVE_CONFIG",
+          "name": "CONTAINER_PRESERVE_CONFIG"
+        }
+      ],
+      "image": "felddy/foundryvtt:release",
+      "logo": "https://raw.githubusercontent.com/pi-hosted/pi-hosted/master/images/foundrylogo.png",
+      "name": "FoundryVTT",
+      "platform": "linux",
+      "ports": [
+        "30000:30000/tcp"
+      ],
+      "restart_policy": "unless-stopped",
+      "title": "FoundryVTT Server",
+      "type": 1,
+      "volumes": [
+        {
+          "bind": "/portainer/Files/AppData/Config/foundryvtt",
+          "container": "/data"
+        }
+      ],
+      "note": "<b>Template created by Pi-Hosted Series</b><br><b>Check our Github page: <a href=\"https://github.com/pi-hosted/pi-hosted\" target=\"_blank\">https://github.com/pi-hosted/pi-hosted</a></b><br><br><b>Official Webpage: </b><a href=\"https://foundryvtt.com/\" target=\"_blank\">https://foundryvtt.com/</a><br><b>Official Docker Documentation: </b><a href=\"https://hub.docker.com/r/felddy/foundryvtt\" target=\"_blank\">https://hub.docker.com/r/felddy/foundryvtt</a><br><br><br>",
+      "maintainer": " https://github.com/novaspirit/pi-hosted/"
+    },
+    {
+      "id": 224,
+      "categories": [
+        "Other",
+        "Tools"
+      ],
+      "description": "Ghost is a free and open source blogging platform written in JavaScript and distributed under the MIT License, designed to simplify the process of online publishing for individual bloggers as well as online publications.",
+      "env": [
+        {
+          "default": "development",
+          "label": "NODE_ENV",
+          "name": "NODE_ENV"
+        },
+        {
+          "default": "http://localhost/",
+          "label": "url",
+          "name": "url"
+        }
+      ],
+      "image": "ghost:latest",
+      "logo": "https://raw.githubusercontent.com/pi-hosted/pi-hosted/master/images/ghost.png",
+      "name": "ghost",
+      "platform": "linux",
+      "ports": [
+        "2368:2368/tcp"
+      ],
+      "restart_policy": "unless-stopped",
+      "title": "Ghost",
+      "type": 1,
+      "volumes": [
+        {
+          "bind": "/portainer/Files/AppData/Config/Ghost",
+          "container": "/var/lib/ghost/content"
+        }
+      ],
+      "note": "<b>Template created by Pi-Hosted Series</b><br><b>Check our Github page: <a href=\"https://github.com/pi-hosted/pi-hosted\" target=\"_blank\">https://github.com/pi-hosted/pi-hosted</a></b><br><br><b>Official Webpage: </b><a href=\"https://github.com/docker-library/docs/tree/master/ghost\" target=\"_blank\">https://github.com/docker-library/docs/tree/master/ghost</a><br><b>Official Docker Documentation: </b><a href=\"https://hub.docker.com/_/ghost\" target=\"_blank\">https://hub.docker.com/_/ghost</a><br><br><br>",
+      "maintainer": " https://github.com/novaspirit/pi-hosted/"
+    },
+    {
+      "id": 225,
+      "categories": [
+        "Proxy"
+      ],
+      "description": "Simple socks5 server using go-socks5 with authentication options",
+      "image": "serjs/go-socks5-proxy:latest",
+      "logo": "https://raw.githubusercontent.com/pi-hosted/pi-hosted/master/images/socks5.png",
+      "name": "socks5-proxy",
+      "platform": "linux",
+      "ports": [
+        "8080:8080/tcp"
+      ],
+      "restart_policy": "unless-stopped",
+      "title": "Go-Socks5-Proxy",
+      "type": 1,
+      "note": "<b>Template created by Pi-Hosted Series</b><br><b>Check our Github page: <a href=\"https://github.com/pi-hosted/pi-hosted\" target=\"_blank\">https://github.com/pi-hosted/pi-hosted</a></b><br><br><b>Official Webpage: </b><a href=\"https://hub.docker.com/r/serjs/go-socks5-proxy\" target=\"_blank\">https://hub.docker.com/r/serjs/go-socks5-proxy</a><br><b>Official Docker Documentation: </b><a href=\"https://hub.docker.com/r/serjs/go-socks5-proxy\" target=\"_blank\">https://hub.docker.com/r/serjs/go-socks5-proxy</a><br><br><br><b>Youtube Video: </b><a href=https://www.youtube.com/watch?v=IWj1-j2QWvo target=\"_blank\">Novaspirit Tech - Route Docker Traffic Through VPN Container</a><br><br>",
+      "maintainer": " https://github.com/novaspirit/pi-hosted/"
+    },
+    {
+      "id": 226,
+      "categories": [
+        "Other",
+        "Tools"
+      ],
+      "description": "A simple server for sending and receiving messages",
+      "env": [
+        {
+          "default": "America/New_York",
+          "label": "TZ",
+          "name": "TZ"
+        },
+        {
+          "default": "admin",
+          "label": "GOTIFY_DEFAULTUSER_NAME",
+          "name": "GOTIFY_DEFAULTUSER_NAME"
+        },
+        {
+          "default": "admin123",
+          "label": "GOTIFY_DEFAULTUSER_PASS",
+          "name": "GOTIFY_DEFAULTUSER_PASS"
+        }
+      ],
+      "image": "gotify/server-arm7:latest",
+      "logo": "https://raw.githubusercontent.com/pi-hosted/pi-hosted/master/images/gotify.png",
+      "name": "gotify",
+      "note": "<b>Template created by Pi-Hosted Series</b><br><b>Check our Github page: <a href=\"https://github.com/pi-hosted/pi-hosted\" target=\"_blank\">https://github.com/pi-hosted/pi-hosted</a></b><br><br><b>Official Webpage: </b><a href=\"https://gotify.net/\" target=\"_blank\">https://gotify.net/</a><br><b>Official Docker Documentation: </b><a href=\"https://gotify.net/docs/install\" target=\"_blank\">https://gotify.net/docs/install</a><br><br><br>ARM7 Image. Documentation is Available <a href='https://gotify.net/docs/index'>here</a>.",
+      "platform": "linux",
+      "ports": [
+        "9008:80/tcp"
+      ],
+      "restart_policy": "unless-stopped",
+      "title": "Gotify",
+      "type": 1,
+      "volumes": [
+        {
+          "bind": "/portainer/Files/AppData/Config/gotify",
+          "container": "/app/data"
+        }
+      ],
+      "maintainer": " https://github.com/novaspirit/pi-hosted/"
+    },
+    {
+      "id": 227,
+      "categories": [
+        "Tools",
+        "Web",
+        "Other"
+      ],
+      "description": "Homarr is a simple and lightweight homepage for your server, that helps you easily access all of your services in one place.",
+      "note": "<b>Template created by Pi-Hosted Series</b><br><b>Check our Github page: <a href=\"https://github.com/pi-hosted/pi-hosted\" target=\"_blank\">https://github.com/pi-hosted/pi-hosted</a></b><br><br><b>Official Webpage: </b><a href=\"https://homarr.vercel.app/\" target=\"_blank\">https://homarr.vercel.app/</a><br><b>Official Docker Documentation: </b><a href=\"https://github.com/ajnart/homarr\" target=\"_blank\">https://github.com/ajnart/homarr</a><br><br><br>This version is not secured and should only be used if you want Docker integration and you don't worry about users on your network.",
+      "env": [
+        {
+          "default": "1000",
+          "label": "PUID",
+          "name": "PUID"
+        },
+        {
+          "default": "1000",
+          "label": "PGID",
+          "name": "PGID"
+        }
+      ],
+      "image": "ghcr.io/ajnart/homarr:latest",
+      "logo": "https://raw.githubusercontent.com/pi-hosted/pi-hosted/master/images/homarr.png",
+      "name": "homarr",
+      "platform": "linux",
+      "ports": [
+        "7575:7575/tcp"
+      ],
+      "restart_policy": "unless-stopped",
+      "title": "Homarr",
+      "type": 1,
+      "volumes": [
+        {
+          "bind": "/var/run/docker.sock",
+          "container": "/var/run/docker.sock"
+        },
+        {
+          "bind": "/portainer/Files/AppData/Config/Homarr/configs",
+          "container": "/app/data/configs"
+        },
+        {
+          "bind": "/portainer/Files/AppData/Config/Homarr/icons",
+          "container": "/app/public/icons"
+        }
+      ],
+      "maintainer": " https://github.com/novaspirit/pi-hosted/"
+    },
+    {
+      "id": 228,
+      "categories": [
+        "Tools",
+        "Web",
+        "Other"
+      ],
+      "description": "Homarr is a simple and lightweight homepage for your server, that helps you easily access all of your services in one place.",
+      "note": "<b>Template created by Pi-Hosted Series</b><br><b>Check our Github page: <a href=\"https://github.com/pi-hosted/pi-hosted\" target=\"_blank\">https://github.com/pi-hosted/pi-hosted</a></b><br><br><b>Official Webpage: </b><a href=\"https://homarr.vercel.app/\" target=\"_blank\">https://homarr.vercel.app/</a><br><b>Official Docker Documentation: </b><a href=\"https://github.com/ajnart/homarr\" target=\"_blank\">https://github.com/ajnart/homarr</a><br><br><br>This version does not allow for interaction with the docker environment for security purposes.",
+      "env": [
+        {
+          "default": "1000",
+          "label": "PUID",
+          "name": "PUID"
+        },
+        {
+          "default": "1000",
+          "label": "PGID",
+          "name": "PGID"
+        }
+      ],
+      "image": "ghcr.io/ajnart/homarr:latest",
+      "logo": "https://raw.githubusercontent.com/pi-hosted/pi-hosted/master/images/homarr.png",
+      "name": "homarr-secured",
+      "platform": "linux",
+      "ports": [
+        "7575:7575/tcp"
+      ],
+      "restart_policy": "unless-stopped",
+      "title": "Homarr-Secured",
+      "type": 1,
+      "volumes": [
+        {
+          "bind": "/portainer/Files/AppData/Config/Homarr/configs",
+          "container": "/app/data/configs"
+        },
+        {
+          "bind": "/portainer/Files/AppData/Config/Homarr/icons",
+          "container": "/app/public/icons"
+        }
+      ],
+      "maintainer": " https://github.com/novaspirit/pi-hosted/"
+    },
+    {
+      "id": 229,
+      "categories": [
+        "Homeautomation"
+      ],
+      "description": "Homebridge allows you to integrate with smart home devices that do not natively support HomeKit. There are over 2,000 Homebridge plugins supporting thousands of different smart accessories.",
+      "env": [
+        {
+          "default": "1000",
+          "label": "PGID",
+          "name": "PGID"
+        },
+        {
+          "default": "1000",
+          "label": "PUID",
+          "name": "PUID"
+        },
+        {
+          "default": "1",
+          "label": "HOMEBRIDGE_CONFIG_UI",
+          "name": "HOMEBRIDGE_CONFIG_UI"
+        },
+        {
+          "default": "8581",
+          "label": "HOMEBRIDGE_CONFIG_UI_PORT",
+          "name": "HOMEBRIDGE_CONFIG_UI_PORT"
+        },
+        {
+          "default": "America/New_York",
+          "label": "TZ",
+          "name": "TZ"
+        }
+      ],
+      "image": "homebridge/homebridge:latest",
+      "logo": "https://raw.githubusercontent.com/pi-hosted/pi-hosted/master/images/homebridge.png",
+      "name": "homebridge",
+      "network": "host",
+      "note": "<b>Template created by Pi-Hosted Series</b><br><b>Check our Github page: <a href=\"https://github.com/pi-hosted/pi-hosted\" target=\"_blank\">https://github.com/pi-hosted/pi-hosted</a></b><br><br><b>Official Webpage: </b><a href=\"https://homebridge.io/\" target=\"_blank\">https://homebridge.io/</a><br><b>Official Docker Documentation: </b><a href=\"https://github.com/homebridge/homebridge/wiki/Install-Homebridge-on-Docker\" target=\"_blank\">https://github.com/homebridge/homebridge/wiki/Install-Homebridge-on-Docker</a><br><br><br>Bringing HomeKit support where there is none",
+      "platform": "linux",
+      "privileged": true,
+      "restart_policy": "unless-stopped",
+      "title": "Homebridge",
+      "type": 1,
+      "volumes": [
+        {
+          "bind": "/portainer/Files/AppData/Config/homebridge",
+          "container": "/homebridge"
+        }
+      ],
+      "maintainer": " https://github.com/novaspirit/pi-hosted/"
+    },
+    {
+      "id": 230,
+      "categories": [
+        "Homeautomation"
+      ],
+      "description": "Debian Homebridge allows you to integrate with smart home devices that do not natively support HomeKit. There are over 2,000 Homebridge plugins supporting thousands of different smart accessories.",
+      "env": [
+        {
+          "default": "1000",
+          "label": "PGID",
+          "name": "PGID"
+        },
+        {
+          "default": "1000",
+          "label": "PUID",
+          "name": "PUID"
+        },
+        {
+          "default": "1",
+          "label": "HOMEBRIDGE_CONFIG_UI",
+          "name": "HOMEBRIDGE_CONFIG_UI"
+        },
+        {
+          "default": "8581",
+          "label": "HOMEBRIDGE_CONFIG_UI_PORT",
+          "name": "HOMEBRIDGE_CONFIG_UI_PORT"
+        },
+        {
+          "default": "America/New_York",
+          "label": "TZ",
+          "name": "TZ"
+        }
+      ],
+      "image": "homebridge/homebridge:ubuntu-arm32v7",
+      "logo": "https://raw.githubusercontent.com/pi-hosted/pi-hosted/master/images/homebridge.png",
+      "name": "homebridge-debian",
+      "network": "host",
+      "note": "<b>Template created by Pi-Hosted Series</b><br><b>Check our Github page: <a href=\"https://github.com/pi-hosted/pi-hosted\" target=\"_blank\">https://github.com/pi-hosted/pi-hosted</a></b><br><br><b>Official Webpage: </b><a href=\"https://homebridge.io/\" target=\"_blank\">https://homebridge.io/</a><br><b>Official Docker Documentation: </b><a href=\"https://github.com/homebridge/homebridge/wiki/Install-Homebridge-on-Docker\" target=\"_blank\">https://github.com/homebridge/homebridge/wiki/Install-Homebridge-on-Docker</a><br><br><br>Bringing HomeKit support where there is none",
+      "platform": "linux",
+      "privileged": true,
+      "restart_policy": "unless-stopped",
+      "title": "Homebridge - Debian",
+      "type": 1,
+      "volumes": [
+        {
+          "bind": "/portainer/Files/AppData/Config/debian-homebridge",
+          "container": "/homebridge"
+        }
+      ],
+      "maintainer": " https://github.com/novaspirit/pi-hosted/"
+    },
+    {
+      "id": 231,
+      "categories": [
+        "Other",
+        "Tools"
+      ],
+      "description": "InfluxDB is an open source time series database for recording metrics, events, and analytics.",
+      "hostname": "rpi-influxdb1810",
+      "image": "influxdb:1.8.10",
+      "logo": "https://raw.githubusercontent.com/docker-library/docs/43d87118415bb75d7bb107683e79cd6d69186f67/influxdb/logo.png",
+      "name": "influxdb1810",
+      "note": "<b>Template created by Pi-Hosted Series</b><br><b>Check our Github page: <a href=\"https://github.com/pi-hosted/pi-hosted\" target=\"_blank\">https://github.com/pi-hosted/pi-hosted</a></b><br><br><b>Official Webpage: </b><a href=\"https://www.influxdata.com/\" target=\"_blank\">https://www.influxdata.com/</a><br><b>Official Docker Documentation: </b><a href=\"https://docs.influxdata.com/influxdb/v2.0/install/?t=Docker\" target=\"_blank\">https://docs.influxdata.com/influxdb/v2.0/install/?t=Docker</a><br><br><br>You will need to add /portainer/Files/AppData/Config/Influxdb/config/influxdb.conf",
+      "platform": "linux",
+      "ports": [
+        "8086:8086/tcp"
+      ],
+      "restart_policy": "unless-stopped",
+      "title": "Influxdb 1.8.10",
+      "type": 1,
+      "volumes": [
+        {
+          "bind": "/portainer/Files/AppData/Config/Influxdb/data",
+          "container": "/var/lib/influxdb"
+        },
+        {
+          "bind": "/portainer/Files/AppData/Config/Influxdb/config",
+          "container": "/etc/influxdb"
+        }
+      ],
+      "maintainer": " https://github.com/novaspirit/pi-hosted/"
+    },
+    {
+      "id": 232,
+      "categories": [
+        "Homeautomation"
+      ],
+      "description": "IoBroker is a open source IoT platform written in JavaScript that easily connects smarthome components from different manufactures. With the help of plugins (called: adapters) ioBroker is able to communicate with a big variety of IoT hardware and services using different protocols and APIs.",
+      "env": [
+        {
+          "default": "1000",
+          "label": "PUID",
+          "name": "PUID"
+        },
+        {
+          "default": "1000",
+          "label": "PGID",
+          "name": "PGID"
+        }
+      ],
+      "image": "buanet/iobroker:latest",
+      "logo": "https://github.com/buanet/ioBroker.docker/raw/main/docs/img/iobroker_logo.png",
+      "name": "iobroker",
+      "platform": "linux",
+      "ports": [
+        "8081:8081/tcp"
+      ],
+      "restart_policy": "unless-stopped",
+      "title": "iobroker",
+      "type": 1,
+      "volumes": [
+        {
+          "bind": "/portainer/Files/AppData/Config/iobrokerdata",
+          "container": "/opt/iobroker"
+        }
+      ],
+      "note": "<b>Template created by Pi-Hosted Series</b><br><b>Check our Github page: <a href=\"https://github.com/pi-hosted/pi-hosted\" target=\"_blank\">https://github.com/pi-hosted/pi-hosted</a></b><br><br><b>Official Webpage: </b><a href=\"https://github.com/buanet/ioBroker.docker\" target=\"_blank\">https://github.com/buanet/ioBroker.docker</a><br><b>Official Docker Documentation: </b><a href=\"https://github.com/buanet/ioBroker.docker\" target=\"_blank\">https://github.com/buanet/ioBroker.docker</a><br><br><br>",
+      "maintainer": " https://github.com/novaspirit/pi-hosted/"
+    },
+    {
+      "id": 233,
+      "categories": [
+        "Downloaders",
+        "Tools"
+      ],
+      "description": "JDownloader docker image",
+      "env": [
+        {
+          "default": "",
+          "label": "MYJD_DEVICE_NAME",
+          "name": "MYJD_DEVICE_NAME"
+        },
+        {
+          "default": "",
+          "label": "MYJD_USER",
+          "name": "MYJD_USER"
+        },
+        {
+          "default": "",
+          "label": "MYJD_PASSWORD",
+          "name": "MYJD_PASSWORD"
+        }
+      ],
+      "image": "jaymoulin/jdownloader:latest",
+      "logo": "https://raw.githubusercontent.com/pi-hosted/pi-hosted/master/images/jdownloader.png",
+      "name": "JDownloader",
+      "platform": "linux",
+      "ports": [
+        "3129:3129/tcp"
+      ],
+      "restart_policy": "unless-stopped",
+      "title": "JDownloader",
+      "type": 1,
+      "volumes": [
+        {
+          "bind": "/portainer/Files/AppData/Config/JDownloader",
+          "container": "/opt/JDownloader/app/cfg"
+        },
+        {
+          "bind": "/portainer/Downloads",
+          "container": "/opt/JDownloader/Downloads"
+        }
+      ],
+      "note": "<b>Template created by Pi-Hosted Series</b><br><b>Check our Github page: <a href=\"https://github.com/pi-hosted/pi-hosted\" target=\"_blank\">https://github.com/pi-hosted/pi-hosted</a></b><br><br><b>Official Webpage: </b><a href=\"https://my.jdownloader.org/\" target=\"_blank\">https://my.jdownloader.org/</a><br><b>Official Docker Documentation: </b><a href=\"https://github.com/jaymoulin/docker-jdownloader\" target=\"_blank\">https://github.com/jaymoulin/docker-jdownloader</a><br><br><br><b>Youtube Video: </b><a href=https://www.youtube.com/watch?v=30MYRgCObu8&list=PL846hFPMqg3jwkxcScD1xw2bKXrJVvarc&index=4 target=\"_blank\">Novaspirit Tech - Installing JDownloader and File Browser On The Pi Docker Server</a><br><br>",
+      "maintainer": " https://github.com/novaspirit/pi-hosted/"
+    },
+    {
+      "id": 234,
+      "categories": [
+        "Video",
+        "Music",
+        "Photos",
+        "Management"
+      ],
+      "description": "jfa-go is a user management app for Jellyfin (and now Emby) that provides invite-based account creation as well as other features that make one's instance much easier to manage.",
+      "image": "hrfee/jfa-go:latest",
+      "logo": "https://github.com/hrfee/jfa-go/raw/main/images/jfa-go-icon.png",
+      "name": "jfa-go",
+      "note": "<b>Template created by Pi-Hosted Series</b><br><b>Check our Github page: <a href=\"https://github.com/pi-hosted/pi-hosted\" target=\"_blank\">https://github.com/pi-hosted/pi-hosted</a></b><br><br><b>Official Webpage: </b><a href=\"https://jfa-go.com/\" target=\"_blank\">https://jfa-go.com/</a><br><b>Official Docker Documentation: </b><a href=\"https://wiki.jfa-go.com/\" target=\"_blank\">https://wiki.jfa-go.com/</a><br><br><br>This system is setup to work with either Emby or Jellyfin out of the box.  During the initial setup the user will have the option of which server they will be administering.",
+      "platform": "linux",
+      "restart_policy": "unless-stopped",
+      "title": "Jellyfin-Accounts",
+      "type": 1,
+      "network": "bridge",
+      "ports": [
+        "8056:8056/tcp"
+      ],
+      "volumes": [
+        {
+          "bind": "/portainer/Files/AppData/Config/Jelllyfin",
+          "container": "/jf"
+        },
+        {
+          "bind": "/portainer/Files/AppData/Config/jfago",
+          "container": "/data"
+        },
+        {
+          "bind": "/etc/localtime",
+          "container": "/etc/localtime",
+          "readonly": true
+        }
+      ],
+      "maintainer": " https://github.com/novaspirit/pi-hosted/"
+    },
+    {
+      "id": 235,
+      "categories": [
+        "Other",
+        "3dprinters",
+        "Tools"
+      ],
+      "description": "Klipper is a 3d-Printer firmware. It combines the power of a general purpose computer with one or more micro-controllers. See the features document for more information on why you should use Klipper.",
+      "env": [
+        {
+          "default": "/dev/ttymxc3",
+          "label": "3D_PRINTER_DEVICE",
+          "name": "3D_PRINTER_DEVICE"
+        }
+      ],
+      "logo": "https://raw.githubusercontent.com/pi-hosted/pi-hosted/master/images/drupal.png",
+      "name": "klipper-mainsail-moonraker",
+      "note": "<b>Template created by Pi-Hosted Series</b><br><b>Check our Github page: <a href=\"https://github.com/pi-hosted/pi-hosted\" target=\"_blank\">https://github.com/pi-hosted/pi-hosted</a></b><br><br><b>Official Webpage: </b><a href=\"https://hub.docker.com/r/mkuf/klipper\" target=\"_blank\">https://hub.docker.com/r/mkuf/klipper</a><br><b>Official Docker Documentation: </b><a href=\"https://hub.docker.com/r/mkuf/klipper\" target=\"_blank\">https://hub.docker.com/r/mkuf/klipper</a><br><br><h3><b><a href=\"https://github.com/pi-hosted/pi-hosted/blob/master/tools/install_klipper.sh\" target=\"_blank\">Pre-installation script</a> must be RAN before you install: </b>wget -qO- https://raw.githubusercontent.com/pi-hosted/pi-hosted/master/tools/install_klipper.sh | bash</h3><br><br>First you will need to download a printer.conf file from https://github.com/Klipper3d/klipper/tree/master/config and copy it to ",
+      "platform": "linux",
+      "repository": {
+        "stackfile": "stack/klipper.yml",
+        "url": "https://github.com/pi-hosted/pi-hosted/"
+      },
+      "restart_policy": "unless-stopped",
+      "title": "Klipper[Testing], Mainsail, Moonraker",
+      "type": 3,
+      "maintainer": " https://github.com/novaspirit/pi-hosted/"
+    },
+    {
+      "id": 236,
+      "categories": [
+        "Other",
+        "Tools"
+      ],
+      "description": "An alternative private front-end to Reddit",
+      "image": "libreddit/libreddit:armv7",
+      "logo": "https://raw.githubusercontent.com/pi-hosted/pi-hosted/master/images/libreddit.png",
+      "name": "libreddit",
+      "platform": "linux",
+      "ports": [
+        "8088:8080/tcp"
+      ],
+      "restart_policy": "unless-stopped",
+      "title": "libreddit",
+      "type": 1,
+      "volumes": [
+        {
+          "bind": "/portainer/Files/AppData/Config/libreddit",
+          "container": "/config"
+        }
+      ],
+      "note": "<b>Template created by Pi-Hosted Series</b><br><b>Check our Github page: <a href=\"https://github.com/pi-hosted/pi-hosted\" target=\"_blank\">https://github.com/pi-hosted/pi-hosted</a></b><br><br><b>Official Webpage: </b><a href=\"https://libreddit.silkky.cloud/\" target=\"_blank\">https://libreddit.silkky.cloud/</a><br><b>Official Docker Documentation: </b><a href=\"https://github.com/spikecodes/libreddit#2-docker\" target=\"_blank\">https://github.com/spikecodes/libreddit#2-docker</a><br><br><br>",
+      "maintainer": " https://github.com/novaspirit/pi-hosted/"
+    },
+    {
+      "id": 237,
+      "categories": [
+        "Tools",
+        "Productivity"
+      ],
+      "description": "This project is a lightweight authentication server that provides an opinionated, simplified LDAP interface for authentication.",
+      "env": [
+        {
+          "default": "somesecretjwt",
+          "label": "LLDAP_JWT_SECRET",
+          "name": "LLDAP_JWT_SECRET"
+        },
+        {
+          "default": "someadminpassword",
+          "label": "LLDAP_LDAP_USER_PASS",
+          "name": "LLDAP_LDAP_USER_PASS"
+        },
+        {
+          "default": "dc=example,dc=com",
+          "label": "LLDAP_LDAP_BASE_DN",
+          "name": "LLDAP_LDAP_BASE_DN"
+        }
+      ],
+      "image": "nitnelave/lldap:stable-debian",
+      "logo": "https://raw.githubusercontent.com/pi-hosted/pi-hosted/master/images/lldap.png",
+      "name": "LLDAP",
+      "platform": "linux",
+      "ports": [
+        "3890:3890/tcp",
+        "17170:17170/tcp"
+      ],
+      "restart_policy": "unless-stopped",
+      "title": "LLDAP",
+      "type": 1,
+      "volumes": [
+        {
+          "bind": "/portainer/Files/AppData/Config/lldap/data",
+          "container": "/data"
+        }
+      ],
+      "note": "<b>Template created by Pi-Hosted Series</b><br><b>Check our Github page: <a href=\"https://github.com/pi-hosted/pi-hosted\" target=\"_blank\">https://github.com/pi-hosted/pi-hosted</a></b><br><br><b>Official Webpage: </b><a href=\"https://github.com/nitnelave/lldap\" target=\"_blank\">https://github.com/nitnelave/lldap</a><br><b>Official Docker Documentation: </b><a href=\"https://github.com/nitnelave/lldap\" target=\"_blank\">https://github.com/nitnelave/lldap</a><br><br><h3><b><a href=\"https://github.com/pi-hosted/pi-hosted/blob/master/tools/install_lldap.sh\" target=\"_blank\">Pre-installation script</a> must be RAN before you install: </b>wget -qO- https://raw.githubusercontent.com/pi-hosted/pi-hosted/master/tools/install_lldap.sh | bash</h3><br><br>",
+      "maintainer": " https://github.com/novaspirit/pi-hosted/"
+    },
+    {
+      "id": 238,
+      "categories": [
+        "Music"
+      ],
+      "description": "Simple self-hosted music scrobble database to create personal listening statistics. No recommendations, no social network, no nonsense.",
+      "env": [
+        {
+          "default": "malojapassword",
+          "label": "MALOJA_FORCE_PASSWORD",
+          "name": "MALOJA_FORCE_PASSWORD"
+        },
+        {
+          "default": "/data",
+          "label": "MALOJA_DATA_DIRECTORY",
+          "name": "MALOJA_DATA_DIRECTORY"
+        }
+      ],
+      "image": "krateng/maloja:latest",
+      "logo": "https://raw.githubusercontent.com/pi-hosted/pi-hosted/master/images/maloja.png",
+      "name": "maloja",
+      "platform": "linux",
+      "ports": [
+        "42010:42010/tcp"
+      ],
+      "restart_policy": "unless-stopped",
+      "title": "Maloja",
+      "type": 1,
+      "volumes": [
+        {
+          "bind": "/portainer/Files/AppData/Config/Maloja/Data",
+          "container": "/data"
+        }
+      ],
+      "note": "<b>Template created by Pi-Hosted Series</b><br><b>Check our Github page: <a href=\"https://github.com/pi-hosted/pi-hosted\" target=\"_blank\">https://github.com/pi-hosted/pi-hosted</a></b><br><br><b>Official Webpage: </b><a href=\"https://github.com/krateng/maloja\" target=\"_blank\">https://github.com/krateng/maloja</a><br><b>Official Docker Documentation: </b><a href=\"https://github.com/krateng/maloja/blob/master/README.md\" target=\"_blank\">https://github.com/krateng/maloja/blob/master/README.md</a><br><br><h3><b><a href=\"https://github.com/pi-hosted/pi-hosted/blob/master/tools/install_maloja.sh\" target=\"_blank\">Pre-installation script</a> must be RAN before you install: </b>wget -qO- https://raw.githubusercontent.com/pi-hosted/pi-hosted/master/tools/install_maloja.sh | bash</h3><br><br>",
+      "maintainer": " https://github.com/novaspirit/pi-hosted/"
+    },
+    {
+      "id": 239,
+      "categories": [
+        "Other",
+        "Tools"
+      ],
+      "description": "A self-hosted recipe manager and meal planner",
+      "env": [
+        {
+          "default": "1000",
+          "label": "PUID",
+          "name": "PUID"
+        },
+        {
+          "default": "1000",
+          "label": "PGID",
+          "name": "PGID"
+        },
+        {
+          "default": "America/New_York",
+          "label": "TZ",
+          "name": "TZ"
+        },
+        {
+          "default": "2",
+          "label": "WEB_CONCURRENCY",
+          "name": "WEB_CONCURRENCY"
+        },
+        {
+          "default": "8",
+          "label": "MAX_WORKERS",
+          "name": "MAX_WORKERS"
+        },
+        {
+          "default": "true",
+          "label": "RECIPE_PUBLIC",
+          "name": "RECIPE_PUBLIC"
+        },
+        {
+          "default": "true",
+          "label": "RECIPE_SHOW_NUTRITION",
+          "name": "RECIPE_SHOW_NUTRITION"
+        },
+        {
+          "default": "true",
+          "label": "RECIPE_SHOW_ASSETS",
+          "name": "RECIPE_SHOW_ASSETS"
+        },
+        {
+          "default": "true",
+          "label": "RECIPE_LANDSCAPE_VIEW",
+          "name": "RECIPE_LANDSCAPE_VIEW"
+        },
+        {
+          "default": "false",
+          "label": "RECIPE_DISABLE_COMMENTS",
+          "name": "RECIPE_DISABLE_COMMENTS"
+        },
+        {
+          "default": "false",
+          "label": "RECIPE_DISABLE_AMOUNT",
+          "name": "RECIPE_DISABLE_AMOUNT"
+        }
+      ],
+      "image": "hkotel/mealie:v0.4.3",
+      "logo": "https://raw.githubusercontent.com/pi-hosted/pi-hosted/master/images/mealie.png",
+      "name": "mealie",
+      "note": "<b>Template created by Pi-Hosted Series</b><br><b>Check our Github page: <a href=\"https://github.com/pi-hosted/pi-hosted\" target=\"_blank\">https://github.com/pi-hosted/pi-hosted</a></b><br><br><b>Official Webpage: </b><a href=\"https://hay-kot.github.io/mealie/\" target=\"_blank\">https://hay-kot.github.io/mealie/</a><br><b>Official Docker Documentation: </b><a href=\"https://hay-kot.github.io/mealie/documentation/getting-started/install/\" target=\"_blank\">https://hay-kot.github.io/mealie/documentation/getting-started/install/</a><br><br><br>Default Credentials: Username: changeme@email.com Password: MyPassword. Documentation is Available <a href='https://hay-kot.github.io/mealie/documentation/getting-started/install/'>here</a>.",
+      "platform": "linux",
+      "ports": [
+        "9925:9000/tcp"
+      ],
+      "restart_policy": "unless-stopped",
+      "title": "Mealie",
+      "type": 1,
+      "volumes": [
+        {
+          "bind": "/portainer/Files/AppData/Config/mealie",
+          "container": "/app/data"
+        }
+      ],
+      "maintainer": " https://github.com/novaspirit/pi-hosted/"
+    },
+    {
+      "id": 240,
+      "categories": [
+        "Downloader"
+      ],
+      "description": "Web GUI for youtube-dl (using the yt-dlp fork) with playlist support. Allows you to download videos from YouTube and dozens of other sites (https://github.com/yt-dlp/yt-dlp/blob/master/supportedsites.md)",
+      "env": [
+        {
+          "default": "1000",
+          "label": "PUID",
+          "name": "PUID"
+        },
+        {
+          "default": "1000",
+          "label": "PGID",
+          "name": "PGID"
+        }
+      ],
+      "image": "alexta69/metube:latest",
+      "logo": "https://raw.githubusercontent.com/pi-hosted/pi-hosted/master/images/metube.png",
+      "name": "MeTube",
+      "platform": "linux",
+      "ports": [
+        "8081:8081/tcp"
+      ],
+      "restart_policy": "unless-stopped",
+      "title": "MeTube",
+      "type": 1,
+      "volumes": [
+        {
+          "bind": "/portainer/Downloads",
+          "container": "/downloads"
+        }
+      ],
+      "note": "<b>Template created by Pi-Hosted Series</b><br><b>Check our Github page: <a href=\"https://github.com/pi-hosted/pi-hosted\" target=\"_blank\">https://github.com/pi-hosted/pi-hosted</a></b><br><br><b>Official Webpage: </b><a href=\"https://hub.docker.com/r/alexta69/metube\" target=\"_blank\">https://hub.docker.com/r/alexta69/metube</a><br><b>Official Docker Documentation: </b><a href=\"https://github.com/alexta69/metube\" target=\"_blank\">https://github.com/alexta69/metube</a><br><br><br>",
+      "maintainer": " https://github.com/novaspirit/pi-hosted/"
+    },
+    {
+      "id": 241,
+      "categories": [
+        "Other",
+        "Tools",
+        "Games"
+      ],
+      "description": "This docker image provides a Minecraft Server that will automatically download the latest stable version at startup. You can also run/upgrade to any specific version or the latest snapshot. See the Versions section below for more information.",
+      "env": [
+        {
+          "default": "TRUE",
+          "label": "EULA",
+          "name": "EULA"
+        }
+      ],
+      "image": "itzg/minecraft-server:latest",
+      "logo": "https://raw.githubusercontent.com/pi-hosted/pi-hosted/master/images/minecraft.png",
+      "name": "minecraft",
+      "platform": "linux",
+      "ports": [
+        "25565:25565/tcp"
+      ],
+      "restart_policy": "unless-stopped",
+      "title": "Minecraft Server",
+      "type": 1,
+      "volumes": [
+        {
+          "bind": "/portainer/Files/AppData/Config/Minecraft-data",
+          "container": "/data"
+        }
+      ],
+      "note": "<b>Template created by Pi-Hosted Series</b><br><b>Check our Github page: <a href=\"https://github.com/pi-hosted/pi-hosted\" target=\"_blank\">https://github.com/pi-hosted/pi-hosted</a></b><br><br><b>Official Webpage: </b><a href=\"https://www.minecraft.net/en-us\" target=\"_blank\">https://www.minecraft.net/en-us</a><br><b>Official Docker Documentation: </b><a href=\"https://github.com/itzg/docker-minecraft-server#using-docker-compose\" target=\"_blank\">https://github.com/itzg/docker-minecraft-server#using-docker-compose</a><br><br><br>",
+      "maintainer": " https://github.com/novaspirit/pi-hosted/"
+    },
+    {
+      "id": 242,
+      "categories": [
+        "Other",
+        "Tools"
+      ],
+      "command": "server --console-address ':9090' /data",
+      "description": "MinIO is a High Performance Object Storage released under GNU Affero GPL v3.0. It is API compatible with Amazon S3 cloud storage service.",
+      "env": [
+        {
+          "default": "1000",
+          "label": "PUID",
+          "name": "PUID"
+        },
+        {
+          "default": "1000",
+          "label": "PGID",
+          "name": "PGID"
+        },
+        {
+          "default": "ROOTUSER",
+          "label": "MINIO_ROOT_USER",
+          "name": "MINIO_ROOT_USER"
+        },
+        {
+          "default": "CHANGEME123",
+          "label": "MINIO_ROOT_PASSWORD",
+          "name": "MINIO_ROOT_PASSWORD"
+        },
+        {
+          "default": "",
+          "label": "MINIO_SERVER_URL",
+          "name": "MINIO_SERVER_URL",
+          "description": "URL hostname for MinIO Console if any"
+        }
+      ],
+      "image": "minio/minio:latest",
+      "logo": "https://raw.githubusercontent.com/pi-hosted/pi-hosted/master/images/minio.png",
+      "name": "minio",
+      "platform": "linux",
+      "ports": [
+        "8760:9000/tcp",
+        "8761:9090/tcp"
+      ],
+      "restart_policy": "unless-stopped",
+      "title": "MinIO",
+      "type": 1,
+      "volumes": [
+        {
+          "bind": "/portainer/Files/AppData/Config/MinIO",
+          "container": "/data"
+        }
+      ],
+      "note": "<b>Template created by Pi-Hosted Series</b><br><b>Check our Github page: <a href=\"https://github.com/pi-hosted/pi-hosted\" target=\"_blank\">https://github.com/pi-hosted/pi-hosted</a></b><br><br><b>Official Webpage: </b><a href=\"https://min.io/\" target=\"_blank\">https://min.io/</a><br><b>Official Docker Documentation: </b><a href=\"https://docs.min.io/minio/baremetal/quickstart/quickstart.html\" target=\"_blank\">https://docs.min.io/minio/baremetal/quickstart/quickstart.html</a><br><br><br>",
+      "maintainer": " https://github.com/novaspirit/pi-hosted/"
+    },
+    {
+      "id": 243,
+      "categories": [
+        "Other",
+        "Tools"
+      ],
+      "description": "Troubleshoot slowdowns and anomalies in your infrastructure with thousands of per-second metrics, meaningful visualizations, and insightful health alarms with zero configuration.",
+      "env": [
+        {
+          "default": "1000",
+          "label": "DOCKER_USR",
+          "name": "DOCKER_USR"
+        },
+        {
+          "default": "1000",
+          "label": "DOCKER_GRP",
+          "name": "DOCKER_GRP"
+        }
+      ],
+      "image": "netdata/netdata:latest",
+      "logo": "https://raw.githubusercontent.com/pi-hosted/pi-hosted/master/images/netdata.png",
+      "name": "netdata",
+      "note": "<b>Template created by Pi-Hosted Series</b><br><b>Check our Github page: <a href=\"https://github.com/pi-hosted/pi-hosted\" target=\"_blank\">https://github.com/pi-hosted/pi-hosted</a></b><br><br><b>Official Webpage: </b><a href=\"https://www.netdata.cloud/\" target=\"_blank\">https://www.netdata.cloud/</a><br><b>Official Docker Documentation: </b><a href=\"https://learn.netdata.cloud/docs/agent/packaging/docker\" target=\"_blank\">https://learn.netdata.cloud/docs/agent/packaging/docker</a><br><br><br>Documentation is Available <a href='https://learn.netdata.cloud/'>here</a>.",
+      "platform": "linux",
+      "ports": [
+        "19999:19999/tcp"
+      ],
+      "restart_policy": "unless-stopped",
+      "title": "Netdata",
+      "type": 1,
+      "volumes": [
+        {
+          "bind": "/portainer/Files/AppData/Config/netdata/netdataconfig",
+          "container": "/etc/netdata"
+        },
+        {
+          "bind": "/portainer/Files/AppData/Config/netdata/netdatalib",
+          "container": "/var/lib/netdata"
+        },
+        {
+          "bind": "/etc/passwd",
+          "container": "/host/etc/passwd:ro"
+        },
+        {
+          "bind": "/etc/group",
+          "container": "/host/etc/group:ro"
+        },
+        {
+          "bind": "/proc",
+          "container": "/host/proc:ro"
+        },
+        {
+          "bind": "/sys",
+          "container": "/host/sys:ro"
+        },
+        {
+          "bind": "/etc/os-release",
+          "container": "/host/etc/os-release:ro"
+        }
+      ],
+      "maintainer": " https://github.com/novaspirit/pi-hosted/"
+    },
+    {
+      "id": 244,
+      "categories": [
+        "Proxy",
+        "Tools"
+      ],
+      "description": "Nginx Proxy Manager v2 with sqlite and Goaccess Charts enables you to easily forward to your websites running at home or otherwise, including free SSL, without having to know too much about Nginx or Letsencrypt.  Please see the install document at https://github.com/pi-hosted/pi-hosted/tree/master/docs installing the template",
+      "env": [
+        {
+          "default": "1000",
+          "label": "PUID",
+          "name": "PUID"
+        },
+        {
+          "default": "1000",
+          "label": "PGID",
+          "name": "PGID"
+        },
+        {
+          "default": "America/New_York",
+          "label": "TZ",
+          "name": "TZ"
+        },
+        {
+          "default": "false",
+          "label": "SKIP_ARCHIVED_LOGS",
+          "name": "SKIP_ARCHIVED_LOGS",
+          "description": "Defaults to false. Set to true to skip archived logs, i.e. proxy-host*.gz"
+        },
+        {
+          "default": "false",
+          "label": "BASIC_AUTH",
+          "name": "BASIC_AUTH",
+          "description": "Defaults to false. Set to true to enable nginx basic authentication. Docker container needs to stopped or restarted each time this flag is modified. This allows for the .htpasswd file to be changed accordingly."
+        },
+        {
+          "default": "user",
+          "label": "BASIC_AUTH_USERNAME Ignore if Basic Auth set to false",
+          "name": "BASIC_AUTH_USERNAME",
+          "description": "(Optional) Requires BASIC_AUTH to bet set to true. Username for basic authentication."
+        },
+        {
+          "default": "Password",
+          "label": "BASIC_AUTH_PASSWORD Ignore if Basic Auth set to false",
+          "name": "BASIC_AUTH_PASSWORD",
+          "description": "(Optional) Requires BASIC_AUTH to bet set to true. Password for basic authentication."
+        }
+      ],
+      "logo": "https://raw.githubusercontent.com/pi-hosted/pi-hosted/master/images/proxy_mgr.png",
+      "name": "nginx-proxy-manager-sqllite-goaccess",
+      "platform": "linux",
+      "ports": [
+        "80:80/tcp",
+        "81:81/tcp",
+        "443:443/tcp",
+        "7880:7880/tcp"
+      ],
+      "repository": {
+        "stackfile": "stack/nginx-proxy-manager-sqlite-goaccess.yml",
+        "url": "https://github.com/pi-hosted/pi-hosted"
+      },
+      "restart_policy": "unless-stopped",
+      "title": "Nginx Proxy Manager v2 with Sqlite and Goaccess Charts",
+      "type": 3,
+      "note": "<b>Template created by Pi-Hosted Series</b><br><b>Check our Github page: <a href=\"https://github.com/pi-hosted/pi-hosted\" target=\"_blank\">https://github.com/pi-hosted/pi-hosted</a></b><br><br><b>Official Webpage: </b><a href=\"https://nginxproxymanager.com/\" target=\"_blank\">https://nginxproxymanager.com/</a><br><b>Official Docker Documentation: </b><a href=\"https://nginxproxymanager.com/setup/#running-the-app\" target=\"_blank\">https://nginxproxymanager.com/setup/#running-the-app</a><br><h3><b>Pi-Hosted dedicated documentation: </b><a href=\"https://github.com/pi-hosted/pi-hosted/blob/master/docs/nginx_proxy_manager.md\" target=\"_blank\">nginx_proxy_manager.md</a></h3><br><br><br><b>Youtube Video: </b><a href=https://www.youtube.com/watch?v=yl2Laxbqvo8&list=PL846hFPMqg3jwkxcScD1xw2bKXrJVvarc&index=10 target=\"_blank\">Novaspirit Tech - Installing Nginx Proxy Manager on Docker</a><br><br>",
+      "maintainer": " https://github.com/novaspirit/pi-hosted/"
+    },
+    {
+      "id": 245,
+      "categories": [
+        "Proxy",
+        "Tools"
+      ],
+      "description": "Nginx Proxy Manager v2 with Sqlite enables you to easily forward to your websites running at home or otherwise, including free SSL, without having to know too much about Nginx or Letsencrypt.  Please see the install document at https://github.com/pi-hosted/pi-hosted/tree/master/docs installing the template",
+      "env": [
+        {
+          "default": "1000",
+          "label": "PUID",
+          "name": "PUID"
+        },
+        {
+          "default": "1000",
+          "label": "PGID",
+          "name": "PGID"
+        },
+        {
+          "default": "America/New_York",
+          "label": "TZ",
+          "name": "TZ"
+        }
+      ],
+      "image": "jc21/nginx-proxy-manager:latest",
+      "logo": "https://raw.githubusercontent.com/pi-hosted/pi-hosted/master/images/proxy_mgr.png",
+      "name": "nginx-proxy-manager-sqlite",
+      "platform": "linux",
+      "ports": [
+        "80:80/tcp",
+        "81:81/tcp",
+        "443:443/tcp"
+      ],
+      "restart_policy": "unless-stopped",
+      "title": "Nginx Proxy Manager v2 with Sqllite",
+      "type": 1,
+      "volumes": [
+        {
+          "bind": "/portainer/Files/AppData/Config/nginx-proxy-manager/data",
+          "container": "/data"
+        },
+        {
+          "bind": "/portainer/Files/AppData/Config/nginx-proxy-manager/letsencrypt",
+          "container": "/etc/letsencrypt"
+        }
+      ],
+      "note": "<b>Template created by Pi-Hosted Series</b><br><b>Check our Github page: <a href=\"https://github.com/pi-hosted/pi-hosted\" target=\"_blank\">https://github.com/pi-hosted/pi-hosted</a></b><br><br><b>Official Webpage: </b><a href=\"https://nginxproxymanager.com/\" target=\"_blank\">https://nginxproxymanager.com/</a><br><b>Official Docker Documentation: </b><a href=\"https://nginxproxymanager.com/setup/\" target=\"_blank\">https://nginxproxymanager.com/setup/</a><br><h3><b>Pi-Hosted dedicated documentation: </b><a href=\"https://github.com/pi-hosted/pi-hosted/blob/master/docs/nginx_proxy_manager.md\" target=\"_blank\">nginx_proxy_manager.md</a></h3><br><br><br><b>Youtube Video: </b><a href=https://www.youtube.com/watch?v=yl2Laxbqvo8&list=PL846hFPMqg3jwkxcScD1xw2bKXrJVvarc&index=10 target=\"_blank\">Novaspirit Tech - Installing Nginx Proxy Manager on Docker</a><br><br>",
+      "maintainer": " https://github.com/novaspirit/pi-hosted/"
+    },
+    {
+      "id": 246,
+      "categories": [
+        "Proxy",
+        "Tools"
+      ],
+      "description": "[DEVEL] Not ready for production.  Nginx Proxy Manager v3 Develop enables you to easily forward to your websites running at home or otherwise, including free SSL, without having to know too much about Nginx or Letsencrypt.  Please see the install document at https://github.com/pi-hosted/pi-hosted/tree/master/docs installing the template",
+      "env": [
+        {
+          "default": "1000",
+          "label": "PUID",
+          "name": "PUID"
+        },
+        {
+          "default": "1000",
+          "label": "PGID",
+          "name": "PGID"
+        },
+        {
+          "default": "America/New_York",
+          "label": "TZ",
+          "name": "TZ"
+        }
+      ],
+      "image": "jc21/nginx-proxy-manager:v3",
+      "logo": "https://raw.githubusercontent.com/pi-hosted/pi-hosted/master/images/proxy_mgr.png",
+      "name": "nginx-proxy-manager-v3",
+      "platform": "linux",
+      "ports": [
+        "80:80/tcp",
+        "81:81/tcp",
+        "443:443/tcp"
+      ],
+      "restart_policy": "unless-stopped",
+      "title": "Nginx Proxy Manager v3 [DEVEL] NOT READY FOR USE",
+      "type": 1,
+      "volumes": [
+        {
+          "bind": "/portainer/Files/AppData/Config/nginx-proxy-manager-v3/data",
+          "container": "/data"
+        }
+      ],
+      "note": "<b>Template created by Pi-Hosted Series</b><br><b>Check our Github page: <a href=\"https://github.com/pi-hosted/pi-hosted\" target=\"_blank\">https://github.com/pi-hosted/pi-hosted</a></b><br><br><b>Official Webpage: </b><a href=\"https://nginxproxymanager.com/\" target=\"_blank\">https://nginxproxymanager.com/</a><br><b>Official Docker Documentation: </b><a href=\"https://nginxproxymanager.com/setup/\" target=\"_blank\">https://nginxproxymanager.com/setup/</a><br><h3><b>Pi-Hosted dedicated documentation: </b><a href=\"https://github.com/pi-hosted/pi-hosted/blob/master/docs/nginx_proxy_manager.md\" target=\"_blank\">nginx_proxy_manager.md</a></h3><br><br><br><b>Youtube Video: </b><a href=https://www.youtube.com/watch?v=yl2Laxbqvo8&list=PL846hFPMqg3jwkxcScD1xw2bKXrJVvarc&index=10 target=\"_blank\">Novaspirit Tech - Installing Nginx Proxy Manager on Docker</a><br><br>",
+      "maintainer": " https://github.com/novaspirit/pi-hosted/"
+    },
+    {
+      "id": 247,
+      "categories": [
+        "Other",
+        "Tools",
+        "Web"
+      ],
+      "description": "A free and open source alternative Twitter front-end focused on privacy and performance.",
+      "logo": "https://raw.githubusercontent.com/pi-hosted/pi-hosted/master/images/nitter.png",
+      "name": "nitter",
+      "repository": {
+        "stackfile": "stack/nitter.yml",
+        "url": "https://github.com/pi-hosted/pi-hosted/"
+      },
+      "platform": "linux",
+      "restart_policy": "unless-stopped",
+      "title": "Nitter",
+      "type": 3,
+      "note": "<b>Template created by Pi-Hosted Series</b><br><b>Check our Github page: <a href=\"https://github.com/pi-hosted/pi-hosted\" target=\"_blank\">https://github.com/pi-hosted/pi-hosted</a></b><br><br><b>Official Webpage: </b><a href=\"https://nitter.net/\" target=\"_blank\">https://nitter.net/</a><br><b>Official Docker Documentation: </b><a href=\"https://github.com/zedeus/nitter\" target=\"_blank\">https://github.com/zedeus/nitter</a><br><br><br>",
+      "maintainer": " https://github.com/novaspirit/pi-hosted/"
+    },
+    {
+      "id": 248,
+      "categories": [
+        "Other"
+      ],
+      "description": "This is an OpenVPN client docker container that uses recommended NordVPN server. It makes routing containers traffic through OpenVPN easy.",
+      "env": [
+        {
+          "default": "user@email.com",
+          "label": "NordVPN user",
+          "name": "USER"
+        },
+        {
+          "default": "password",
+          "label": "NordVPN password",
+          "name": "PASS"
+        },
+        {
+          "default": "Spain;Hong Kong;IE;131",
+          "label": "Countries to connect to (see webpage readme)",
+          "name": "COUNTRY"
+        },
+        {
+          "default": "Standard VPN servers",
+          "label": "Group name filter to which to connect to",
+          "name": "GROUP"
+        },
+        {
+          "default": "10",
+          "label": "Range of servers to pick from the top",
+          "name": "RANDOM_TOP"
+        },
+        {
+          "default": "5 */3 * * *",
+          "label": "Define when to look again for new defined servers",
+          "name": "RECREATE_VPN_CRON"
+        },
+        {
+          "default": "https://www.google.com",
+          "label": "URL to check internet connection is working to",
+          "name": "CHECK_CONNECTION_URL"
+        },
+        {
+          "default": "192.168.1.0/24;192.168.2.0/24",
+          "label": "Subnet to define network access (read Local Network access to services connecting to the internet through the VPN readme to get the right subnet!)",
+          "name": "NETWORK"
+        },
+        {
+          "default": "--mute-replay-warnings",
+          "label": "Used to pass extra parameters to openvpn",
+          "name": "OPENVPN_OPTS"
+        }
+      ],
+      "image": "azinchen/nordvpn:latest",
+      "logo": "https://s3.us-east-2.amazonaws.com/ccp-prd-s3-uploads/2022/3/8/03500108885898f010e823eeb284e393b99e1ad5.png",
+      "name": "nord-vpn",
+      "platform": "linux",
+      "ports": [
+        "8080:80/tcp"
+      ],
+      "restart_policy": "unless-stopped",
+      "title": "nord-vpn",
+      "type": 1,
+      "privileged": true,
+      "note": "<b>Template created by Pi-Hosted Series</b><br><b>Check our Github page: <a href=\"https://github.com/pi-hosted/pi-hosted\" target=\"_blank\">https://github.com/pi-hosted/pi-hosted</a></b><br><br><b>Official Webpage: </b><a href=\"https://github.com/azinchen/nordvpn\" target=\"_blank\">https://github.com/azinchen/nordvpn</a><br><b>Official Docker Documentation: </b><a href=\"https://hub.docker.com/r/azinchen/nordvpn\" target=\"_blank\">https://hub.docker.com/r/azinchen/nordvpn</a><br><br><br>",
+      "maintainer": " https://github.com/novaspirit/pi-hosted/"
+    },
+    {
+      "id": 249,
+      "categories": [
+        "Other",
+        "Tools"
+      ],
+      "description": "The purpose of NUT Server is to monitor a UPS attached device",
+      "env": [
+        {
+          "default": "1000",
+          "label": "PUID",
+          "name": "PUID"
+        },
+        {
+          "default": "1000",
+          "label": "PGID",
+          "name": "PGID"
+        },
+        {
+          "default": "none",
+          "label": "SERIAL",
+          "name": "SERIAL"
+        },
+        {
+          "default": "none",
+          "label": "NAME",
+          "name": "NAME"
+        },
+        {
+          "default": "none",
+          "label": "VENDOR ID",
+          "name": "VENDOR ID"
+        },
+        {
+          "default": "none",
+          "label": "API_PASSWORD",
+          "name": "API_PASSWORD"
+        },
+        {
+          "default": "none",
+          "label": "DESCRIPTION",
+          "name": "DESCRIPTION"
+        }
+      ],
+      "image": "instantlinux/nut-upsd:latest",
+      "logo": "https://raw.githubusercontent.com/pi-hosted/pi-hosted/master/images/nut-server.png",
+      "name": "NUT Server",
+      "platform": "linux",
+      "ports": [
+        "3493:3493/tcp"
+      ],
+      "restart_policy": "unless-stopped",
+      "title": "NUT Server",
+      "type": 1,
+      "note": "<b>Template created by Pi-Hosted Series</b><br><b>Check our Github page: <a href=\"https://github.com/pi-hosted/pi-hosted\" target=\"_blank\">https://github.com/pi-hosted/pi-hosted</a></b><br><br><b>Official Webpage: </b><a href=\"https://networkupstools.org\" target=\"_blank\">https://networkupstools.org</a><br><b>Official Docker Documentation: </b><a href=\"https://hub.docker.com/r/instantlinux/nut-upsd\" target=\"_blank\">https://hub.docker.com/r/instantlinux/nut-upsd</a><br><br><br>",
+      "maintainer": " https://github.com/novaspirit/pi-hosted/"
+    },
+    {
+      "id": 250,
+      "categories": [
+        "Other",
+        "Tools"
+      ],
+      "description": "OctoPrint is an open source 3D printer controller application, which provides a web interface for the connected printers.",
+      "env": [
+        {
+          "default": "development ",
+          "label": "NODE_ENV",
+          "name": "NODE_ENV"
+        },
+        {
+          "default": "true",
+          "label": "ENABLE_MJPG_STREAMER",
+          "name": "ENABLE_MJPG_STREAMER"
+        }
+      ],
+      "image": "octoprint/octoprint:latest",
+      "logo": "https://raw.githubusercontent.com/pi-hosted/pi-hosted/master/images/octoprint.png",
+      "name": "octoprint",
+      "platform": "linux",
+      "ports": [
+        "8051:80/tcp"
+      ],
+      "privileged": true,
+      "restart_policy": "unless-stopped",
+      "title": "OctoPrint",
+      "type": 1,
+      "volumes": [
+        {
+          "bind": "/portainer/Files/AppData/Config/OctoPrint",
+          "container": "/octoprint"
+        },
+        {
+          "bind": "/dev",
+          "container": "/dev"
+        }
+      ],
+      "note": "<b>Template created by Pi-Hosted Series</b><br><b>Check our Github page: <a href=\"https://github.com/pi-hosted/pi-hosted\" target=\"_blank\">https://github.com/pi-hosted/pi-hosted</a></b><br><br><b>Official Webpage: </b><a href=\"https://octoprint.org/\" target=\"_blank\">https://octoprint.org/</a><br><b>Official Docker Documentation: </b><a href=\"https://hub.docker.com/r/octoprint/octoprint\" target=\"_blank\">https://hub.docker.com/r/octoprint/octoprint</a><br><br><br>",
+      "maintainer": " https://github.com/novaspirit/pi-hosted/"
+    },
+    {
+      "id": 251,
+      "categories": [
+        "Management",
+        "Tools"
+      ],
+      "description": "TP-Link Omada is a software-defined network solution. The EAP Controller is used to manage multiple EAPs. Raspberry Pi 1 and Zero are not supported.",
+      "env": [
+        {
+          "default": "1000",
+          "label": "PUID",
+          "name": "PUID"
+        },
+        {
+          "default": "1000",
+          "label": "PGID",
+          "name": "PGID"
+        }
+      ],
+      "image": "mbentley/omada-controller:latest",
+      "logo": "https://raw.githubusercontent.com/pi-hosted/pi-hosted/master/images/omada.png",
+      "name": "omada-controller",
+      "platform": "linux",
+      "ports": [
+        "8088:8088/tcp",
+        "8043:8043/tcp",
+        "27001:27001/udp",
+        "27002:27002/tcp",
+        "29810:29810/udp",
+        "29811:29811/tcp",
+        "29812:29812/tcp",
+        "29813:29813/tcp"
+      ],
+      "restart_policy": "unless-stopped",
+      "title": "Omada EAP Controller",
+      "type": 1,
+      "volumes": [
+        {
+          "bind": "/portainer/Files/AppData/Config/Omada",
+          "container": "/config"
+        }
+      ],
+      "note": "<b>Template created by Pi-Hosted Series</b><br><b>Check our Github page: <a href=\"https://github.com/pi-hosted/pi-hosted\" target=\"_blank\">https://github.com/pi-hosted/pi-hosted</a></b><br><br><b>Official Webpage: </b><a href=\"https://www.tp-link.com/us/business-networking/omada-sdn-controller/\" target=\"_blank\">https://www.tp-link.com/us/business-networking/omada-sdn-controller/</a><br><b>Official Docker Documentation: </b><a href=\"https://hub.docker.com/r/mbentley/omada-controller\" target=\"_blank\">https://hub.docker.com/r/mbentley/omada-controller</a><br><br><br>",
+      "maintainer": " https://github.com/novaspirit/pi-hosted/"
+    },
+    {
+      "id": 252,
+      "categories": [
+        "Cloud",
+        "Management",
+        "Productivity"
+      ],
+      "description": "Paperless-ngx is a document management system that transforms your physical documents into a searchable online archive so you can keep, well, less paper.  Paperless-ngx forked from paperless-ng to continue the great work and distribute responsibility of supporting and advancing the project among a team of people. Consider joining us! Discussion of this transition can be found in issues #1599 and #1632.  A demo is available at demo.paperless-ngx.com using login demo / demo. Note: demo content is reset frequently and confidential information should not be uploaded.",
+      "env": [
+        {
+          "default": "1000",
+          "label": "PUID",
+          "name": "PUID",
+          "description": "for UserID"
+        },
+        {
+          "default": "1000",
+          "label": "PGID",
+          "name": "PGID",
+          "description": "for GroupID"
+        },
+        {
+          "default": "America/New_York",
+          "label": "TZ",
+          "name": "TZ",
+          "description": "Specify a timezone to use for example America/New_York"
+        },
+        {
+          "default": "",
+          "label": "PAPERLESS_URL",
+          "name": "PAPERLESSURL",
+          "description": "Example https://paperless.example.com.  It would be best to run this behind a reverse proxy"
+        },
+        {
+          "default": "",
+          "label": "Administrator username",
+          "name": "ADMIN_USER",
+          "description": "Set the name of the default admin user."
+        },
+        {
+          "default": "",
+          "label": "Administrator password",
+          "name": "ADMIN_PASS",
+          "description": "Set the password of the default admin user."
+        },
+        {
+          "default": "",
+          "label": "Secret Key",
+          "name": "RANDOMKEY",
+          "description": "This should be a very long sequence of random characters."
+        },
+        {
+          "default": "eng",
+          "label": "OCR Language",
+          "name": "LANG",
+          "description": "The default language to use for OCR"
+        }
+      ],
+      "logo": "https://raw.githubusercontent.com/pi-hosted/pi-hosted/master/images/paperless.png",
+      "name": "paperless-ngx",
+      "repository": {
+        "stackfile": "stack/paperless-ngx.yml",
+        "url": "https://github.com/pi-hosted/pi-hosted/"
+      },
+      "platform": "linux",
+      "restart_policy": "unless-stopped",
+      "title": "Paperless NGX",
+      "type": 3,
+      "note": "<b>Template created by Pi-Hosted Series</b><br><b>Check our Github page: <a href=\"https://github.com/pi-hosted/pi-hosted\" target=\"_blank\">https://github.com/pi-hosted/pi-hosted</a></b><br><br><b>Official Webpage: </b><a href=\"https://github.com/paperless-ngx/paperless-ngx\" target=\"_blank\">https://github.com/paperless-ngx/paperless-ngx</a><br><b>Official Docker Documentation: </b><a href=\"https://github.com/paperless-ngx/paperless-ngx\" target=\"_blank\">https://github.com/paperless-ngx/paperless-ngx</a><br><br><br>",
+      "maintainer": " https://github.com/novaspirit/pi-hosted/"
+    },
+    {
+      "id": 253,
+      "categories": [
+        "Other",
+        "Tools"
+      ],
+      "description": "Passbolt is a free and open source password manager designed for collaboration. With Passbolt you can securely generate, store, manage and monitor your team credentials. Get access to all of your logins and passwords from multiple browsers or even your mobile phone.",
+      "env": [
+        {
+          "default": "1000",
+          "description": "Enter your user's PUID here",
+          "label": "PUID",
+          "name": "PUID"
+        },
+        {
+          "default": "1000",
+          "description": "Enter your user's PGID here",
+          "label": "PGID",
+          "name": "PGID"
+        },
+        {
+          "default": "Europe/Zurich",
+          "description": "Enter your time zone here. See examples https://en.wikipedia.org/wiki/List_of_tz_database_time_zones",
+          "label": "TZ",
+          "name": "TZ"
+        },
+        {
+          "default": "",
+          "description": "Enter your MySql root password here",
+          "label": "MYSQL_ROOT_PASSWORD",
+          "name": "MYSQL_ROOT_PASSWORD"
+        },
+        {
+          "default": "passbolt",
+          "description": "Enter your Passbolt database name here",
+          "label": "MYSQL_DATABASE",
+          "name": "MYSQL_DATABASE"
+        },
+        {
+          "default": "passbolt",
+          "description": "Enter your Passbolt database user here",
+          "label": "MYSQL_USER",
+          "name": "MYSQL_USER"
+        },
+        {
+          "default": "",
+          "description": "Enter your Passbolt database password here",
+          "label": "MYSQL_PASSWORD",
+          "name": "MYSQL_PASSWORD"
+        },
+        {
+          "default": "443",
+          "description": "Enter your Passbolt https port here",
+          "label": "PASSBOLT_PORT",
+          "name": "PASSBOLT_PORT"
+        },
+        {
+          "default": "https://passbolt.local",
+          "description": "Enter your full Passbolt https base URL here. Including port if different from 443",
+          "label": "PASSBOLT_URL",
+          "name": "PASSBOLT_URL"
+        },
+        {
+          "default": "Passbolt",
+          "description": "Enter your from email name",
+          "label": "EMAIL_FROM_NAME",
+          "name": "EMAIL_FROM_NAME"
+        },
+        {
+          "default": "",
+          "description": "Enter your from email address",
+          "label": "EMAIL_FROM_ADDRESS",
+          "name": "EMAIL_FROM_ADDRESS"
+        },
+        {
+          "default": "smtp.gmail.com",
+          "description": "Enter your email smtp server here",
+          "label": "EMAIL_SMTP_SERVER",
+          "name": "EMAIL_SMTP_SERVER"
+        },
+        {
+          "default": "587",
+          "description": "Enter your email smtp port here",
+          "label": "EMAIL_SMTP_PORT",
+          "name": "EMAIL_SMTP_PORT"
+        },
+        {
+          "default": "",
+          "description": "Enter your email username here",
+          "label": "EMAIL_USERNAME",
+          "name": "EMAIL_USERNAME"
+        },
+        {
+          "default": "",
+          "description": "Enter your email password here",
+          "label": "EMAIL_PASSWORD",
+          "name": "EMAIL_PASSWORD"
+        },
+        {
+          "default": "true",
+          "description": "Enter set TLS here",
+          "label": "EMAIL_TLS",
+          "name": "EMAIL_TLS"
+        }
+      ],
+      "logo": "https://raw.githubusercontent.com/pi-hosted/pi-hosted/master/images/passbolt.png",
+      "name": "Passbolt",
+      "platform": "linux",
+      "repository": {
+        "stackfile": "stack/passbolt.yml",
+        "url": "https://github.com/pi-hosted/pi-hosted"
+      },
+      "restart_policy": "unless-stopped",
+      "title": "Passbolt",
+      "type": 3,
+      "note": "<b>Template created by Pi-Hosted Series</b><br><b>Check our Github page: <a href=\"https://github.com/pi-hosted/pi-hosted\" target=\"_blank\">https://github.com/pi-hosted/pi-hosted</a></b><br><br><b>Official Webpage: </b><a href=\"https://github.com/pi-hosted/pi-hosted/blob/master/docs/passbolt.md\" target=\"_blank\">https://github.com/pi-hosted/pi-hosted/blob/master/docs/passbolt.md</a><br><b>Official Docker Documentation: </b><a href=\"https://github.com/pi-hosted/pi-hosted/blob/master/docs/passbolt.md\" target=\"_blank\">https://github.com/pi-hosted/pi-hosted/blob/master/docs/passbolt.md</a><br><h3><b>Pi-Hosted dedicated documentation: </b><a href=\"https://github.com/pi-hosted/pi-hosted/blob/master/docs/passbolt.md\" target=\"_blank\">passbolt.md</a></h3><br><br><br>",
+      "maintainer": " https://github.com/novaspirit/pi-hosted/"
+    },
+    {
+      "id": 254,
+      "categories": [
+        "Other",
+        "Tools"
+      ],
+      "description": "PGAdmin is a web-based GUI tool used to interact with the Postgres database sessions, both locally and remote servers as well. You can use PGAdmin to perform any sort of database administration required for a Postgres database.",
+      "env": [
+        {
+          "default": "1000",
+          "label": "PUID",
+          "name": "PUID"
+        },
+        {
+          "default": "1000",
+          "label": "PGID",
+          "name": "PGID"
+        },
+        {
+          "default": "",
+          "label": "PGADMIN_DEFAULT_EMAIL",
+          "name": "PGADMIN_DEFAULT_EMAIL"
+        },
+        {
+          "default": "",
+          "label": "PGADMIN_DEFAULT_PASSWORD",
+          "name": "PGADMIN_DEFAULT_PASSWORD"
+        },
+        {
+          "default": "America/New_York",
+          "label": "TZ",
+          "name": "TZ"
+        }
+      ],
+      "image": "dpage/pgadmin4:latest",
+      "logo": "https://raw.githubusercontent.com/pi-hosted/pi-hosted/master/images/pgadmin.png",
+      "name": "pgadmin",
+      "platform": "linux",
+      "ports": [
+        "5050:80/tcp"
+      ],
+      "restart_policy": "unless-stopped",
+      "title": "pgAdmin",
+      "type": 1,
+      "volumes": [
+        {
+          "bind": "/portainer/Files/AppData/Config/pgadmin",
+          "container": "/var/lib/pgadmin"
+        }
+      ],
+      "note": "<b>Template created by Pi-Hosted Series</b><br><b>Check our Github page: <a href=\"https://github.com/pi-hosted/pi-hosted\" target=\"_blank\">https://github.com/pi-hosted/pi-hosted</a></b><br><br><b>Official Webpage: </b><a href=\"https://www.pgadmin.org/\" target=\"_blank\">https://www.pgadmin.org/</a><br><b>Official Docker Documentation: </b><a href=\"https://www.pgadmin.org/docs/pgadmin4/latest/container_deployment.html\" target=\"_blank\">https://www.pgadmin.org/docs/pgadmin4/latest/container_deployment.html</a><br><br><h3><b><a href=\"https://github.com/pi-hosted/pi-hosted/blob/master/tools/install_pgadmin.sh\" target=\"_blank\">Pre-installation script</a> must be RAN before you install: </b>wget -qO- https://raw.githubusercontent.com/pi-hosted/pi-hosted/master/tools/install_pgadmin.sh | bash</h3><br><br>",
+      "maintainer": " https://github.com/novaspirit/pi-hosted/"
+    },
+    {
+      "id": 255,
+      "categories": [
+        "Other",
+        "Tools"
+      ],
+      "description": "A Linux network-level advertisement and Internet tracker blocking application which acts as a DNS sinkhole with both DoH (DNS over HTTPS) and DoT (DNS over TLS) clients.",
+      "image": "oijkn/pihole-doh-dot:latest",
+      "logo": "https://raw.githubusercontent.com/pi-hosted/pi-hosted/master/images/pihole_doh-dot.png",
+      "name": "pihole DoH/DoT",
+      "note": "<b>Template created by Pi-Hosted Series</b><br><b>Check our Github page: <a href=\"https://github.com/pi-hosted/pi-hosted\" target=\"_blank\">https://github.com/pi-hosted/pi-hosted</a></b><br><br><b>Official Webpage: </b><a href=\"https://pi-hole.net/\" target=\"_blank\">https://pi-hole.net/</a><br><b>Official Docker Documentation: </b><a href=\"https://hub.docker.com/r/oijkn/pihole-doh-dot\" target=\"_blank\">https://hub.docker.com/r/oijkn/pihole-doh-dot</a><br><h3><b>Pi-Hosted dedicated documentation: </b><a href=\"https://github.com/pi-hosted/pi-hosted/blob/master/docs/pi-hole.md\" target=\"_blank\">pi-hole.md</a></h3><br><br><br>When the installation is complete, navigate to your.ip.goes.here:1010/admin. Follow the article <a href='https://medium.com/@niktrix/getting-rid-of-systemd-resolved-consuming-port-53-605f0234f32f'>here</a> if you run into issues binding to port 53. If you like to use Pi-Hole's built in DHCP-Server change the Network type to host and open advance options and scroll to Labels and add: NET_ADMIN with the value True. When you do so, specify a port is no more needed, navigate to your.ip.goes.here/admin.",
+      "platform": "linux",
+      "ports": [
+        "53:53/tcp",
+        "53:53/udp",
+        "67:67/udp",
+        "1010:80/tcp",
+        "4443:443/tcp"
+      ],
+      "restart_policy": "unless-stopped",
+      "title": "Pi-Hole DoH/DoT",
+      "type": 1,
+      "volumes": [
+        {
+          "bind": "/portainer/Files/AppData/Config/PiHole_DoH-DoT",
+          "container": "/etc/pihole"
+        },
+        {
+          "bind": "/portainer/Files/AppData/Config/PiHole_DoH-DoT/DNS",
+          "container": "/etc/dnsmasq.d"
+        }
+      ],
+      "maintainer": " https://github.com/novaspirit/pi-hosted/"
+    },
+    {
+      "id": 256,
+      "categories": [
+        "Other",
+        "Tools"
+      ],
+      "description": "A Linux network-level advertisement and Internet tracker blocking application which acts as a DNS sinkhole. This version has Ubound software installed on it so you don't need to rely on external DNS providers. When the installation is complete, navigate to your.ip.goes.here:1010/admin. Follow the article <a href='https://medium.com/@niktrix/getting-rid-of-systemd-resolved-consuming-port-53-605f0234f32f'>here</a>",
+      "env": [
+        {
+          "default": "192.168.0.X",
+          "description": "Insert the Raspberry Pi IP here",
+          "label": "ServerIP",
+          "name": "ServerIP"
+        },
+        {
+          "default": "Europe\\London",
+          "label": "TZ",
+          "name": "TZ"
+        },
+        {
+          "label": "DNSSEC",
+          "name": "DNSSEC",
+          "select": [
+            {
+              "default": true,
+              "text": "Enable DNSSEC",
+              "value": "true"
+            },
+            {
+              "text": "Disable DNSSEC",
+              "value": "false"
+            }
+          ]
+        },
+        {
+          "default": "127.0.0.1#5335",
+          "label": "DNS1",
+          "name": "DNS1",
+          "preset": true
+        },
+        {
+          "default": "127.0.0.1#5335",
+          "label": "DNS2",
+          "name": "DNS2",
+          "preset": true
+        }
+      ],
+      "image": "cbcrowe/pihole-unbound:latest",
+      "logo": "https://raw.githubusercontent.com/pi-hosted/pi-hosted/master/images/pihole-unbound.png",
+      "name": "pihole-unbound",
+      "note": "<b>Template created by Pi-Hosted Series</b><br><b>Check our Github page: <a href=\"https://github.com/pi-hosted/pi-hosted\" target=\"_blank\">https://github.com/pi-hosted/pi-hosted</a></b><br><br><b>Official Webpage: </b><a href=\"https://pi-hole.net/\" target=\"_blank\">https://pi-hole.net/</a><br><b>Official Docker Documentation: </b><a href=\"https://github.com/chriscrowe/docker-pihole-unbound/tree/master/one-container\" target=\"_blank\">https://github.com/chriscrowe/docker-pihole-unbound/tree/master/one-container</a><br><h3><b>Pi-Hosted dedicated documentation: </b><a href=\"https://github.com/pi-hosted/pi-hosted/blob/master/docs/pi-hole.md\" target=\"_blank\">pi-hole.md</a></h3><br><br><br>When the installation is complete, navigate to your.ip.goes.here:1010/admin. Follow the article <a href='https://medium.com/@niktrix/getting-rid-of-systemd-resolved-consuming-port-53-605f0234f32f'>here</a> if you run into issues binding to port 53. For extra information on this container visit the mainteiner <a href='https://github.com/chriscrowe/docker-pihole-unbound/tree/master/one-container'>GitHub Page</a>. You can add ports: 5335 to access Ubound externally; 22 to enable SSH; 67 to use DHCP Server. Add those ports in Show advanced options. if you run into issues binding to port 53. If you like to use Pi-Hole's built in DHCP-Server change the Network type to host and open advance options and scroll to Labels and add: NET_ADMIN with the value True. When you do so, specify a port is no more needed, navigate to your.ip.goes.here/admin.",
+      "platform": "linux",
+      "ports": [
+        "53:53/tcp",
+        "53:53/udp",
+        "1010:80/tcp",
+        "4443:443/tcp"
+      ],
+      "restart_policy": "unless-stopped",
+      "title": "Pi-Hole-Unbound",
+      "type": 1,
+      "volumes": [
+        {
+          "bind": "/portainer/Files/AppData/Config/PiHole-Unbound",
+          "container": "/etc/pihole"
+        },
+        {
+          "bind": "/portainer/Files/AppData/Config/PiHole-Unbound/DNS",
+          "container": "/etc/dnsmasq.d"
+        }
+      ],
+      "maintainer": " https://github.com/novaspirit/pi-hosted/"
+    },
+    {
+      "id": 257,
+      "categories": [
+        "Other"
+      ],
+      "description": "Wireless control of PixelStrips or NeoPixels using a web graphical interface running on a Raspberry Pi.",
+      "image": "macley/pixel-server:latest",
+      "logo": "https://lirp.cdn-website.com/c73f56a6/dms3rep/multi/opt/ir.appnice.controlpad_512x512-640w.png",
+      "name": "pixel-server",
+      "platform": "linux",
+      "ports": [
+        "85:80/tcp"
+      ],
+      "restart_policy": "unless-stopped",
+      "title": "Pixel-server",
+      "type": 1,
+      "volumes": [
+        {
+          "bind": "/portainer/Files/AppData/Config/pixel-server/auth.cfg",
+          "container": "/opt/pixel-server/auth.cfg"
+        },
+        {
+          "bind": "/portainer/Files/AppData/Config/pixel-server/pixelserver.cfg",
+          "container": "/opt/pixel-server/pixelserver.cfg"
+        },
+        {
+          "bind": "/portainer/Files/AppData/Config/pixel-server/users.cfg",
+          "container": "/opt/pixel-server/users.cfg"
+        },
+        {
+          "container": "/etc/crontabs/"
+        }
+      ],
+      "privileged": true,
+      "note": "<b>Template created by Pi-Hosted Series</b><br><b>Check our Github page: <a href=\"https://github.com/pi-hosted/pi-hosted\" target=\"_blank\">https://github.com/pi-hosted/pi-hosted</a></b><br><br><b>Official Webpage: </b><a href=\"http://www.penguintutor.com/projects/pixel-server\" target=\"_blank\">http://www.penguintutor.com/projects/pixel-server</a><br><b>Official Docker Documentation: </b><a href=\"https://github.com/Macleykun/pixel-server\" target=\"_blank\">https://github.com/Macleykun/pixel-server</a><br><h3><b>Pi-Hosted dedicated documentation: </b><a href=\"https://github.com/pi-hosted/pi-hosted/blob/master/docs/pixel-server_setup.md\" target=\"_blank\">pixel-server_setup.md</a></h3><br><br><h3><b><a href=\"https://github.com/pi-hosted/pi-hosted/blob/master/tools/install_pixel-server.sh\" target=\"_blank\">Pre-installation script</a> must be RAN before you install: </b>wget -qO- https://raw.githubusercontent.com/pi-hosted/pi-hosted/master/tools/install_pixel-server.sh | bash</h3><br><br>",
+      "maintainer": " https://github.com/novaspirit/pi-hosted/"
+    },
+    {
+      "id": 258,
+      "categories": [
+        "Other",
+        "Tools"
+      ],
+      "description": "PostgreSQL, also known as Postgres, is a free and open-source relational database management system emphasizing extensibility and SQL compliance.",
+      "env": [
+        {
+          "default": "1000",
+          "label": "PUID",
+          "name": "PUID"
+        },
+        {
+          "default": "1000",
+          "label": "PGID",
+          "name": "PGID"
+        },
+        {
+          "default": "rootpassword",
+          "label": "POSTGRES_PASSWORD",
+          "name": "POSTGRES_PASSWORD"
+        },
+        {
+          "default": "America/New_York",
+          "label": "TZ",
+          "name": "TZ"
+        }
+      ],
+      "image": "postgres:latest",
+      "logo": "https://raw.githubusercontent.com/pi-hosted/pi-hosted/master/images/postgresql.png",
+      "name": "postgresql",
+      "platform": "linux",
+      "ports": [
+        "5432:5432/tcp"
+      ],
+      "restart_policy": "unless-stopped",
+      "title": "PostgreSQL",
+      "type": 1,
+      "volumes": [
+        {
+          "bind": "/portainer/Files/AppData/Config/PostgreSQL",
+          "container": "/var/lib/postgresql/data"
+        }
+      ],
+      "note": "<b>Template created by Pi-Hosted Series</b><br><b>Check our Github page: <a href=\"https://github.com/pi-hosted/pi-hosted\" target=\"_blank\">https://github.com/pi-hosted/pi-hosted</a></b><br><br><b>Official Webpage: </b><a href=\"https://www.postgresql.org/\" target=\"_blank\">https://www.postgresql.org/</a><br><b>Official Docker Documentation: </b><a href=\"https://hub.docker.com/_/postgres/\" target=\"_blank\">https://hub.docker.com/_/postgres/</a><br><br><br>",
+      "maintainer": " https://github.com/novaspirit/pi-hosted/"
+    },
+    {
+      "id": 259,
+      "categories": [
+        "Cloud",
+        "Productivity",
+        "Tools",
+        "Web"
+      ],
+      "description": "PrivateBin is a minimalist, open source online pastebin where the server has zero knowledge of pasted data!\n  ",
+      "env": [
+        {
+          "default": "1000",
+          "label": "PUID",
+          "name": "PUID"
+        },
+        {
+          "default": "1000",
+          "label": "PGID",
+          "name": "PGID"
+        }
+      ],
+      "image": "privatebin/nginx-fpm-alpine:latest",
+      "logo": "https://raw.githubusercontent.com/pi-hosted/pi-hosted/master/images/privatebin.png",
+      "name": "privatebin",
+      "platform": "linux",
+      "ports": [
+        "8080:8080/tcp"
+      ],
+      "privileged": true,
+      "restart_policy": "unless-stopped",
+      "title": "PrivateBin",
+      "type": 1,
+      "volumes": [
+        {
+          "bind": "/portainer/Files/AppData/PrivateBin",
+          "container": "/srv/data"
+        },
+        {
+          "bind": "/portainer/Files/AppData/Config/PrivateBin",
+          "container": "/srv/cfg"
+        }
+      ],
+      "note": "<b>Template created by Pi-Hosted Series</b><br><b>Check our Github page: <a href=\"https://github.com/pi-hosted/pi-hosted\" target=\"_blank\">https://github.com/pi-hosted/pi-hosted</a></b><br><br><b>Official Webpage: </b><a href=\"https://privatebin.info/\" target=\"_blank\">https://privatebin.info/</a><br><b>Official Docker Documentation: </b><a href=\"https://hub.docker.com/r/privatebin/nginx-fpm-alpine\" target=\"_blank\">https://hub.docker.com/r/privatebin/nginx-fpm-alpine</a><br><br><br>",
+      "maintainer": " https://github.com/novaspirit/pi-hosted/"
+    },
+    {
+      "id": 260,
+      "categories": [
+        "Downloaders"
+      ],
+      "description": "A docker image with qBittorrent and the Flood UI, also optional WireGuard VPN support. See the official documentation for WireGuard VPN support at https://hotio.dev/containers/qflood/",
+      "env": [
+        {
+          "default": "1000",
+          "label": "PUID",
+          "name": "PUID"
+        },
+        {
+          "default": "1000",
+          "label": "PGID",
+          "name": "PGID"
+        },
+        {
+          "default": "002",
+          "label": "UMASK",
+          "name": "UMASK"
+        },
+        {
+          "default": "America/New_York",
+          "label": "TZ",
+          "name": "TZ"
+        },
+        {
+          "default": "false",
+          "label": "FLOOD_AUTH",
+          "name": "FLOOD_AUTH"
+        }
+      ],
+      "image": "hotio/qflood:latest",
+      "logo": "https://raw.githubusercontent.com/jesec/flood/master/flood.svg",
+      "name": "qflood",
+      "note": "<b>Template created by Pi-Hosted Series</b><br><b>Check our Github page: <a href=\"https://github.com/pi-hosted/pi-hosted\" target=\"_blank\">https://github.com/pi-hosted/pi-hosted</a></b><br><br><b>Official Webpage: </b><a href=\"https://hotio.dev/containers/qflood/\" target=\"_blank\">https://hotio.dev/containers/qflood/</a><br><b>Official Docker Documentation: </b><a href=\"https://hotio.dev/containers/qflood/\" target=\"_blank\">https://hotio.dev/containers/qflood/</a><br><br><br>The default qBittorrent username is admin and the default password is adminadmin.",
+      "platform": "linux",
+      "ports": [
+        "3000:3000/tcp",
+        "8080:8080/tcp"
+      ],
+      "restart_policy": "unless-stopped",
+      "title": "qFlood",
+      "type": 1,
+      "volumes": [
+        {
+          "bind": "/portainer/Files/AppData/Config/qFlood",
+          "container": "/config"
+        },
+        {
+          "bind": "/portainer/Downloads",
+          "container": "/app/qBittorrent/downloads"
+        }
+      ],
+      "maintainer": " https://github.com/novaspirit/pi-hosted/"
+    },
+    {
+      "id": 261,
+      "categories": [
+        "Monitor",
+        "Tools"
+      ],
+      "description": "Monitor your Raspberry Pi and Dockers using Grafana developed by oijkn. Please download grafana configs from his git https://github.com/oijkn/Docker-Raspberry-PI-Monitoring",
+      "env": [
+        {
+          "default": "15d",
+          "label": "PROMETHEUS_RETENTION",
+          "name": "PROMETHEUS_RETENTION"
+        }
+      ],
+      "logo": "https://raw.githubusercontent.com/pi-hosted/pi-hosted/master/images/rpi_monitor.png",
+      "name": "RaspberryPi-Docker-Monitor",
+      "platform": "linux",
+      "ports": [
+        "3000:3000/tcp"
+      ],
+      "repository": {
+        "stackfile": "stack/raspberrypi-monitoring.yml",
+        "url": "https://github.com/pi-hosted/pi-hosted"
+      },
+      "restart_policy": "unless-stopped",
+      "title": "Raspberry Pi Docker Monitor",
+      "type": 3,
+      "note": "<b>Template created by Pi-Hosted Series</b><br><b>Check our Github page: <a href=\"https://github.com/pi-hosted/pi-hosted\" target=\"_blank\">https://github.com/pi-hosted/pi-hosted</a></b><br><br><b>Official Webpage: </b><a href=\"https://github.com/pi-hosted/pi-hosted/blob/master/docs/rpi_docker_monitor.md\" target=\"_blank\">https://github.com/pi-hosted/pi-hosted/blob/master/docs/rpi_docker_monitor.md</a><br><b>Official Docker Documentation: </b><a href=\"https://github.com/pi-hosted/pi-hosted/blob/master/docs/rpi_docker_monitor.md\" target=\"_blank\">https://github.com/pi-hosted/pi-hosted/blob/master/docs/rpi_docker_monitor.md</a><br><h3><b>Pi-Hosted dedicated documentation: </b><a href=\"https://github.com/pi-hosted/pi-hosted/blob/master/docs/rpi_docker_monitor.md\" target=\"_blank\">rpi_docker_monitor.md</a></h3><br><br><h3><b><a href=\"https://github.com/pi-hosted/pi-hosted/blob/master/tools/rpi_docker_monitor.sh\" target=\"_blank\">Pre-installation script</a> must be RAN before you install: </b>wget -qO- https://raw.githubusercontent.com/pi-hosted/pi-hosted/master/tools/rpi_docker_monitor.sh | bash</h3><br><br><b>Youtube Video: </b><a href=https://www.youtube.com/watch?v=IoD3vFuep64&list=PL846hFPMqg3jwkxcScD1xw2bKXrJVvarc&index=8 target=\"_blank\">Novaspirit Tech - Raspberry Pi Docker Monitoring</a><br><br>",
+      "maintainer": " https://github.com/novaspirit/pi-hosted/"
+    },
+    {
+      "id": 262,
+      "categories": [
+        "Other",
+        "Tools"
+      ],
+      "description": "A remote desktop software, the open source TeamViewer alternative, works out of the box, no configuration required. You have full control of your data, with no concerns about security.",
+      "env": [
+        {
+          "default": "rustdesk.example.com:21117",
+          "description": "Use your domain with the default 21117 port",
+          "label": "RELAY",
+          "name": "RELAY"
+        },
+        {
+          "default": "1",
+          "description": "if set to \"1\" unencrypted connection will not be accepted",
+          "label": "ENCRYPTED_ONLY",
+          "name": "ENCRYPTED_ONLY"
+        }
+      ],
+      "image": "rustdesk/rustdesk-server-s6:latest",
+      "logo": "https://raw.githubusercontent.com/pi-hosted/pi-hosted/master/images/rustdesk.png",
+      "name": "rustdesk",
+      "note": "<b>Template created by Pi-Hosted Series</b><br><b>Check our Github page: <a href=\"https://github.com/pi-hosted/pi-hosted\" target=\"_blank\">https://github.com/pi-hosted/pi-hosted</a></b><br><br><b>Official Webpage: </b><a href=\"https://rustdesk.com/\" target=\"_blank\">https://rustdesk.com/</a><br><b>Official Docker Documentation: </b><a href=\"https://github.com/rustdesk/rustdesk-server\" target=\"_blank\">https://github.com/rustdesk/rustdesk-server</a><br><br><br><b>Youtube Video: </b><a href=https://www.youtube.com/watch?v=PDnqFnnbVHg target=\"_blank\">Novaspirit Tech - Rust Desk Open Source Remote Desktop</a><br><br>Don't forget to open ports 21115 to 21119 in your router.",
+      "platform": "linux",
+      "ports": [
+        "21115:21115/tcp",
+        "21116:21116/tcp",
+        "21116:21116/udp",
+        "21117:21117/tcp",
+        "21118:21118/tcp",
+        "21119:21119/tcp"
+      ],
+      "restart_policy": "unless-stopped",
+      "title": "RustDesk",
+      "type": 1,
+      "volumes": [
+        {
+          "bind": "/portainer/Files/AppData/Config/rustdesk",
+          "container": "/data"
+        }
+      ],
+      "maintainer": " https://github.com/novaspirit/pi-hosted/"
+    },
+    {
+      "id": 263,
+      "categories": [
+        "Other",
+        "Tools"
+      ],
+      "command": "",
+      "description": "Samba has provided secure, stable and fast file and print services for all clients using the SMB/CIFS protocol, such as all versions of DOS and Windows, OS/2, Linux and many others.",
+      "env": [
+        {
+          "default": "1000",
+          "label": "PUID",
+          "name": "PUID"
+        },
+        {
+          "default": "1000",
+          "label": "PGID",
+          "name": "PGID"
+        },
+        {
+          "default": "1000",
+          "label": "USERID",
+          "name": "USERID"
+        },
+        {
+          "default": "1000",
+          "label": "GROUPID",
+          "name": "GROUPID"
+        },
+        {
+          "default": "guest;guest",
+          "label": "USER",
+          "name": "USER"
+        },
+        {
+          "default": "true",
+          "label": "PERMISSIONS",
+          "name": "PERMISSIONS"
+        },
+        {
+          "default": "portainer;/share;yes;no;yes;guest",
+          "label": "SHARE",
+          "name": "SHARE"
+        }
+      ],
+      "image": "dperson/samba:latest",
+      "logo": "https://raw.githubusercontent.com/pi-hosted/pi-hosted/master/images/samba.png",
+      "name": "Samba",
+      "platform": "linux",
+      "ports": [
+        "139:139/tcp",
+        "445:445/tcp"
+      ],
+      "privileged": true,
+      "restart_policy": "unless-stopped",
+      "title": "Samba",
+      "type": 1,
+      "volumes": [
+        {
+          "bind": "/portainer/Downloads",
+          "container": "/share"
+        }
+      ],
+      "note": "<b>Template created by Pi-Hosted Series</b><br><b>Check our Github page: <a href=\"https://github.com/pi-hosted/pi-hosted\" target=\"_blank\">https://github.com/pi-hosted/pi-hosted</a></b><br><br><b>Official Webpage: </b><a href=\"https://www.samba.org/\" target=\"_blank\">https://www.samba.org/</a><br><b>Official Docker Documentation: </b><a href=\"https://github.com/dperson/samba\" target=\"_blank\">https://github.com/dperson/samba</a><br><br><br><b>Youtube Videos:</b><br><ul><li><a href=https://www.youtube.com/watch?v=2zZ3_1GRWrM&list=PL846hFPMqg3jwkxcScD1xw2bKXrJVvarc&index=11 target=\"_blank\">Novaspirit Tech - Setting up Raspberry Pi Samba Server For File Sharing on Docker</a></li><li><a href=https://www.youtube.com/watch?v=9ln6UFH4z8o target=\"_blank\">Novaspirit Tech - Building NAS with Container</a></li></ul><br><br>",
+      "maintainer": " https://github.com/novaspirit/pi-hosted/"
+    },
+    {
+      "id": 264,
+      "categories": [
+        "Other",
+        "Tools"
+      ],
+      "description": "Open-Source Privacy-respecting metasearch engine",
+      "env": [
+        {
+          "default": "http://localhost:9017",
+          "label": "BASE_URL",
+          "name": "BASE_URL"
+        },
+        {
+          "default": "my-instance",
+          "label": "INSTANCE_NAME",
+          "name": "INSTANCE_NAME"
+        }
+      ],
+      "image": "searxng/searxng:latest",
+      "logo": "https://raw.githubusercontent.com/pi-hosted/pi-hosted/master/images/searx.png",
+      "name": "SearXNG",
+      "platform": "linux",
+      "ports": [
+        "9017:8080/tcp"
+      ],
+      "restart_policy": "unless-stopped",
+      "title": "SearXNG",
+      "type": 1,
+      "volumes": [
+        {
+          "bind": "/portainer/Files/AppData/Config/searxng",
+          "container": "/etc/searxng"
+        }
+      ],
+      "note": "<b>Template created by Pi-Hosted Series</b><br><b>Check our Github page: <a href=\"https://github.com/pi-hosted/pi-hosted\" target=\"_blank\">https://github.com/pi-hosted/pi-hosted</a></b><br><br><b>Official Webpage: </b><a href=\"https://docs.searxng.org/\" target=\"_blank\">https://docs.searxng.org/</a><br><b>Official Docker Documentation: </b><a href=\"https://docs.searxng.org/admin/installation-docker.html\" target=\"_blank\">https://docs.searxng.org/admin/installation-docker.html</a><br><h3><b>Pi-Hosted dedicated documentation: </b><a href=\"https://github.com/pi-hosted/pi-hosted/blob/master/docs/searxng.md\" target=\"_blank\">searxng.md</a></h3><br><br><br>",
+      "maintainer": " https://github.com/novaspirit/pi-hosted/"
+    },
+    {
+      "id": 265,
+      "categories": [
+        "Other",
+        "Tools"
+      ],
+      "description": "Snippet Box is a simple self-hosted app for organizing your code snippets.",
+      "image": "pawelmalak/snippet-box:arm",
+      "logo": "https://raw.githubusercontent.com/pi-hosted/pi-hosted/master/images/snibox.png",
+      "name": "Snippet-box",
+      "note": "<b>Template created by Pi-Hosted Series</b><br><b>Check our Github page: <a href=\"https://github.com/pi-hosted/pi-hosted\" target=\"_blank\">https://github.com/pi-hosted/pi-hosted</a></b><br><br><b>Official Webpage: </b><a href=\"https://github.com/pawelmalak/snippet-box\" target=\"_blank\">https://github.com/pawelmalak/snippet-box</a><br><b>Official Docker Documentation: </b><a href=\"https://github.com/pawelmalak/snippet-box#with-docker\" target=\"_blank\">https://github.com/pawelmalak/snippet-box#with-docker</a><br><br><br><b>Youtube Video: </b><a href=https://www.youtube.com/watch?v=v-jUyB3fvAo target=\"_blank\">Novaspirit Tech - My Most used container! Snippet Box</a><br><br>Label-oriented interface with search. Supports various programming languages, markdown, plain text.",
+      "platform": "linux",
+      "ports": [
+        "5010:5000/tcp"
+      ],
+      "restart_policy": "unless-stopped",
+      "title": "Snippet-box",
+      "type": 1,
+      "volumes": [
+        {
+          "bind": "/portainer/Files/AppData/Config/Snippet-box",
+          "container": "/app/data"
+        }
+      ],
+      "maintainer": " https://github.com/novaspirit/pi-hosted/"
+    },
+    {
+      "id": 266,
+      "categories": [
+        "Tools",
+        "Web",
+        "Other"
+      ],
+      "description": "Run a Speedtest every hour and graph the results.  See https://hub.docker.com/r/henrywhitaker3/speedtest-tracker/tags for arch options",
+      "env": [
+        {
+          "default": "true",
+          "label": "OOKLA_EULA_GDPR",
+          "name": "OOKLA_EULA_GDPR"
+        }
+      ],
+      "image": "henrywhitaker3/speedtest-tracker:dev-arm",
+      "logo": "https://raw.githubusercontent.com/pi-hosted/pi-hosted/master/images/speedtest-tracker.png",
+      "name": "speedtest-tracker",
+      "platform": "linux",
+      "ports": [
+        "8765:80/tcp"
+      ],
+      "restart_policy": "unless-stopped",
+      "title": "Speedtest Tracker",
+      "type": 1,
+      "volumes": [
+        {
+          "bind": "/portainer/Files/AppData/Config/speedtest-tracker",
+          "container": "/config"
+        }
+      ],
+      "note": "<b>Template created by Pi-Hosted Series</b><br><b>Check our Github page: <a href=\"https://github.com/pi-hosted/pi-hosted\" target=\"_blank\">https://github.com/pi-hosted/pi-hosted</a></b><br><br><b>Official Webpage: </b><a href=\"https://github.com/henrywhitaker3/Speedtest-Tracker\" target=\"_blank\">https://github.com/henrywhitaker3/Speedtest-Tracker</a><br><b>Official Docker Documentation: </b><a href=\"https://github.com/henrywhitaker3/Speedtest-Tracker#using-docker\" target=\"_blank\">https://github.com/henrywhitaker3/Speedtest-Tracker#using-docker</a><br><br><br>",
+      "maintainer": " https://github.com/novaspirit/pi-hosted/"
+    },
+    {
+      "id": 267,
+      "categories": [
+        "Tools",
+        "Web"
+      ],
+      "description": "Sshwifty is a SSH and Telnet connector made for the Web. It can be deployed on your computer or server to provide SSH and Telnet access interface for any compatible (standard) web browser.",
+      "image": "niruix/sshwifty:latest",
+      "logo": "https://raw.githubusercontent.com/pi-hosted/pi-hosted/master/images/sshwifty-icon.png",
+      "name": "Sshwifty",
+      "platform": "linux",
+      "ports": [
+        "8182:8182/tcp"
+      ],
+      "restart_policy": "unless-stopped",
+      "title": "Sshwifty",
+      "type": 1,
+      "note": "<b>Template created by Pi-Hosted Series</b><br><b>Check our Github page: <a href=\"https://github.com/pi-hosted/pi-hosted\" target=\"_blank\">https://github.com/pi-hosted/pi-hosted</a></b><br><br><b>Official Webpage: </b><a href=\"https://sshwifty.herokuapp.com/\" target=\"_blank\">https://sshwifty.herokuapp.com/</a><br><b>Official Docker Documentation: </b><a href=\"https://github.com/nirui/sshwifty#docker-image\" target=\"_blank\">https://github.com/nirui/sshwifty#docker-image</a><br><br><br>",
+      "maintainer": " https://github.com/novaspirit/pi-hosted/"
+    },
+    {
+      "id": 268,
+      "categories": [
+        "Other",
+        "Tool"
+      ],
+      "description": "SurrealDB is an end-to-end cloud native database for web, mobile, serverless, jamstack, backend, and traditional applications.",
+      "image": "surrealdb/surrealdb:latest",
+      "logo": "",
+      "name": "SurrealDB",
+      "env": [
+        {
+          "default": "default_username",
+          "label": "SDB_USERNAME",
+          "name": "SDB_USERNAME"
+        },
+        {
+          "default": "default_password",
+          "label": "SDB_PASSWORD",
+          "name": "SDB_PASSWORD"
+        }
+      ],
+      "platform": "linux",
+      "ports": [
+        "8020:8000/tcp"
+      ],
+      "command": "start --user ${SDB_USERNAME} --pass ${SDB_PASSWORD} file:/data/database.db",
+      "volumes": [
+        {
+          "bind": "/portainer/Files/AppData/Config/surrealdb/data",
+          "container": "/data"
+        }
+      ],
+      "restart_policy": "unless-stopped",
+      "title": "SurrealDB",
+      "type": 1,
+      "note": "<b>Template created by Pi-Hosted Series</b><br><b>Check our Github page: <a href=\"https://github.com/pi-hosted/pi-hosted\" target=\"_blank\">https://github.com/pi-hosted/pi-hosted</a></b><br><br><b>Official Webpage: </b><a href=\"https://surrealdb.com/\" target=\"_blank\">https://surrealdb.com/</a><br><b>Official Docker Documentation: </b><a href=\"https://hub.docker.com/r/surrealdb/surrealdb\" target=\"_blank\">https://hub.docker.com/r/surrealdb/surrealdb</a><br><br><br>",
+      "maintainer": " https://github.com/novaspirit/pi-hosted/"
+    },
+    {
+      "id": 269,
+      "categories": [
+        "Monitor",
+        "Other"
+      ],
+      "description": "A quick way to display system stats on a 128x64 I2C OLED display.",
+      "env": [
+        {
+          "default": "8",
+          "label": "start displaying screen",
+          "name": "start"
+        },
+        {
+          "default": "23",
+          "label": "end displaying screen",
+          "name": "end"
+        }
+      ],
+      "note": "<b>Template created by Pi-Hosted Series</b><br><b>Check our Github page: <a href=\"https://github.com/pi-hosted/pi-hosted\" target=\"_blank\">https://github.com/pi-hosted/pi-hosted</a></b><br><br><b>Official Webpage: </b><a href=\"https://www.the-diy-life.com/\" target=\"_blank\">https://www.the-diy-life.com/</a><br><b>Official Docker Documentation: </b><a href=\"https://github.com/mklements/OLED_Stats_Docker\" target=\"_blank\">https://github.com/mklements/OLED_Stats_Docker</a><br><br><br>Run this command first to enable is2 communication! \\nsudo raspi-config nonint do_i2c 0\\nsudo /DietPi/dietpi/func/dietpi-set_hardware i2c enable || sudo /boot/dietpi/func/dietpi-set_hardware i2c enable\\n",
+      "image": "mklements/oled_stats:latest",
+      "logo": "https://camo.githubusercontent.com/4cf4aaa1e53612347e4d48f152d6d4eea0ce93a6ecacacaa9d44061d0994b408/68747470733a2f2f7777772e7468652d6469792d6c6966652e636f6d2f77702d636f6e74656e742f75706c6f6164732f323032322f30392f3138373137323831322d64653264653635632d626433302d343065372d613835322d3264343234656463323761622e6a7067",
+      "name": "OLED_Stats",
+      "platform": "linux",
+      "restart_policy": "unless-stopped",
+      "title": "System Stats OLED display",
+      "type": 1,
+      "volumes": [
+        {
+          "bind": "/etc/timezone",
+          "container": "/etc/timezone"
+        },
+        {
+          "bind": "/etc/localtime",
+          "container": "/etc/localtime"
+        }
+      ],
+      "network": "host",
+      "privileged": true,
+      "maintainer": " https://github.com/novaspirit/pi-hosted/"
+    },
+    {
+      "id": 270,
+      "categories": [
+        "Other",
+        "Vpn"
+      ],
+      "command": "tailscale up --authkey=$AUTH_KEY",
+      "description": "Connect your devices and users together in your own secure Zero config virtual private network. ",
+      "env": [
+        {
+          "default": "",
+          "description": "Get AUTH KEY from your tailscale.com user panel",
+          "label": "AUTH_KEY",
+          "name": "AUTH_KEY"
+        }
+      ],
+      "image": "tailscale/tailscale:stable",
+      "logo": "https://raw.githubusercontent.com/pi-hosted/pi-hosted/master/images/tailscale-icon.png",
+      "name": "tailscale",
+      "platform": "linux",
+      "restart_policy": "unless-stopped",
+      "title": "Tailscale",
+      "type": 1,
+      "volumes": [
+        {
+          "bind": "/portainer/Files/AppData/Config/tailscale",
+          "container": "/var/lib/tailscale"
+        },
+        {
+          "bind": "/dev/net/tun",
+          "container": "/dev/net/tun"
+        }
+      ],
+      "note": "<b>Template created by Pi-Hosted Series</b><br><b>Check our Github page: <a href=\"https://github.com/pi-hosted/pi-hosted\" target=\"_blank\">https://github.com/pi-hosted/pi-hosted</a></b><br><br><b>Official Webpage: </b><a href=\"https://tailscale.com/\" target=\"_blank\">https://tailscale.com/</a><br><b>Official Docker Documentation: </b><a href=\"https://hub.docker.com/r/tailscale/tailscale\" target=\"_blank\">https://hub.docker.com/r/tailscale/tailscale</a><br><br><br>",
+      "maintainer": " https://github.com/novaspirit/pi-hosted/"
+    },
+    {
+      "id": 271,
+      "categories": [
+        "Proxy",
+        "Security",
+        "Tools"
+      ],
+      "description": "Cloud-Native Networking Stack That Just Works.",
+      "image": "traefik:latest",
+      "logo": "https://raw.githubusercontent.com/pi-hosted/pi-hosted/master/images/traefik.png",
+      "name": "traefik",
+      "note": "<b>Template created by Pi-Hosted Series</b><br><b>Check our Github page: <a href=\"https://github.com/pi-hosted/pi-hosted\" target=\"_blank\">https://github.com/pi-hosted/pi-hosted</a></b><br><br><b>Official Webpage: </b><a href=\"https://doc.traefik.io/traefik/\" target=\"_blank\">https://doc.traefik.io/traefik/</a><br><b>Official Docker Documentation: </b><a href=\"https://doc.traefik.io/traefik/getting-started/install-traefik/\" target=\"_blank\">https://doc.traefik.io/traefik/getting-started/install-traefik/</a><br><br><h3><b><a href=\"https://github.com/pi-hosted/pi-hosted/blob/master/tools/traefik.sh\" target=\"_blank\">Pre-installation script</a> must be RAN before you install: </b>wget -qO- https://raw.githubusercontent.com/pi-hosted/pi-hosted/master/tools/traefik.sh | bash</h3><br><br>A simple and lightweight reverse proxy",
+      "platform": "linux",
+      "ports": [
+        "80:80/tcp",
+        "443:443/tcp",
+        "8080:8080/tcp"
+      ],
+      "restart_policy": "unless-stopped",
+      "title": "Traefik",
+      "type": 1,
+      "volumes": [
+        {
+          "bind": "/portainer/Files/AppData/Config/traefik/traefik.yml",
+          "container": "/traefik.yml"
+        },
+        {
+          "bind": "/portainer/Files/AppData/Config/traefik/config.yml",
+          "container": "/config.yml"
+        },
+        {
+          "bind": "/portainer/Files/AppData/Config/traefik/acme.json",
+          "container": "/acme.json"
+        },
+        {
+          "bind": "/var/run/docker.sock",
+          "container": "/var/run/docker.sock"
+        }
+      ],
+      "maintainer": " https://github.com/novaspirit/pi-hosted/"
+    },
+    {
+      "id": 272,
+      "categories": [
+        "Other",
+        "Vpn",
+        "Tools"
+      ],
+      "description": "This container contains OpenVPN and Transmission with a configuration\nwhere Transmission is running only when OpenVPN has an active tunnel.\nIt bundles configuration files for many popular VPN providers to make the setup easier.",
+      "env": [
+        {
+          "default": "1000",
+          "label": "PUID",
+          "name": "PUID"
+        },
+        {
+          "default": "1000",
+          "label": "PGID",
+          "name": "PGID"
+        },
+        {
+          "default": "MULLVAD",
+          "description": "https://haugene.github.io/docker-transmission-openvpn/supported-providers/",
+          "label": "OPENVPN_PROVIDER",
+          "name": "OPENVPN_PROVIDER"
+        },
+        {
+          "default": "",
+          "description": "Optional. Mostly used to narrow down what location to use by the provider",
+          "label": "OPENVPN_CONFIG",
+          "name": "OPENVPN_CONFIG"
+        },
+        {
+          "default": "",
+          "label": "OPENVPN_USERNAME",
+          "name": "OPENVPN_USERNAME"
+        },
+        {
+          "default": "",
+          "label": "OPENVPN_PASSWORD",
+          "name": "OPENVPN_PASSWORD"
+        },
+        {
+          "default": "192.168.0.0/24",
+          "label": "LOCAL_NETWORK",
+          "name": "LOCAL_NETWORK"
+        },
+        {
+          "default": "true",
+          "label": "watch-dir-enabled",
+          "name": "TRANSMISSION_WATCH_DIR_ENABLED"
+        }
+      ],
+      "image": "haugene/transmission-openvpn:latest",
+      "logo": "https://raw.githubusercontent.com/pi-hosted/pi-hosted/master/images/transmission-icon.png",
+      "name": "transmission-openvpn-latest",
+      "note": "<b>Template created by Pi-Hosted Series</b><br><b>Check our Github page: <a href=\"https://github.com/pi-hosted/pi-hosted\" target=\"_blank\">https://github.com/pi-hosted/pi-hosted</a></b><br><br><b>Official Webpage: </b><a href=\"https://transmissionbt.com/\" target=\"_blank\">https://transmissionbt.com/</a><br><b>Official Docker Documentation: </b><a href=\"https://haugene.github.io/docker-transmission-openvpn/run-container/\" target=\"_blank\">https://haugene.github.io/docker-transmission-openvpn/run-container/</a><br><br><br>List of supported providers available <a href='https://haugene.github.io/docker-transmission-openvpn/supported-providers'/>here</a>.",
+      "platform": "linux",
+      "ports": [
+        "9091:9091/tcp"
+      ],
+      "privileged": true,
+      "restart_policy": "unless-stopped",
+      "title": "Transmission OpenVPN Latest",
+      "type": 1,
+      "volumes": [
+        {
+          "bind": "/portainer/Files/AppData/Config/transmission-openvpn",
+          "container": "/config"
+        },
+        {
+          "bind": "/portainer/Downloads",
+          "container": "/data"
+        },
+        {
+          "bind": "/etc/localtime",
+          "container": "/etc/localtime"
+        }
+      ],
+      "maintainer": " https://github.com/novaspirit/pi-hosted/"
+    },
+    {
+      "id": 273,
+      "categories": [
+        "Other",
+        "Vpn",
+        "Tools"
+      ],
+      "description": "This container contains OpenVPN and Transmission with a configuration\nwhere Transmission is running only when OpenVPN has an active tunnel.\nIt bundles configuration files for many popular VPN providers to make the setup easier.",
+      "env": [
+        {
+          "default": "1000",
+          "label": "PUID",
+          "name": "PUID"
+        },
+        {
+          "default": "1000",
+          "label": "PGID",
+          "name": "PGID"
+        },
+        {
+          "default": "MULLVAD",
+          "description": "https://haugene.github.io/docker-transmission-openvpn/supported-providers/",
+          "label": "OPENVPN_PROVIDER",
+          "name": "OPENVPN_PROVIDER"
+        },
+        {
+          "default": "",
+          "description": "Optional. Mostly used to narrow down what location to use by the provider",
+          "label": "OPENVPN_CONFIG",
+          "name": "OPENVPN_CONFIG"
+        },
+        {
+          "default": "",
+          "label": "OPENVPN_USERNAME",
+          "name": "OPENVPN_USERNAME"
+        },
+        {
+          "default": "",
+          "label": "OPENVPN_PASSWORD",
+          "name": "OPENVPN_PASSWORD"
+        },
+        {
+          "default": "192.168.0.0/24",
+          "label": "LOCAL_NETWORK",
+          "name": "LOCAL_NETWORK"
+        },
+        {
+          "default": "true",
+          "label": "watch-dir-enabled",
+          "name": "TRANSMISSION_WATCH_DIR_ENABLED"
+        }
+      ],
+      "image": "haugene/transmission-openvpn:3.7.1",
+      "logo": "https://raw.githubusercontent.com/pi-hosted/pi-hosted/master/images/transmission-icon.png",
+      "name": "transmission-openvpn",
+      "note": "<b>Template created by Pi-Hosted Series</b><br><b>Check our Github page: <a href=\"https://github.com/pi-hosted/pi-hosted\" target=\"_blank\">https://github.com/pi-hosted/pi-hosted</a></b><br><br><b>Official Webpage: </b><a href=\"https://transmissionbt.com/\" target=\"_blank\">https://transmissionbt.com/</a><br><b>Official Docker Documentation: </b><a href=\"https://haugene.github.io/docker-transmission-openvpn/run-container/\" target=\"_blank\">https://haugene.github.io/docker-transmission-openvpn/run-container/</a><br><br><br><b>Youtube Video: </b><a href=https://www.youtube.com/watch?v=tGLVEq913_4&list=PL846hFPMqg3jwkxcScD1xw2bKXrJVvarc&index=5 target=\"_blank\">Novaspirit Tech - Torrent with Docker and OPENVPN with Transmission and PIA</a><br><br>List of supported providers available <a href='https://haugene.github.io/docker-transmission-openvpn/supported-providers'/>here</a>.",
+      "platform": "linux",
+      "ports": [
+        "9091:9091/tcp"
+      ],
+      "privileged": true,
+      "restart_policy": "unless-stopped",
+      "title": "Transmission OpenVPN v3",
+      "type": 1,
+      "volumes": [
+        {
+          "bind": "/portainer/Files/AppData/Config/transmission-openvpn",
+          "container": "/config"
+        },
+        {
+          "bind": "/portainer/Downloads",
+          "container": "/data"
+        },
+        {
+          "bind": "/etc/localtime",
+          "container": "/etc/localtime"
+        }
+      ],
+      "maintainer": " https://github.com/novaspirit/pi-hosted/"
+    },
+    {
+      "id": 274,
+      "categories": [
+        "Tools"
+      ],
+      "description": "Unmanic is a simple tool for optimising your file library. You can use it to convert your files into a single, uniform format, manage file movements based on timestamps, or execute custom commands against a file based on its file size.",
+      "env": [
+        {
+          "default": "1000",
+          "label": "PUID",
+          "name": "PUID"
+        },
+        {
+          "default": "1000",
+          "label": "PGID",
+          "name": "PGID"
+        }
+      ],
+      "image": "josh5/unmanic:latest",
+      "logo": "https://docs.unmanic.app/img/icon.png",
+      "name": "unmanic",
+      "platform": "linux",
+      "ports": [
+        "8888:8888/tcp"
+      ],
+      "restart_policy": "unless-stopped",
+      "title": "Unmanic",
+      "type": 1,
+      "volumes": [
+        {
+          "bind": "/portainer/Files/AppData/Config/unmanic/config",
+          "container": "/config"
+        },
+        {
+          "bind": "/portainer/Files/AppData/Config/unmanic/library",
+          "container": "/library"
+        },
+        {
+          "bind": "/portainer/Files/AppData/Config/unmanic/tmp",
+          "container": "/tmp/unmanic"
+        }
+      ],
+      "note": "<b>Template created by Pi-Hosted Series</b><br><b>Check our Github page: <a href=\"https://github.com/pi-hosted/pi-hosted\" target=\"_blank\">https://github.com/pi-hosted/pi-hosted</a></b><br><br><b>Official Webpage: </b><a href=\"https://docs.unmanic.app/\" target=\"_blank\">https://docs.unmanic.app/</a><br><b>Official Docker Documentation: </b><a href=\"https://docs.unmanic.app/docs/installation/docker\" target=\"_blank\">https://docs.unmanic.app/docs/installation/docker</a><br><br><br>",
+      "maintainer": " https://github.com/novaspirit/pi-hosted/"
+    },
+    {
+      "id": 275,
+      "categories": [
+        "Backup"
+      ],
+      "description": "UrBackup is an easy to setup Open Source client/server backup system, that through a combination of image and file backups accomplishes both data safety and a fast restoration time.",
+      "env": [
+        {
+          "default": "1000",
+          "label": "PUID",
+          "name": "PUID"
+        },
+        {
+          "default": "1000",
+          "label": "PGID",
+          "name": "PGID"
+        }
+      ],
+      "image": "uroni/urbackup-server:latest",
+      "logo": "https://raw.githubusercontent.com/pi-hosted/pi-hosted/master/images/urbackup.png",
+      "name": "UrBackup",
+      "platform": "linux",
+      "ports": [
+        "55415:55415/tcp",
+        "55414:55414/tcp"
+      ],
+      "restart_policy": "unless-stopped",
+      "title": "UrBackup",
+      "type": 1,
+      "volumes": [
+        {
+          "bind": "/portainer/Files/AppData/Config/urbackup",
+          "container": "/var/urbackup"
+        },
+        {
+          "bind": "/portainer/backups",
+          "container": "/backup"
+        }
+      ],
+      "note": "<b>Template created by Pi-Hosted Series</b><br><b>Check our Github page: <a href=\"https://github.com/pi-hosted/pi-hosted\" target=\"_blank\">https://github.com/pi-hosted/pi-hosted</a></b><br><br><b>Official Webpage: </b><a href=\"https://www.urbackup.org/\" target=\"_blank\">https://www.urbackup.org/</a><br><b>Official Docker Documentation: </b><a href=\"https://www.github.com/uroni/urbackup-server-docker\" target=\"_blank\">https://www.github.com/uroni/urbackup-server-docker</a><br><br><br>",
+      "maintainer": " https://github.com/novaspirit/pi-hosted/"
+    },
+    {
+      "id": 276,
+      "categories": [
+        "Other",
+        "Tools"
+      ],
+      "description": "This is a replacement for Microsoft's KMS server.",
+      "image": "mikolatero/vlmcsd:latest",
+      "logo": "https://raw.githubusercontent.com/pi-hosted/pi-hosted/master/images/vlmcsd.png",
+      "name": "vlmcsd-kms",
+      "platform": "linux",
+      "ports": [
+        "1688:1688/tcp"
+      ],
+      "restart_policy": "unless-stopped",
+      "title": "Vlmcsd - KMS",
+      "type": 1,
+      "note": "<b>Template created by Pi-Hosted Series</b><br><b>Check our Github page: <a href=\"https://github.com/pi-hosted/pi-hosted\" target=\"_blank\">https://github.com/pi-hosted/pi-hosted</a></b><br><br><b>Official Webpage: </b><a href=\"https://hub.docker.com/r/mikolatero/vlmcsd\" target=\"_blank\">https://hub.docker.com/r/mikolatero/vlmcsd</a><br><b>Official Docker Documentation: </b><a href=\"https://github.com/mikolatero/docker-vlmcsd\" target=\"_blank\">https://github.com/mikolatero/docker-vlmcsd</a><br><br><br>",
+      "maintainer": " https://github.com/novaspirit/pi-hosted/"
+    },
+    {
+      "id": 277,
+      "categories": [
+        "Other",
+        "Vpn"
+      ],
+      "description": "Fast VPN Server with easy to use User Interface",
+      "env": [
+        {
+          "default": "example.domain.com",
+          "description": "Set here your DDNS domain",
+          "label": "WG_HOST",
+          "name": "WG_HOST"
+        },
+        {
+          "default": "ENTER AN ADMIN PASSWORD",
+          "description": "Leave blank to access WebUI without loggin",
+          "label": "PASSWORD",
+          "name": "PASSWORD"
+        },
+        {
+          "default": "51820",
+          "label": "WG_PORT",
+          "name": "WG_PORT"
+        },
+        {
+          "default": "1.1.1.1",
+          "label": "WG_DEFAULT_DNS",
+          "name": "WG_DEFAULT_DNS"
+        },
+        {
+          "default": "10.8.0.x",
+          "label": "WG_DEFAULT_ADDRESS",
+          "name": "WG_DEFAULT_ADDRESS"
+        },
+        {
+          "default": "0.0.0.0/0, ::/0",
+          "label": "WG_ALLOWED_IPS",
+          "name": "WG_ALLOWED_IPS"
+        }
+      ],
+      "logo": "https://raw.githubusercontent.com/pi-hosted/pi-hosted/master/images/wireguard.png",
+      "name": "wg-easy",
+      "platform": "linux",
+      "repository": {
+        "stackfile": "stack/wireguard-easy.yml",
+        "url": "https://github.com/pi-hosted/pi-hosted"
+      },
+      "title": "Wireguard Server",
+      "type": 3,
+      "note": "<b>Template created by Pi-Hosted Series</b><br><b>Check our Github page: <a href=\"https://github.com/pi-hosted/pi-hosted\" target=\"_blank\">https://github.com/pi-hosted/pi-hosted</a></b><br><br><b>Official Webpage: </b><a href=\"https://github.com/WeeJeWel/wg-easy/\" target=\"_blank\">https://github.com/WeeJeWel/wg-easy/</a><br><b>Official Docker Documentation: </b><a href=\"https://github.com/WeeJeWel/wg-easy/#1-install-docker\" target=\"_blank\">https://github.com/WeeJeWel/wg-easy/#1-install-docker</a><br><h3><b>Pi-Hosted dedicated documentation: </b><a href=\"https://github.com/pi-hosted/pi-hosted/blob/master/docs/wireguard-install.md\" target=\"_blank\">wireguard-install.md</a></h3><br><br><br><b>Youtube Video: </b><a href=https://www.youtube.com/watch?v=yB_jAumIxOg target=\"_blank\">Novaspirit Tech - Beginners Guide to WireGuard Docker and Installing Pi-OS 64bit</a><br><br>",
+      "maintainer": " https://github.com/novaspirit/pi-hosted/"
+    },
+    {
+      "id": 278,
+      "categories": [
+        "Wordpress",
+        "Web"
+      ],
+      "description": "Wordpress setup with a MySQL database",
+      "env": [
+        {
+          "default": "5080",
+          "label": "External Port for webserver forward to port 80",
+          "name": "WEB_SERVER_PORT"
+        },
+        {
+          "default": "wordpress",
+          "label": "Database user name",
+          "name": "MYSQL_DATABASE_USER_NAME"
+        },
+        {
+          "label": "Database password for user",
+          "name": "MYSQL_DATABASE_PASSWORD"
+        },
+        {
+          "label": "Database root password",
+          "name": "MYSQL_DATABASE_ROOT_PASSWORD"
+        }
+      ],
+      "logo": "https://raw.githubusercontent.com/pi-hosted/pi-hosted/master/images/wordpress.png",
+      "note": "<b>Template created by Pi-Hosted Series</b><br><b>Check our Github page: <a href=\"https://github.com/pi-hosted/pi-hosted\" target=\"_blank\">https://github.com/pi-hosted/pi-hosted</a></b><br><br><b>Official Webpage: </b><a href=\"https://wordpress.com/\" target=\"_blank\">https://wordpress.com/</a><br><b>Official Docker Documentation: </b><a href=\"https://github.com/docker-library/docs/tree/master/wordpress#-via-docker-stack-deploy-or-docker-compose\" target=\"_blank\">https://github.com/docker-library/docs/tree/master/wordpress#-via-docker-stack-deploy-or-docker-compose</a><br><h3><b>Pi-Hosted dedicated documentation: </b><a href=\"https://github.com/pi-hosted/pi-hosted/blob/master/docs/wordpress_installation.md\" target=\"_blank\">wordpress_installation.md</a></h3><br><br><br>Deploys a Wordpress instance connected to a MySQL database.",
+      "platform": "linux",
+      "repository": {
+        "stackfile": "stack/wordpress-stack.yml",
+        "url": "https://github.com/pi-hosted/pi-hosted"
+      },
+      "title": "Wordpress",
+      "type": 3,
+      "maintainer": " https://github.com/novaspirit/pi-hosted/"
+    },
+    {
+      "id": 279,
+      "categories": [
+        "Other"
+      ],
+      "description": "AdGuard Home is a network-wide software for blocking ads & tracking. After you set it up, it’ll cover ALL your home devices, and you don’t need any client-side software for that. With the rise of Internet-Of-Things and connected devices, it becomes more and more important to be able to control your whole network.",
+      "env": [
+        {
+          "default": "1000",
+          "label": "PUID",
+          "name": "PUID"
+        },
+        {
+          "default": "100",
+          "label": "PGID",
+          "name": "PGID"
+        },
+        {
+          "label": "CONTEXT_PATH",
+          "name": "CONTEXT_PATH",
+          "set": "adguard home"
+        }
+      ],
+      "image": "adguard/adguardhome:latest",
+      "logo": "https://raw.githubusercontent.com/mikestraney/portainer-templates/master/Images/adguard.png",
+      "name": "adguard",
+      "platform": "linux",
+      "ports": [
+        "53:53/tcp",
+        "53:53/udp",
+        "67:67/udp",
+        "68:68/tcp",
+        "68:68/udp",
+        "80:80/tcp",
+        "443:443/tcp",
+        "853:853/tcp",
+        "3000:3000/tcp"
+      ],
+      "restart_policy": "unless-stopped",
+      "title": "Adguard",
+      "type": 1,
+      "volumes": [
+        {
+          "bind": "/portainer/Files/AppData/Adguard/Workdir",
+          "container": "/opt/adguardhome/work"
+        },
+        {
+          "bind": "/portainer/Files/AppData/Adguard/Conf",
+          "container": "/opt/adguardhome/conf"
+        }
+      ],
+      "maintainer": " https://github.com/mikestraney/portainer-templates/"
+    },
+    {
+      "id": 280,
+      "type": 2,
+      "title": "CockroachDB",
+      "description": "CockroachDB cluster",
+      "note": "Deploys an insecure CockroachDB cluster, please refer to <a href=\"https://www.cockroachlabs.com/docs/stable/orchestrate-cockroachdb-with-docker-swarm.html\" target=\"_blank\">CockroachDB documentation</a> for production deployments.",
+      "categories": [
+        "Database"
+      ],
+      "platform": "linux",
+      "logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/cockroachdb.png",
+      "repository": {
+        "url": "https://github.com/mikestraney/portainer-templates",
+        "stackfile": "stacks/cockroachdb/docker-stack.yml"
+      },
+      "maintainer": " https://github.com/mikestraney/portainer-templates/"
+    },
+    {
+      "id": 281,
+      "type": 1,
+      "title": "CommandBox",
+      "description": "ColdFusion (CFML) CLI",
+      "categories": [
+        "Development"
+      ],
+      "platform": "linux",
+      "logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/ortussolutions-commandbox.png",
+      "image": "ortussolutions/commandbox:latest",
+      "env": [
+        {
+          "name": "CFENGINE",
+          "set": "lucee@4.5"
+        }
+      ],
+      "ports": [
+        "8080/tcp",
+        "8443/tcp"
+      ],
+      "maintainer": " https://github.com/mikestraney/portainer-templates/"
+    },
+    {
+      "id": 282,
+      "type": 1,
+      "title": "ContentBox",
+      "description": "Open-source modular CMS",
+      "categories": [
+        "Cms"
+      ],
+      "platform": "linux",
+      "logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/ortussolutions-contentbox.png",
+      "image": "ortussolutions/contentbox:latest",
+      "env": [
+        {
+          "name": "express",
+          "set": "true"
+        },
+        {
+          "name": "install",
+          "set": "true"
+        },
+        {
+          "name": "CFENGINE",
+          "set": "lucee@4.5"
+        }
+      ],
+      "ports": [
+        "8080/tcp",
+        "8443/tcp"
+      ],
+      "volumes": [
+        {
+          "container": "/data/contentbox/db"
+        },
+        {
+          "container": "/app/includes/shared/media"
+        }
+      ],
+      "maintainer": " https://github.com/mikestraney/portainer-templates/"
+    },
+    {
+      "id": 283,
+      "type": 1,
+      "title": "CrateDB",
+      "description": "An open-source distributed SQL database",
+      "categories": [
+        "Database"
+      ],
+      "platform": "linux",
+      "logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/cratedb.png",
+      "image": "crate:latest",
+      "ports": [
+        "4200/tcp",
+        "4300/tcp"
+      ],
+      "volumes": [
+        {
+          "container": "/data"
+        }
+      ],
+      "maintainer": " https://github.com/mikestraney/portainer-templates/"
+    },
+    {
+      "id": 284,
+      "type": 1,
+      "title": "Datadog agent",
+      "description": "Collect events and metrics",
+      "categories": [
+        "Monitoring"
+      ],
+      "platform": "linux",
+      "logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/datadog_agent.png",
+      "image": "datadog/agent:latest",
+      "env": [
+        {
+          "name": "DD_API_KEY",
+          "label": "Datadog API key"
+        }
+      ],
+      "volumes": [
+        {
+          "container": "/var/run/docker.sock",
+          "bind": "/var/run/docker.sock",
+          "readonly": true
+        },
+        {
+          "container": "/host/sys/fs/cgroup",
+          "bind": "/sys/fs/cgroup",
+          "readonly": true
+        },
+        {
+          "container": "/host/proc",
+          "bind": "/proc",
+          "readonly": true
+        }
+      ],
+      "maintainer": " https://github.com/mikestraney/portainer-templates/"
+    },
+    {
+      "id": 285,
+      "type": 1,
+      "title": "Drupal",
+      "description": "Open-source content management framework",
+      "categories": [
+        "Cms"
+      ],
+      "platform": "linux",
+      "logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/drupal.png",
+      "image": "drupal:latest",
+      "ports": [
+        "80/tcp"
+      ],
+      "volumes": [
+        {
+          "container": "/var/www/html"
+        }
+      ],
+      "maintainer": " https://github.com/mikestraney/portainer-templates/"
+    },
+    {
+      "id": 286,
+      "type": 1,
+      "title": "Elasticsearch",
+      "description": "Open-source search and analytics engine",
+      "categories": [
+        "Database"
+      ],
+      "platform": "linux",
+      "logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/elasticsearch.png",
+      "image": "elasticsearch:latest",
+      "ports": [
+        "9200/tcp",
+        "9300/tcp"
+      ],
+      "volumes": [
+        {
+          "container": "/usr/share/elasticsearch/data"
+        }
+      ],
+      "maintainer": " https://github.com/mikestraney/portainer-templates/"
+    },
+    {
+      "id": 287,
+      "type": 1,
+      "title": "Httpd",
+      "description": "Open-source HTTP server",
+      "categories": [
+        "Webserver"
+      ],
+      "platform": "linux",
+      "logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/httpd.png",
+      "image": "httpd:latest",
+      "ports": [
+        "80/tcp"
+      ],
+      "volumes": [
+        {
+          "container": "/usr/local/apache2/htdocs/"
+        }
+      ],
+      "maintainer": " https://github.com/mikestraney/portainer-templates/"
+    },
+    {
+      "id": 288,
+      "type": 2,
+      "title": "IronFunctions",
+      "description": "Open-source serverless computing platform",
+      "note": "Deploys the IronFunctions API and UI.",
+      "categories": [
+        "Serverless"
+      ],
+      "platform": "linux",
+      "logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/ironfunctions.png",
+      "repository": {
+        "url": "https://github.com/mikestraney/portainer-templates",
+        "stackfile": "stacks/ironfunctions/docker-stack.yml"
+      },
+      "maintainer": " https://github.com/mikestraney/portainer-templates/"
+    },
+    {
+      "id": 289,
+      "type": 1,
+      "title": "IronFunctions API",
+      "description": "Open-source serverless computing platform",
+      "categories": [
+        "Serverless"
+      ],
+      "platform": "linux",
+      "logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/ironfunctions.png",
+      "image": "iron/functions:latest",
+      "ports": [
+        "8080/tcp"
+      ],
+      "volumes": [
+        {
+          "container": "/app/data"
+        }
+      ],
+      "privileged": true,
+      "maintainer": " https://github.com/mikestraney/portainer-templates/"
+    },
+    {
+      "id": 290,
+      "type": 1,
+      "title": "IronFunctions UI",
+      "description": "Open-source user interface for IronFunctions",
+      "categories": [
+        "Serverless"
+      ],
+      "platform": "linux",
+      "logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/ironfunctions.png",
+      "image": "iron/functions-ui:latest",
+      "ports": [
+        "4000/tcp"
+      ],
+      "volumes": [
+        {
+          "container": "/app/data"
+        }
+      ],
+      "env": [
+        {
+          "name": "API_URL",
+          "label": "API URL"
+        }
+      ],
+      "privileged": true,
+      "maintainer": " https://github.com/mikestraney/portainer-templates/"
+    },
+    {
+      "id": 291,
+      "type": 1,
+      "title": "Jenkins",
+      "description": "Open-source continuous integration tool",
+      "categories": [
+        "Continuousintegration"
+      ],
+      "platform": "linux",
+      "logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/jenkins.png",
+      "image": "jenkins/jenkins:lts",
+      "ports": [
+        "8080/tcp",
+        "50000/tcp"
+      ],
+      "env": [
+        {
+          "name": "JENKINS_OPTS",
+          "label": "Jenkins options"
+        }
+      ],
+      "volumes": [
+        {
+          "container": "/var/jenkins_home"
+        }
+      ],
+      "maintainer": " https://github.com/mikestraney/portainer-templates/"
+    },
+    {
+      "id": 292,
+      "type": 1,
+      "title": "Joomla",
+      "description": "Another free and open-source CMS",
+      "categories": [
+        "Cms"
+      ],
+      "platform": "linux",
+      "logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/joomla.png",
+      "image": "joomla:latest",
+      "env": [
+        {
+          "name": "JOOMLA_DB_HOST",
+          "label": "MySQL database host",
+          "type": "container"
+        },
+        {
+          "name": "JOOMLA_DB_PASSWORD",
+          "label": "Database password"
+        }
+      ],
+      "ports": [
+        "80/tcp"
+      ],
+      "volumes": [
+        {
+          "container": "/var/www/html"
+        }
+      ],
+      "maintainer": " https://github.com/mikestraney/portainer-templates/"
+    },
+    {
+      "id": 293,
+      "type": 1,
+      "title": "Magento 2",
+      "description": "Open-source e-commerce platform",
+      "categories": [
+        "Cms"
+      ],
+      "platform": "linux",
+      "logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/magento.png",
+      "image": "alankent/gsd:latest",
+      "ports": [
+        "80/tcp",
+        "3000/tcp",
+        "3001/tcp"
+      ],
+      "volumes": [
+        {
+          "container": "/var/www/html/"
+        }
+      ],
+      "maintainer": " https://github.com/mikestraney/portainer-templates/"
+    },
+    {
+      "id": 294,
+      "type": 1,
+      "title": "Mautic",
+      "description": "Open-source marketing automation platform",
+      "categories": [
+        "Marketing"
+      ],
+      "platform": "linux",
+      "logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/mautic.png",
+      "image": "mautic/mautic:latest",
+      "env": [
+        {
+          "name": "MAUTIC_DB_HOST",
+          "label": "MySQL database host",
+          "type": "container"
+        },
+        {
+          "name": "MAUTIC_DB_PASSWORD",
+          "label": "Database password"
+        }
+      ],
+      "ports": [
+        "80/tcp"
+      ],
+      "volumes": [
+        {
+          "container": "/var/www/html"
+        }
+      ],
+      "maintainer": " https://github.com/mikestraney/portainer-templates/"
+    },
+    {
+      "id": 295,
+      "type": 2,
+      "title": "Microsoft OMS Agent",
+      "description": "Microsoft Operations Management Suite Linux agent.",
+      "categories": [
+        "Ops"
+      ],
+      "platform": "linux",
+      "logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/microsoft.png",
+      "repository": {
+        "url": "https://github.com/mikestraney/portainer-templates",
+        "stackfile": "stacks/microsoft-oms/docker-stack.yml"
+      },
+      "env": [
+        {
+          "name": "AZURE_WORKSPACE_ID",
+          "label": "Workspace ID",
+          "description": "Azure Workspace ID"
+        },
+        {
+          "name": "AZURE_PRIMARY_KEY",
+          "label": "Primary key",
+          "description": "Azure primary key"
+        }
+      ],
+      "maintainer": " https://github.com/mikestraney/portainer-templates/"
+    },
+    {
+      "id": 296,
+      "type": 1,
+      "title": "Mongo",
+      "description": "Open-source document-oriented database",
+      "categories": [
+        "Database"
+      ],
+      "platform": "linux",
+      "logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/mongo.png",
+      "image": "mongo:latest",
+      "ports": [
+        "27017/tcp"
+      ],
+      "volumes": [
+        {
+          "container": "/data/db"
+        }
+      ],
+      "maintainer": " https://github.com/mikestraney/portainer-templates/"
+    },
+    {
+      "id": 297,
+      "type": 2,
+      "title": "NextcloudStack",
+      "description": "Nextcloud setup with a MySQL database",
+      "note": "Deploys a Nextcloud instance connected to a MySQL database.",
+      "categories": [
+        "Cloud"
+      ],
+      "platform": "linux",
+      "logo": "https://raw.githubusercontent.com/mikestraney/portainer-templates/master/Images/nextcloud-icon.png",
+      "repository": {
+        "url": "https://github.com/mikestraney/portainer-templates",
+        "stackfile": "stacks/nextcloud/docker-stack.yml"
+      },
+      "env": [
+        {
+          "label": "MYSQL_PASSWORD",
+          "name": "mypassword",
+          "description": "password for sql"
+        },
+        {
+          "label": "MYSQL_ROOT_PASSWORD",
+          "name": "myrpassword",
+          "description": "root password for sql"
+        }
+      ],
+      "maintainer": " https://github.com/mikestraney/portainer-templates/"
+    },
+    {
+      "id": 298,
+      "type": 1,
+      "title": "Odoo",
+      "description": "Open-source business apps",
+      "categories": [
+        "Projectmanagement"
+      ],
+      "platform": "linux",
+      "logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/odoo.png",
+      "image": "odoo:latest",
+      "env": [
+        {
+          "name": "HOST",
+          "label": "PostgreSQL database host",
+          "type": "container"
+        },
+        {
+          "name": "USER",
+          "label": "Database user"
+        },
+        {
+          "name": "PASSWORD",
+          "label": "Database password"
+        }
+      ],
+      "ports": [
+        "8069/tcp"
+      ],
+      "volumes": [
+        {
+          "container": "/var/lib/odoo"
+        },
+        {
+          "container": "/mnt/extra-addons"
+        }
+      ],
+      "maintainer": " https://github.com/mikestraney/portainer-templates/"
+    },
+    {
+      "id": 299,
+      "type": 2,
+      "title": "OpenFaaS",
+      "name": "func",
+      "description": "Serverless functions made simple",
+      "note": "Deploys the API gateway and sample functions. You can access the UI on port 8080. <b>Warning</b>: the name of the stack must be 'func'.",
+      "categories": [
+        "Serverless"
+      ],
+      "platform": "linux",
+      "logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/openfaas.png",
+      "repository": {
+        "url": "https://github.com/openfaas/faas",
+        "stackfile": "docker-compose.yml"
+      },
+      "maintainer": " https://github.com/mikestraney/portainer-templates/"
+    },
+    {
+      "id": 300,
+      "type": 1,
+      "title": "Plesk",
+      "description": "WebOps platform and hosting control panel",
+      "categories": [
+        "Cms"
+      ],
+      "platform": "linux",
+      "note": "Default credentials: admin / changeme",
+      "logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/plesk.png",
+      "image": "plesk/plesk:latest",
+      "ports": [
+        "21/tcp",
+        "80/tcp",
+        "443/tcp",
+        "8880/tcp",
+        "8443/tcp",
+        "8447/tcp"
+      ],
+      "maintainer": " https://github.com/mikestraney/portainer-templates/"
+    },
+    {
+      "id": 301,
+      "type": 1,
+      "title": "Plone",
+      "description": "A free and open-source CMS built on top of Zope",
+      "categories": [
+        "Cms"
+      ],
+      "platform": "linux",
+      "logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/plone.png",
+      "image": "plone:latest",
+      "ports": [
+        "8080/tcp"
+      ],
+      "volumes": [
+        {
+          "container": "/data"
+        }
+      ],
+      "maintainer": " https://github.com/mikestraney/portainer-templates/"
+    },
+    {
+      "id": 302,
+      "type": 2,
+      "title": "Portainer Agent",
+      "description": "Manage all the resources in your Swarm cluster",
+      "note": "The agent will be deployed globally inside your cluster and available on port 9001.",
+      "categories": [
+        "Portainer"
+      ],
+      "platform": "linux",
+      "logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/portainer.png",
+      "repository": {
+        "url": "https://github.com/mikestraney/portainer-templates",
+        "stackfile": "stacks/portainer-agent/docker-stack.yml"
+      },
+      "maintainer": " https://github.com/mikestraney/portainer-templates/"
+    },
+    {
+      "id": 303,
+      "type": 1,
+      "title": "RabbitMQ",
+      "description": "Highly reliable enterprise messaging system",
+      "categories": [
+        "Messaging"
+      ],
+      "platform": "linux",
+      "logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/rabbitmq.png",
+      "image": "rabbitmq:latest",
+      "ports": [
+        "5671/tcp",
+        "5672/tcp"
+      ],
+      "volumes": [
+        {
+          "container": "/var/lib/rabbitmq"
+        }
+      ],
+      "maintainer": " https://github.com/mikestraney/portainer-templates/"
+    },
+    {
+      "id": 304,
+      "type": 1,
+      "title": "Redis",
+      "description": "Open-source in-memory data structure store",
+      "categories": [
+        "Database"
+      ],
+      "platform": "linux",
+      "logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/redis.png",
+      "image": "redis:latest",
+      "ports": [
+        "6379/tcp"
+      ],
+      "volumes": [
+        {
+          "container": "/data"
+        }
+      ],
+      "maintainer": " https://github.com/mikestraney/portainer-templates/"
+    },
+    {
+      "id": 305,
+      "type": 1,
+      "title": "Redmine",
+      "description": "Open-source project management tool",
+      "categories": [
+        "Projectmanagement"
+      ],
+      "platform": "linux",
+      "logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/redmine.png",
+      "image": "redmine:latest",
+      "ports": [
+        "3000/tcp"
+      ],
+      "volumes": [
+        {
+          "container": "/usr/src/redmine/files"
+        }
+      ],
+      "maintainer": " https://github.com/mikestraney/portainer-templates/"
+    },
+    {
+      "id": 306,
+      "type": 1,
+      "title": "Registry",
+      "description": "Docker image registry",
+      "categories": [
+        "Docker"
+      ],
+      "platform": "linux",
+      "logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/registry.png",
+      "image": "registry:latest",
+      "ports": [
+        "5000/tcp"
+      ],
+      "volumes": [
+        {
+          "container": "/var/lib/registry"
+        }
+      ],
+      "maintainer": " https://github.com/mikestraney/portainer-templates/"
+    },
+    {
+      "id": 307,
+      "type": 1,
+      "title": "Scality S3",
+      "description": "Standalone AWS S3 protocol server",
+      "categories": [
+        "Storage"
+      ],
+      "platform": "linux",
+      "logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/scality-s3.png",
+      "image": "scality/s3server",
+      "ports": [
+        "8000/tcp"
+      ],
+      "env": [
+        {
+          "name": "SCALITY_ACCESS_KEY",
+          "label": "Scality S3 access key"
+        },
+        {
+          "name": "SCALITY_SECRET_KEY",
+          "label": "Scality S3 secret key"
+        }
+      ],
+      "volumes": [
+        {
+          "container": "/usr/src/app/localData"
+        },
+        {
+          "container": "/usr/src/app/localMetadata"
+        }
+      ],
+      "maintainer": " https://github.com/mikestraney/portainer-templates/"
+    },
+    {
+      "id": 308,
+      "type": 1,
+      "title": "Sematext Docker Agent",
+      "description": "Collect logs, metrics and docker events",
+      "categories": [
+        "Logmanagement",
+        "Monitoring"
+      ],
+      "platform": "linux",
+      "logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/sematext_agent.png",
+      "image": "sematext/sematext-agent-docker:latest",
+      "name": "sematext-agent",
+      "privileged": true,
+      "env": [
+        {
+          "name": "LOGSENE_TOKEN",
+          "label": "Logs token"
+        },
+        {
+          "name": "SPM_TOKEN",
+          "label": "SPM monitoring token"
+        }
+      ],
+      "volumes": [
+        {
+          "container": "/var/run/docker.sock",
+          "bind": "/var/run/docker.sock"
+        }
+      ],
+      "maintainer": " https://github.com/mikestraney/portainer-templates/"
+    },
+    {
+      "id": 309,
+      "type": 1,
+      "title": "Solr",
+      "description": "Open-source enterprise search platform",
+      "categories": [
+        "Searchengine"
+      ],
+      "platform": "linux",
+      "logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/solr.png",
+      "image": "solr:latest",
+      "ports": [
+        "8983/tcp"
+      ],
+      "volumes": [
+        {
+          "container": "/opt/solr/mydata"
+        }
+      ],
+      "maintainer": " https://github.com/mikestraney/portainer-templates/"
+    },
+    {
+      "id": 310,
+      "type": 1,
+      "title": "SQL Server",
+      "description": "Microsoft SQL Server on Linux",
+      "categories": [
+        "Database"
+      ],
+      "platform": "linux",
+      "note": "Password needs to include at least 8 characters including uppercase, lowercase letters, base-10 digits and/or non-alphanumeric symbols.",
+      "logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/microsoft.png",
+      "image": "microsoft/mssql-server-linux:2017-GA",
+      "ports": [
+        "1433/tcp"
+      ],
+      "env": [
+        {
+          "name": "ACCEPT_EULA",
+          "set": "Y"
+        },
+        {
+          "name": "SA_PASSWORD",
+          "label": "SA password"
+        }
+      ],
+      "maintainer": " https://github.com/mikestraney/portainer-templates/"
+    },
+    {
+      "id": 311,
+      "type": 1,
+      "title": "SQL Server Express",
+      "description": "Microsoft SQL Server Express for Windows containers",
+      "categories": [
+        "Database"
+      ],
+      "platform": "windows",
+      "note": "Password needs to include at least 8 characters including uppercase, lowercase letters, base-10 digits and/or non-alphanumeric symbols.",
+      "logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/microsoft.png",
+      "image": "microsoft/mssql-server-windows-express:latest",
+      "ports": [
+        "1433/tcp"
+      ],
+      "env": [
+        {
+          "name": "ACCEPT_EULA",
+          "set": "Y"
+        },
+        {
+          "name": "sa_password",
+          "label": "SA password"
+        }
+      ],
+      "volumes": [
+        {
+          "container": "C:/temp/"
+        }
+      ],
+      "maintainer": " https://github.com/mikestraney/portainer-templates/"
+    },
+    {
+      "id": 312,
+      "category": [
+        "Music"
+      ],
+      "description": "Libresonic is a free, web-based media streamer, providing ubiqutious access to your music. Use it to share your music with friends, or to listen to your own music while at work. You can stream to multiple players simultaneously, for instance to one player in your kitchen and another in your living room. /music = Location of music. /media = Location of other media. /podcasts = Location of podcasts. /playlists = Location for playlists storage. CONTEXT_PATH is for setting url-base in reverse proxy setups - (optional) Default user/pass is admin/admin",
+      "env": [
+        {
+          "label": "CONTEXT_PATH",
+          "name": "CONTEXT_PATH",
+          "set": ""
+        },
+        {
+          "label": "PUID",
+          "name": "PUID",
+          "set": "1000"
+        },
+        {
+          "label": "PGID",
+          "name": "PGID",
+          "set": "1000"
+        },
+        {
+          "label": "TZ",
+          "name": "TZ",
+          "set": "America/Chicago"
+        }
+      ],
+      "image": "linuxserver/libresonic:latest",
+      "logo": "https://raw.githubusercontent.com/thesugarat/portainer_templates-1/master/Images/libresonic.png",
+      "platform": "linux",
+      "ports": [
+        "4040/tcp"
+      ],
+      "title": "libresonic",
+      "type": 1,
+      "volumes": [
+        {
+          "container": "/music"
+        },
+        {
+          "container": "/playlists"
+        },
+        {
+          "container": "/podcasts"
+        },
+        {
+          "container": "/media"
+        },
+        {
+          "container": "/config"
+        }
+      ],
+      "maintainer": " https://github.com/dnburgess/self-hosted-template/",
+      "categories": []
+    },
+    {
+      "id": 313,
+      "category": [
+        "Messenger"
+      ],
+      "description": "Quassel IRC is a modern, cross-platform, distributed IRC client, meaning that one (or multiple) client(s) can attach to and detach from a central core -- much like the popular combination of screen and a text-based IRC client such as WeeChat, but graphical. Blowfish support and optional web-ui included.",
+      "env": [
+        {
+          "label": "PGID",
+          "name": "PGID",
+          "set": "1000"
+        },
+        {
+          "label": "PUID",
+          "name": "PUID",
+          "set": "1000"
+        },
+        {
+          "label": "TZ",
+          "name": "TZ",
+          "set": "America/Chicago"
+        }
+      ],
+      "image": "linuxserver/quassel-core:latest",
+      "logo": "https://raw.githubusercontent.com/thesugarat/portainer_templates-1/master/Images/quassel-core-icon.png",
+      "platform": "linux",
+      "ports": [
+        "4242/tcp"
+      ],
+      "title": "quassel-core",
+      "type": 1,
+      "volumes": [
+        {
+          "container": "/config"
+        }
+      ],
+      "maintainer": " https://github.com/dnburgess/self-hosted-template/",
+      "categories": []
+    },
+    {
+      "id": 314,
+      "category": [
+        "Other"
+      ],
+      "description": "OpenVPN Access Server is a full featured secure network tunneling VPN software solution that integrates OpenVPN server capabilities, enterprise management capabilities, simplified OpenVPN Connect UI, and OpenVPN Client software packages that accommodate Windows, MAC, Linux, Android, and iOS environments.",
+      "env": [
+        {
+          "label": "INTERFACE",
+          "name": "INTERFACE",
+          "set": "eth0"
+        },
+        {
+          "label": "PGID",
+          "name": "PGID",
+          "set": "1000"
+        },
+        {
+          "label": "PUID",
+          "name": "PUID",
+          "set": "1000"
+        },
+        {
+          "label": "TZ",
+          "name": "TZ",
+          "set": "America/Chicago"
+        }
+      ],
+      "image": "linuxserver/openvpn-as:latest",
+      "logo": "https://raw.githubusercontent.com/thesugarat/portainer_templates-1/master/Images/openvpn-as-icon.png",
+      "platform": "linux",
+      "ports": [
+        "943/tcp",
+        "9443/tcp",
+        "1194/udp"
+      ],
+      "title": "openvpn-as",
+      "type": 1,
+      "volumes": [
+        {
+          "container": "/config"
+        }
+      ],
+      "maintainer": " https://github.com/dnburgess/self-hosted-template/",
+      "categories": []
+    },
+    {
+      "id": 315,
+      "category": [
+        "Downloaders",
+        "Other",
+        "Tools"
+      ],
+      "description": "NZBHydra is a meta search for NZB indexers and the \"spiritual successor\" to NZBmegasearcH. It provides easy access to a number of raw and newznab based indexers.",
+      "env": [
+        {
+          "label": "PUID",
+          "name": "PUID",
+          "set": "1000"
+        },
+        {
+          "label": "PGID",
+          "name": "PGID",
+          "set": "1000"
+        },
+        {
+          "label": "TZ",
+          "name": "TZ",
+          "set": "America/Chicago"
+        }
+      ],
+      "image": "linuxserver/hydra2:latest",
+      "logo": "https://raw.githubusercontent.com/thesugarat/portainer_templates-1/master/Images/hydra-icon.png",
+      "platform": "linux",
+      "ports": [
+        "5076/tcp"
+      ],
+      "title": "hydra2",
+      "type": 1,
+      "volumes": [
+        {
+          "container": "/config"
+        },
+        {
+          "container": "/downloads"
+        }
+      ],
+      "maintainer": " https://github.com/dnburgess/self-hosted-template/",
+      "categories": []
+    },
+    {
+      "id": 316,
+      "categories": [
+        "Social",
+        "Forum"
+      ],
+      "description": "Zusam is a free and open-source way to self-host private forums for groups of friends.",
+      "env": [
+        {
+          "default": "email@domain.example",
+          "label": "INIT_USER",
+          "name": "INIT_USER"
+        },
+        {
+          "default": "initpass zusam",
+          "label": "INIT_PASSWORD",
+          "name": "INIT_PASSWORD"
+        }
+      ],
+      "image": "zusam/zusam",
+      "logo": "https://github.com/zusam/zusam/raw/master/app/src/assets/zusam_logo.png",
+      "name": "Zusam",
+      "platform": "linux",
+      "ports": [
+        "4180:8080/tcp"
+      ],
+      "restart_policy": "unless-stopped",
+      "title": "Zus.am",
+      "type": 1,
+      "volumes": [
+        {
+          "bind": "/portainer/Files/AppData/Config/Zusam",
+          "container": "/zusam/data"
+        }
+      ],
+      "maintainer": " https://github.com/xneo1/portainer_templates/"
+    },
+    {
+      "id": 317,
+      "categories": [
+        "Social"
+      ],
+      "description": "Use Tiktok with an alternative frontend, inspired by Nitter.",
+      "name": "proxitok",
+      "platform": "linux",
+      "repository": {
+        "stackfile": "Template/Stack/proxitok.yml",
+        "url": "https://github.com/xneo1/portainer_templates"
+      },
+      "title": "ProxiTok",
+      "type": 3,
+      "maintainer": " https://github.com/xneo1/portainer_templates/"
+    },
+    {
+      "id": 318,
+      "categories": [
+        "Feedreader"
+      ],
+      "description": "Miniflux is a minimalist and opinionated feed reader.",
+      "logo": "",
+      "name": "miniflux",
+      "platform": "linux",
+      "repository": {
+        "stackfile": "Template/Stack/miniflux.yml",
+        "url": "https://github.com/xneo1/portainer_templates"
+      },
+      "title": "Miniflux",
+      "type": 3,
+      "maintainer": " https://github.com/xneo1/portainer_templates/"
+    },
+    {
+      "id": 319,
+      "categories": [
+        "Tools"
+      ],
+      "description": "Koillection is a self-hosted collection manager created to keep track of physical (mostly) collections of any kind like books, DVDs, stamps, games..",
+      "env": [
+        {
+          "default": "1000",
+          "label": "PUID",
+          "name": "PUID"
+        },
+        {
+          "default": "1000",
+          "label": "PGID",
+          "name": "PGID"
+        },
+        {
+          "label": "PORT",
+          "name": "PORT"
+        }
+      ],
+      "logo": "https://user-images.githubusercontent.com/20560781/80213166-0e560e00-8639-11ea-944e-4f79fdbcef55.png",
+      "name": "Koillection",
+      "platform": "linux",
+      "repository": {
+        "stackfile": "Template/Stack/koillection.yml",
+        "url": "https://github.com/xneo1/portainer_templates"
+      },
+      "title": "Koillection",
+      "type": 3,
+      "maintainer": " https://github.com/xneo1/portainer_templates/"
+    },
+    {
+      "id": 320,
+      "categories": [
+        "Tools"
+      ],
+      "description": "Eufy Security Web Socket. Edit container and add username & password.",
+      "env": [
+        {
+          "default": "InputUSER-email",
+          "label": "USERNAME",
+          "name": "USERNAME"
+        },
+        {
+          "default": "InputPWD",
+          "label": "PASSWORD",
+          "name": "PASSWORD"
+        }
+      ],
+      "image": "bropat/eufy-security-ws:latest",
+      "logo": "https://github.com/bropat/eufy-security-ws/raw/master/docs/_media/eufy-security-ws.png",
+      "name": "eufy-security-ws",
+      "platform": "linux",
+      "ports": [
+        "3993:3000/tcp"
+      ],
+      "restart_policy": "unless-stopped",
+      "title": "Eufy Security WS",
+      "type": 1,
+      "volumes": [
+        {
+          "bind": "/portainer/Files/AppData/Config/eufy-security-ws",
+          "container": "/data"
+        }
+      ],
+      "maintainer": " https://github.com/xneo1/portainer_templates/"
+    },
+    {
+      "id": 321,
+      "categories": [
+        "Multimedia"
+      ],
+      "description": "Tdarr is a popular conditional transcoding application for processing large (or small) media libraries.",
+      "logo": "https://tdarr.io/static/media/logo3.02a3f4a3.png",
+      "name": "tdarr",
+      "platform": "linux",
+      "repository": {
+        "stackfile": "Template/Stack/tdarr.yml",
+        "url": "https://github.com/xneo1/portainer_templates"
+      },
+      "title": "Tdarr",
+      "type": 3,
+      "maintainer": " https://github.com/xneo1/portainer_templates/"
+    },
+    {
+      "id": 322,
+      "categories": [
+        "Social"
+      ],
+      "description": "Monica is a great open source personal relationship management system to organize the interactions with your loved ones.",
+      "logo": "https://raw.githubusercontent.com/docker-library/docs/b962028212dbd77c9531dbcf8d5a81db79d4a735/monica/logo.svg",
+      "name": "monica",
+      "platform": "linux",
+      "repository": {
+        "stackfile": "Template/Stack/monica.yml",
+        "url": "https://github.com/xneo1/portainer_templates"
+      },
+      "title": "Monica",
+      "type": 3,
+      "maintainer": " https://github.com/xneo1/portainer_templates/"
+    },
+    {
+      "id": 323,
+      "categories": [
+        "Tools"
+      ],
+      "description": "Teleport allows engineers and security professionals to unify access for SSH servers, Kubernetes clusters, web applications, and databases across all environments.",
+      "logo": "https://bookface-images.s3.amazonaws.com/logos/386100350818400a035ac8e0caa84111de3316eb.png",
+      "name": "teleport",
+      "repository": {
+        "stackfile": "Template/Stack/teleport.yml",
+        "url": "https://github.com/xneo1/portainer_templates"
+      },
+      "platform": "linux",
+      "restart_policy": "always",
+      "title": "Teleport",
+      "type": 3,
+      "maintainer": " https://github.com/xneo1/portainer_templates/"
+    },
+    {
+      "id": 324,
+      "categories": [
+        "Dashboard",
+        "Crypto",
+        "Finance"
+      ],
+      "description": "Cryptofolio is an open-source, and self-hosted solution for tracking your cryptocurrency holdings. It features a web interface, an Android mobile app, and a cross-platform desktop application for Windows, macOS, and Linux.",
+      "image": "xtrendence/cryptofolio:latest",
+      "logo": "https://i.imgur.com/5v8lzea.png",
+      "name": "cryptofolio",
+      "platform": "linux",
+      "ports": [
+        "7280:80/tcp"
+      ],
+      "restart_policy": "always",
+      "title": "Cryptofolio",
+      "type": 1,
+      "maintainer": " https://github.com/xneo1/portainer_templates/"
+    },
+    {
+      "id": 325,
+      "categories": [
+        "Presentation"
+      ],
+      "description": "It is an open source HTML presentation framework. It enables anyone with a web browser to create fully featured and beautiful presentations for free | Production Mode",
+      "image": "cloudogu/reveal.js",
+      "logo": "https://pbs.twimg.com/profile_images/1260911777929400325/_ClbHpsz_400x400.jpg",
+      "name": "revealjs",
+      "platform": "linux",
+      "ports": [
+        "6060:8080/tcp"
+      ],
+      "restart_policy": "always",
+      "title": "Reveal.js",
+      "type": 1,
+      "volumes": [
+        {
+          "bind": "/portainer/Files/AppData/Config/revealjs/docs/slides",
+          "container": "/reveal/docs/slides"
+        },
+        {
+          "bind": "/portainer/Files/AppData/Config/revealjs/scripts/test",
+          "container": "/resources"
+        }
+      ],
+      "maintainer": " https://github.com/xneo1/portainer_templates/"
+    },
+    {
+      "id": 326,
+      "categories": [
+        "Network"
+      ],
+      "description": "An easy to use Status Page for your websites and applications. Statping will automatically fetch the application and render a beautiful status page with tons of features for you to build an even better status page.",
+      "image": "statping/statping:latest",
+      "logo": "https://raw.githubusercontent.com/xneo1/portainer_templates/master/Images/statping.png",
+      "name": "statping",
+      "platform": "linux",
+      "ports": [
+        "4040:8080/tcp"
+      ],
+      "restart_policy": "always",
+      "title": "Statping",
+      "type": 1,
+      "volumes": [
+        {
+          "bind": "/portainer/Files/AppData/Config/statping",
+          "container": "/app"
+        }
+      ],
+      "maintainer": " https://github.com/xneo1/portainer_templates/"
+    },
+    {
+      "id": 327,
+      "categories": [
+        "Network"
+      ],
+      "description": "Network UPS Tools server",
+      "image": "upshift/nut-upsd",
+      "logo": "",
+      "name": "nuts",
+      "platform": "linux",
+      "ports": [
+        "3493:3493/tcp"
+      ],
+      "restart_policy": "always",
+      "title": "NUTS",
+      "type": 1,
+      "volumes": [
+        {
+          "bind": "/portainer/Files/AppData/Config/nuts",
+          "container": "/app"
+        }
+      ],
+      "maintainer": " https://github.com/xneo1/portainer_templates/"
+    },
+    {
+      "id": 328,
+      "categories": [
+        "Tools"
+      ],
+      "description": "Your Budgets, Calendars, Meals, Inventory, Tasks, and so much more in one simple app.For everyone in your household.On all of your devices.In the cloud or self-hosted",
+      "logo": "https://homechart.app/images/homechart.min.776793e5e4334866f0799e8a84b8448efb1b06cb2762b2bb20f99068ac36136c.png",
+      "name": "homechart",
+      "platform": "linux",
+      "repository": {
+        "stackfile": "Template/Stack/homechart.yml",
+        "url": "https://github.com/xneo1/portainer_templates"
+      },
+      "title": "Homechart",
+      "type": 3,
+      "maintainer": " https://github.com/xneo1/portainer_templates/"
+    },
+    {
+      "id": 329,
+      "categories": [
+        "Messenger"
+      ],
+      "description": "Ferdi is a messaging browser that allows you to combine your favourite messaging services into one application",
+      "logo": "https://raw.githubusercontent.com/getferdi/server/master/logo.png",
+      "name": "ferdi-server",
+      "platform": "linux",
+      "repository": {
+        "stackfile": "Template/Stack/ferdiserver.yml",
+        "url": "https://github.com/xneo1/portainer_templates"
+      },
+      "title": "Ferdi Server",
+      "type": 3,
+      "maintainer": " https://github.com/xneo1/portainer_templates/"
+    },
+    {
+      "id": 330,
+      "categories": [
+        "Messenger"
+      ],
+      "description": "Ferdium is a messaging browser that allows you to combine your favourite messaging services into one application",
+      "logo": "https://github.com/ferdium/ferdium-server/raw/main/logo.png",
+      "name": "ferdium",
+      "platform": "linux",
+      "repository": {
+        "stackfile": "Template/Stack/ferdium.yml",
+        "url": "https://github.com/xneo1/portainer_templates"
+      },
+      "title": "Ferdium",
+      "type": 3,
+      "maintainer": " https://github.com/xneo1/portainer_templates/"
+    },
+    {
+      "id": 331,
+      "categories": [
+        "Social"
+      ],
+      "description": "LittleLink is an open source DIY self-hosted alternative to services like Linktree and many.link. ",
+      "logo": "https://littlelink.io/images/avatar@2x.png",
+      "name": "littlelink-server",
+      "platform": "linux",
+      "repository": {
+        "stackfile": "Template/Stack/littlelink.yml",
+        "url": "https://github.com/xneo1/portainer_templates"
+      },
+      "ports": [
+        "3000:3000/tcp"
+      ],
+      "title": "Littlelink Server",
+      "type": 3,
+      "maintainer": " https://github.com/xneo1/portainer_templates/"
+    },
+    {
+      "id": 332,
+      "categories": [
+        "Social"
+      ],
+      "description": "Self-hosted open-source Linktree alternative. LinkStack is a highly customizable link sharing platform with an intuitive, easy to use user interface.",
+      "logo": "https://linkstack.org/wp-content/uploads/2023/04/logo-animated.svg",
+      "name": "linkstack",
+      "platform": "linux",
+      "repository": {
+        "stackfile": "Template/Stack/linkstack.yml",
+        "url": "https://github.com/xneo1/portainer_templates"
+      },
+      "title": "Linkstack",
+      "type": 3,
+      "maintainer": " https://github.com/xneo1/portainer_templates/"
+    },
+    {
+      "id": 333,
+      "categories": [
+        "Downloaders"
+      ],
+      "description": "A perfect Aria2 Docker image. Out of the box, just add download tasks and don't need to think about anything else.",
+      "logo": "https://imgcdn.p3terx.com/post/20201113041845.jpg",
+      "name": "aria2-pro",
+      "platform": "linux",
+      "repository": {
+        "stackfile": "Template/Stack/aria2pro.yml",
+        "url": "https://github.com/xneo1/portainer_templates"
+      },
+      "title": "Aria2 Pro",
+      "type": 3,
+      "maintainer": " https://github.com/xneo1/portainer_templates/"
+    },
+    {
+      "id": 334,
+      "categories": [
+        "Downloaders"
+      ],
+      "description": "A docker image with qBittorrent and the Flood UI, also optional WireGuard VPN support.",
+      "logo": "https://hotio.dev/img/image-logos/flood.svg",
+      "name": "flood",
+      "platform": "linux",
+      "repository": {
+        "stackfile": "Template/Stack/flood.yml",
+        "url": "https://github.com/xneo1/portainer_templates"
+      },
+      "title": "Flood",
+      "type": 3,
+      "maintainer": " https://github.com/xneo1/portainer_templates/"
+    },
+    {
+      "id": 335,
+      "categories": [
+        "Photos",
+        "Ai"
+      ],
+      "description": "PhotoPrism is an AI-powered app for browsing, organizing & sharing your photo collection. It makes use of the latest technologies to tag and find pictures automatically without getting in your way.| Copy as Custom stack and EDIT environment variables.",
+      "logo": "https://photoprism.app/static/img/logo.svg",
+      "name": "photoprism",
+      "platform": "linux",
+      "repository": {
+        "stackfile": "Template/Stack/photoprism.yml",
+        "url": "https://github.com/xneo1/portainer_templates"
+      },
+      "title": "Photoprism",
+      "type": 3,
+      "maintainer": " https://github.com/xneo1/portainer_templates/"
+    },
+    {
+      "id": 336,
+      "categories": [
+        "Photos",
+        "Ai"
+      ],
+      "description": "Immich is a high performance self-hosted photo and video backup solution.",
+      "logo": "https://github.com/immich-app/immich/raw/main/design/immich-logo.svg",
+      "name": "immich",
+      "platform": "linux",
+      "repository": {
+        "stackfile": "Template/Stack/immich.yml",
+        "url": "https://github.com/xneo1/portainer_templates"
+      },
+      "title": "Immich",
+      "type": 3,
+      "maintainer": " https://github.com/xneo1/portainer_templates/"
+    },
+    {
+      "id": 337,
+      "categories": [
+        "Filebrowsers"
+      ],
+      "description": "Pingvin Share is self-hosted file sharing platform and an alternative for WeTransfer.",
+      "logo": "https://user-images.githubusercontent.com/58886915/166198400-c2134044-1198-4647-a8b6-da9c4a204c68.svg",
+      "name": "pingvin-share",
+      "platform": "linux",
+      "repository": {
+        "stackfile": "Template/Stack/pingvin.yml",
+        "url": "https://github.com/xneo1/portainer_templates"
+      },
+      "title": "Pingvin",
+      "type": 3,
+      "maintainer": " https://github.com/xneo1/portainer_templates/"
+    },
+    {
+      "id": 338,
+      "categories": [
+        "Pdftools",
+        "Productivity"
+      ],
+      "description": "This is a powerful locally hosted web based PDF manipulation tool using docker that allows you to perform various operations on PDF files, such as splitting merging, converting, reorganizing, adding images, rotating, compressing, and more.",
+      "logo": "https://raw.githubusercontent.com/Stirling-Tools/Stirling-PDF/main/docs/stirling.png",
+      "name": "stirling-pdf",
+      "platform": "linux",
+      "repository": {
+        "stackfile": "Template/Stack/stirling-pdf.yml",
+        "url": "https://github.com/xneo1/portainer_templates"
+      },
+      "title": "Stirling-PDF",
+      "type": 3,
+      "maintainer": " https://github.com/xneo1/portainer_templates/"
+    },
+    {
+      "id": 339,
+      "categories": [
+        "Network"
+      ],
+      "description": "WIFI / LAN intruder detector. Scans for devices connected to your network and alerts you if new and unknown devices are found.",
+      "logo": "https://avatars.githubusercontent.com/u/96159884?s=48&v=4",
+      "name": "NetAlertX",
+      "platform": "linux",
+      "repository": {
+        "stackfile": "Template/Stack/netalertx.yml",
+        "url": "https://github.com/xneo1/portainer_templates"
+      },
+      "title": "NetAlertX",
+      "type": 3,
+      "maintainer": " https://github.com/xneo1/portainer_templates/"
+    },
+    {
+      "id": 340,
+      "categories": [
+        "Productivity",
+        "Timerelated"
+      ],
+      "description": "Open source time-tracker with an interactive user experience and powerful reporting.",
+      "logo": "https://timetagger.app/timetagger_wl.svg",
+      "name": "TimeTagger",
+      "platform": "linux",
+      "repository": {
+        "stackfile": "Template/Stack/timetagger.yml",
+        "url": "https://github.com/xneo1/portainer_templates"
+      },
+      "title": "TimeTagger",
+      "type": 3,
+      "maintainer": " https://github.com/xneo1/portainer_templates/"
+    },
+    {
+      "id": 341,
+      "categories": [
+        "Multimedia"
+      ],
+      "description": "Invidious is an open source alternative front-end to YouTube.",
+      "logo": "https://invidious.io/invidious-colored-vector.svg",
+      "name": "Invidious",
+      "platform": "linux",
+      "repository": {
+        "stackfile": "Template/Stack/invidious.yml",
+        "url": "https://github.com/xneo1/portainer_templates"
+      },
+      "title": "Invidious",
+      "type": 3,
+      "maintainer": " https://github.com/xneo1/portainer_templates/"
+    },
+    {
+      "id": 342,
+      "categories": [
+        "Filebrowsers"
+      ],
+      "description": "Chibisafe is a modern and self-hosted take on file uploading services that can handle anything you throw at it thanks to it's robust and fast API, chunked uploads support and more.",
+      "logo": "https://chibisafe.moe/logo.svg",
+      "name": "chibisafe",
+      "platform": "linux",
+      "repository": {
+        "stackfile": "Template/Stack/chibisafe.yml",
+        "url": "https://github.com/xneo1/portainer_templates"
+      },
+      "title": "Chibisafe",
+      "type": 3,
+      "maintainer": " https://github.com/xneo1/portainer_templates/"
+    },
+    {
+      "id": 343,
+      "categories": [
+        "Offline"
+      ],
+      "description": "Internet. Offline.Store any website on your mobile phone or computer, easily.",
+      "logo": "https://www.kiwix.org/wp-content/uploads/kiwix-logo-995x200-1.png",
+      "name": "kiwix",
+      "platform": "linux",
+      "repository": {
+        "stackfile": "Template/Stack/kiwix.yml",
+        "url": "https://github.com/xneo1/portainer_templates"
+      },
+      "title": "Kiwix",
+      "type": 3,
+      "maintainer": " https://github.com/xneo1/portainer_templates/"
+    },
+    {
+      "id": 344,
+      "categories": [
+        "Tools"
+      ],
+      "description": "The recipe manager that allows you to manage your ever growing collection of digital recipes.",
+      "logo": "https://docs.tandoor.dev/logo_color.svg",
+      "name": "tandoor",
+      "platform": "linux",
+      "repository": {
+        "stackfile": "Template/Stack/tandoor.yml",
+        "url": "https://github.com/xneo1/portainer_templates"
+      },
+      "title": "Tandoor",
+      "type": 3,
+      "maintainer": " https://github.com/xneo1/portainer_templates/"
+    },
+    {
+      "id": 345,
+      "categories": [
+        "Social"
+      ],
+      "description": "Webtrees is the web’s leading online collaborative genealogy application. [GEDCOM files support]",
+      "logo": "https://upload.wikimedia.org/wikipedia/commons/thumb/c/c3/Logo_webtrees.svg/400px-Logo_webtrees.svg.png",
+      "name": "webtrees",
+      "platform": "linux",
+      "repository": {
+        "stackfile": "Template/Stack/webtrees.yml",
+        "url": "https://github.com/xneo1/portainer_templates"
+      },
+      "title": "Webtrees",
+      "type": 3,
+      "maintainer": " https://github.com/xneo1/portainer_templates/"
+    },
+    {
+      "id": 346,
+      "categories": [
+        "Metrics"
+      ],
+      "description": "This is an exporter that exposes information gathered from Proxmox VE node for use by the Prometheus monitoring system.",
+      "logo": "",
+      "name": "pve-exporter",
+      "platform": "linux",
+      "repository": {
+        "stackfile": "Template/Stack/pve-exporter.yml",
+        "url": "https://github.com/xneo1/portainer_templates"
+      },
+      "title": "pve-exporter",
+      "type": 3,
+      "maintainer": " https://github.com/xneo1/portainer_templates/"
+    },
+    {
+      "id": 347,
+      "categories": [
+        "Devops"
+      ],
+      "description": "Modern UI for Ansible",
+      "logo": "https://res.cloudinary.com/canonical/image/fetch/f_auto,q_auto,fl_sanitize,w_60,h_60/https://dashboard.snapcraft.io/site_media/appmedia/2020/11/Screenshot_2020-11-21_at_02.05.22.png",
+      "name": "ansible-semaphore",
+      "platform": "linux",
+      "repository": {
+        "stackfile": "Template/Stack/ansible-semaphore.yml",
+        "url": "https://github.com/xneo1/portainer_templates"
+      },
+      "title": "Ansible-semaphore",
+      "type": 3,
+      "maintainer": " https://github.com/xneo1/portainer_templates/"
+    },
+    {
+      "id": 348,
+      "categories": [
+        "Audio",
+        "Multimedia"
+      ],
+      "description": "A social platform to enjoy and share music.Funkwhale is a community-driven project that lets you listen and share music and audio within a decentralized, open network.",
+      "logo": "https://funkwhale.audio/img/with-text-500.4aff7861.png",
+      "name": "funkwhale",
+      "platform": "linux",
+      "repository": {
+        "stackfile": "Template/Stack/funkwhale.yml",
+        "url": "https://github.com/xneo1/portainer_templates"
+      },
+      "title": "Funkwhale",
+      "type": 3,
+      "maintainer": " https://github.com/xneo1/portainer_templates/"
+    },
+    {
+      "id": 349,
+      "categories": [
+        "Cloud"
+      ],
+      "description": "Gokapi is a lightweight server to share files, which expire after a set amount of downloads or days. It is similar to the discontinued Firefox Send, with the difference that only the admin is allowed to upload files",
+      "logo": "https://noted.lol/content/images/2023/02/gokapi-self-hosted-main.png",
+      "name": "gokapi",
+      "platform": "linux",
+      "repository": {
+        "stackfile": "Template/Stack/gokapi.yml",
+        "url": "https://github.com/xneo1/portainer_templates"
+      },
+      "title": "Gokapi",
+      "type": 3,
+      "maintainer": " https://github.com/xneo1/portainer_templates/"
+    },
+    {
+      "id": 350,
+      "categories": [
+        "Timetracking"
+      ],
+      "description": "Traggo is a tag-based time tracking tool. In Traggo there are no tasks, only tagged time spans.",
+      "logo": "https://traggo.net/images/favicon.png",
+      "name": "traggo",
+      "platform": "linux",
+      "repository": {
+        "stackfile": "Template/Stack/traggo.yml",
+        "url": "https://github.com/xneo1/portainer_templates"
+      },
+      "title": "Traggo",
+      "type": 3,
+      "maintainer": " https://github.com/xneo1/portainer_templates/"
+    },
+    {
+      "id": 351,
+      "categories": [
+        "Learning"
+      ],
+      "description": "Moodle is a learning platform designed to provide educators, administrators and learners with a single robust, secure and integrated system to create personalised learning environments.",
+      "logo": "https://download.moodle.org/theme/moodleorgcleaned/pix/moodle_logo_TM.svg",
+      "name": "moodle",
+      "platform": "linux",
+      "repository": {
+        "stackfile": "Template/Stack/moodle.yml",
+        "url": "https://github.com/xneo1/portainer_templates"
+      },
+      "title": "Moodle",
+      "type": 3,
+      "maintainer": " https://github.com/xneo1/portainer_templates/"
+    },
+    {
+      "id": 352,
+      "categories": [
+        "Helpdesk"
+      ],
+      "description": "FreeScout is the super lightweight free open source help desk and shared inbox written in PHP (Laravel framework) – self hosted clone of HelpScout.",
+      "logo": "https://raw.githubusercontent.com/freescout-helpdesk/freescout/master/public/img/logo-300.png",
+      "name": "freescout",
+      "platform": "linux",
+      "repository": {
+        "stackfile": "Template/Stack/freescout.yml",
+        "url": "https://github.com/xneo1/portainer_templates"
+      },
+      "title": "Freescout",
+      "type": 3,
+      "maintainer": " https://github.com/xneo1/portainer_templates/"
+    },
+    {
+      "id": 353,
+      "categories": [
+        "Fitness"
+      ],
+      "description": "Self hosted FLOSS fitness/workout, nutrition and weight tracker written with Django",
+      "logo": "https://raw.githubusercontent.com/wger-project/wger/master/wger/core/static/images/logos/logo.png",
+      "name": "wger",
+      "platform": "linux",
+      "repository": {
+        "stackfile": "Template/Stack/wger.yml",
+        "url": "https://github.com/xneo1/portainer_templates"
+      },
+      "title": "Wger",
+      "type": 3,
+      "maintainer": " https://github.com/xneo1/portainer_templates/"
+    },
+    {
+      "id": 354,
+      "categories": [
+        "Docker"
+      ],
+      "description": "Docker Container Stats is a web interface for viewing historical and current statistics per docker container (cpu, mem, net i/o, block i/o) - in a docker container.",
+      "logo": "https://raw.githubusercontent.com/Poeschl/Hassio-Addons/master/container-stats/logo.png",
+      "name": "Docker Container Stats",
+      "platform": "linux",
+      "repository": {
+        "stackfile": "Template/Stack/docker-container-stats.yml",
+        "url": "https://github.com/xneo1/portainer_templates"
+      },
+      "title": "Docker Container Stats",
+      "type": 3,
+      "maintainer": " https://github.com/xneo1/portainer_templates/"
+    },
+    {
+      "id": 355,
+      "categories": [
+        "Ebooks"
+      ],
+      "description": "Codex is a web server comic book browser and reader.",
+      "logo": "https://github.com/ajslater/codex/raw/main/codex/static_src/img/logo.svg",
+      "name": "codex",
+      "platform": "linux",
+      "repository": {
+        "stackfile": "Template/Stack/codex.yml",
+        "url": "https://github.com/xneo1/portainer_templates"
+      },
+      "title": "Codex",
+      "type": 3,
+      "maintainer": " https://github.com/xneo1/portainer_templates/"
+    },
+    {
+      "id": 356,
+      "categories": [
+        "Ebooks",
+        "Comics"
+      ],
+      "description": "Kapowarr is a software to build and manage a comic book library, fitting in the *arr suite of software.",
+      "logo": "",
+      "name": "kapowarr",
+      "platform": "linux",
+      "repository": {
+        "stackfile": "Template/Stack/kapowarr.yml",
+        "url": "https://github.com/xneo1/portainer_templates"
+      },
+      "title": "Kapowarr",
+      "type": 3,
+      "maintainer": " https://github.com/xneo1/portainer_templates/"
+    },
+    {
+      "id": 357,
+      "categories": [
+        "Messaging"
+      ],
+      "description": "A TLS proxy relay for the Signal privacy messenger app.",
+      "logo": "https://avatars.githubusercontent.com/u/702459?s=200&v=4",
+      "name": "signal",
+      "platform": "linux",
+      "repository": {
+        "stackfile": "Template/Stack/signal.yml",
+        "url": "https://github.com/xneo1/portainer_templates"
+      },
+      "title": "Signal Proxy",
+      "type": 3,
+      "maintainer": " https://github.com/xneo1/portainer_templates/"
+    },
+    {
+      "id": 358,
+      "categories": [
+        "Employee"
+      ],
+      "description": "ChiefOnboarding is a free and open source employee onboarding platform. You can onboarding new hires through Slack or the dashboard.",
+      "logo": "https://chiefonboarding.com/wp-content/uploads/2022/07/ChiefOnBoarding-768x138.png",
+      "name": "chiefonboarding",
+      "platform": "linux",
+      "repository": {
+        "stackfile": "Template/Stack/chiefonboarding.yml",
+        "url": "https://github.com/xneo1/portainer_templates"
+      },
+      "title": "Chiefonboarding",
+      "type": 3,
+      "maintainer": " https://github.com/xneo1/portainer_templates/"
+    },
+    {
+      "id": 359,
+      "categories": [
+        "Podcast"
+      ],
+      "description": "Castopod is a free and open-source hosting platform made for podcasters.",
+      "logo": "https://pbs.twimg.com/profile_images/1313854745161932800/w_qe6Qq6_400x400.png",
+      "name": "castopod",
+      "platform": "linux",
+      "repository": {
+        "stackfile": "Template/Stack/castopod.yml",
+        "url": "https://github.com/xneo1/portainer_templates"
+      },
+      "title": "Castopod",
+      "type": 3,
+      "maintainer": " https://github.com/xneo1/portainer_templates/"
+    },
+    {
+      "id": 360,
+      "categories": [
+        "Music",
+        "Monitoring"
+      ],
+      "description": "YourSpotify is a self-hosted application that tracks what you listen and offers you a dashboard to explore statistics about it!",
+      "logo": "",
+      "name": "your_spotify",
+      "platform": "linux",
+      "repository": {
+        "stackfile": "Template/Stack/your_spotify.yml",
+        "url": "https://github.com/xneo1/portainer_templates"
+      },
+      "title": "Your_spotify",
+      "type": 3,
+      "maintainer": " https://github.com/xneo1/portainer_templates/"
+    },
+    {
+      "id": 361,
+      "categories": [
+        "Database",
+        "Metrics"
+      ],
+      "description": "InfluxDB is an open source time series database for recording metrics, events, and analytics. Telegraf is an agent for collecting metrics and writing them to InfluxDB or other outputs.",
+      "logo": "https://raw.githubusercontent.com/xneo1/portainer_templates/master/Images/influxdb_telegraf.jpg",
+      "name": "influxdb-telegraf",
+      "platform": "linux",
+      "repository": {
+        "stackfile": "Template/Stack/influxdb2_telegraf.yml",
+        "url": "https://github.com/xneo1/portainer_templates"
+      },
+      "title": "Influxdb & Telegraf",
+      "type": 3,
+      "maintainer": " https://github.com/xneo1/portainer_templates/"
+    },
+    {
+      "id": 362,
+      "categories": [
+        "Database"
+      ],
+      "description": "InfluxDB is an open source time series database for recording metrics, events, and analytics.",
+      "logo": "https://www.niagaramarketplace.com/media/catalog/product/cache/f7420c7cfd302c73440e50c5a6066c3c/m/a/marketplace_icons_13_.png",
+      "name": "influxdb2",
+      "platform": "linux",
+      "repository": {
+        "stackfile": "Template/Stack/influxdb2.yml",
+        "url": "https://github.com/xneo1/portainer_templates"
+      },
+      "title": "Influxdb",
+      "type": 3,
+      "maintainer": " https://github.com/xneo1/portainer_templates/"
+    },
+    {
+      "id": 363,
+      "categories": [
+        "Files"
+      ],
+      "description": "A Dropbox-like file manager that let you manage your data anywhere it is located.",
+      "logo": "https://downloads.filestash.app/brand/logo_white.svg",
+      "name": "filestash",
+      "platform": "linux",
+      "repository": {
+        "stackfile": "Template/Stack/filestash.yml",
+        "url": "https://github.com/xneo1/portainer_templates"
+      },
+      "title": "Filestash",
+      "type": 3,
+      "maintainer": " https://github.com/xneo1/portainer_templates/"
+    },
+    {
+      "id": 364,
+      "categories": [
+        "Cms"
+      ],
+      "description": "Silverstripe CMS is a free and open source Content Management System (CMS) and Framework for creating and maintaining websites and web applications.",
+      "logo": "https://github.com/brettt89/silverstripe-docker/raw/master/docs/logo.png",
+      "name": "silverstripe",
+      "platform": "linux",
+      "repository": {
+        "stackfile": "Template/Stack/silverstripe.yml",
+        "url": "https://github.com/xneo1/portainer_templates"
+      },
+      "title": "Silverstripe",
+      "type": 3,
+      "maintainer": " https://github.com/xneo1/portainer_templates/"
+    },
+    {
+      "id": 365,
+      "categories": [
+        "Adult"
+      ],
+      "description": "Whisparr is an adult movie collection manager for Usenet and BitTorrent users.",
+      "logo": "https://whisparr.com/logo/256.png",
+      "name": "whisparr",
+      "platform": "linux",
+      "repository": {
+        "stackfile": "Template/Stack/whisparr.yml",
+        "url": "https://github.com/xneo1/portainer_templates"
+      },
+      "title": "Whisparr",
+      "type": 3,
+      "maintainer": " https://github.com/xneo1/portainer_templates/"
+    },
+    {
+      "id": 366,
+      "categories": [
+        "Multimedia"
+      ],
+      "description": "Your media enjoyed through a minimal lightweight media server.",
+      "logo": "https://github.com/midarrlabs/midarr-server/raw/master/priv/static/logo.svg",
+      "name": "midarr",
+      "platform": "linux",
+      "repository": {
+        "stackfile": "Template/Stack/midarr.yml",
+        "url": "https://github.com/xneo1/portainer_templates"
+      },
+      "title": "Midarr",
+      "type": 3,
+      "maintainer": " https://github.com/xneo1/portainer_templates/"
+    },
+    {
+      "id": 367,
+      "categories": [
+        "Social"
+      ],
+      "description": "Mastodon is a free, open-source social network server based on ActivityPub where users can follow friends and discover new ones..",
+      "logo": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/mastodon-banner.png",
+      "name": "mastodon",
+      "platform": "linux",
+      "repository": {
+        "stackfile": "Template/Stack/mastodon.yml",
+        "url": "https://github.com/xneo1/portainer_templates"
+      },
+      "title": "Mastodon",
+      "type": 3,
+      "maintainer": " https://github.com/xneo1/portainer_templates/"
+    },
+    {
+      "id": 368,
+      "categories": [
+        "Development"
+      ],
+      "description": "Appwrite is a self-hosted backend-as-a-service platform that provides developers with all the core APIs required to build any application.",
+      "logo": "https://appwrite.io/images/appwrite.svg",
+      "name": "appwrite",
+      "platform": "linux",
+      "repository": {
+        "stackfile": "Template/Stack/appwrite.yml",
+        "url": "https://github.com/xneo1/portainer_templates"
+      },
+      "title": "Appwrite",
+      "type": 3,
+      "maintainer": " https://github.com/xneo1/portainer_templates/"
+    },
+    {
+      "id": 369,
+      "categories": [
+        "Productivity",
+        "Lowcode"
+      ],
+      "description": "OpnForm is an open-source form builder. It's an alternative to products like Typeform, JotForm, Tally etc.",
+      "logo": "https://opnform.com/img/logo.svg",
+      "name": "opnform",
+      "platform": "linux",
+      "repository": {
+        "stackfile": "Template/Stack/opnform.yml",
+        "url": "https://github.com/xneo1/portainer_templates"
+      },
+      "title": "OpnForm",
+      "type": 3,
+      "maintainer": " https://github.com/xneo1/portainer_templates/"
+    },
+    {
+      "id": 370,
+      "categories": [
+        "Social",
+        "Events"
+      ],
+      "description": "Gathio is a simple, federated, privacy-first event hosting platform.",
+      "logo": "https://gath.io/og-image.jpg",
+      "name": "gathio",
+      "platform": "linux",
+      "repository": {
+        "stackfile": "Template/Stack/gathio.yml",
+        "url": "https://github.com/xneo1/portainer_templates"
+      },
+      "title": "Gathio",
+      "type": 3,
+      "maintainer": " https://github.com/xneo1/portainer_templates/"
+    },
+    {
+      "id": 371,
+      "categories": [
+        "Monitoring"
+      ],
+      "description": "A lightweight server resource monitoring hub with historical data, docker stats, and alerts.",
+      "logo": "",
+      "name": "beszel",
+      "platform": "linux",
+      "repository": {
+        "stackfile": "Template/Stack/beszel.yml",
+        "url": "https://github.com/xneo1/portainer_templates"
+      },
+      "title": "Beszel",
+      "type": 3,
+      "maintainer": " https://github.com/xneo1/portainer_templates/"
+    },
+    {
+      "id": 372,
+      "categories": [
+        "Rss"
+      ],
+      "description": "A lightweight RSS feed aggregator and reader.",
+      "logo": "",
+      "name": "fusion",
+      "platform": "linux",
+      "repository": {
+        "stackfile": "Template/Stack/fusion.yml",
+        "url": "https://github.com/xneo1/portainer_templates"
+      },
+      "title": "Fusion",
+      "type": 3,
+      "maintainer": " https://github.com/xneo1/portainer_templates/"
+    },
+    {
+      "id": 373,
+      "categories": [
+        "Analytics"
+      ],
+      "description": "Medama Analytics is an open-source project dedicated to providing self-hostable, cookie-free website analytics.",
+      "logo": "https://raw.githubusercontent.com/medama-io/medama/main/.github/images/banner-dark.svg",
+      "name": "medama",
+      "platform": "linux",
+      "repository": {
+        "stackfile": "Template/Stack/medama.yml",
+        "url": "https://github.com/xneo1/portainer_templates"
+      },
+      "title": "Medama",
+      "type": 3,
+      "maintainer": " https://github.com/xneo1/portainer_templates/"
+    },
+    {
+      "id": 374,
+      "categories": [
+        "Notes"
+      ],
+      "description": "Markopolis is like the self hosted version of Obsidian Publish.",
+      "logo": "",
+      "name": "markopolis",
+      "platform": "linux",
+      "repository": {
+        "stackfile": "Template/Stack/markopolis.yml",
+        "url": "https://github.com/xneo1/portainer_templates"
+      },
+      "title": "Markopolis",
+      "type": 3,
+      "maintainer": " https://github.com/xneo1/portainer_templates/"
+    },
+    {
+      "id": 375,
+      "categories": [
+        "Bookmarks"
+      ],
+      "description": "Hoarder is an open source 'Bookmark Everything' app that uses AI for automatically tagging the content you throw at it.",
+      "logo": "https://raw.githubusercontent.com/hoarder-app/hoarder/main/screenshots/logo.png",
+      "name": "hoarder",
+      "platform": "linux",
+      "repository": {
+        "stackfile": "Template/Stack/hoarder.yml",
+        "url": "https://github.com/xneo1/portainer_templates"
+      },
+      "title": "Hoarder",
+      "type": 3,
+      "maintainer": " https://github.com/xneo1/portainer_templates/"
+    },
+    {
+      "id": 376,
+      "categories": [
+        "Multimedia"
+      ],
+      "description": "TinyMediaManager is a media management tool written in Java/Swing. It is written to provide metadata for the Kodi Media Center (formerly known as XBMC), MediaPortal and Plex media server.",
+      "logo": "https://www.tinymediamanager.org/images/avatar.png",
+      "name": "tinymediamanager",
+      "platform": "linux",
+      "repository": {
+        "stackfile": "Template/Stack/tinymediamanager.yml",
+        "url": "https://github.com/xneo1/portainer_templates"
+      },
+      "title": "TinyMediaManager",
+      "type": 3,
+      "maintainer": " https://github.com/xneo1/portainer_templates/"
+    },
+    {
+      "id": 377,
+      "categories": [
+        "Tools"
+      ],
+      "description": "Web Check give you a comprehensive, on-demand open source intelligence for any website",
+      "logo": "https://camo.githubusercontent.com/e081ebebf2ef1dbe9ecffa081063db7c9f696e5913d75699f7d2968a186d0d72/68747470733a2f2f692e6962622e636f2f7131675a4e32702f7765622d636865636b2d6c6f676f2e706e67",
+      "name": "web-check",
+      "platform": "linux",
+      "repository": {
+        "stackfile": "Template/Stack/webcheck.yml",
+        "url": "https://github.com/xneo1/portainer_templates"
+      },
+      "title": "Web Check",
+      "type": 3,
+      "maintainer": " https://github.com/xneo1/portainer_templates/"
+    },
+    {
+      "id": 378,
+      "categories": [
+        "Remotecontrol"
+      ],
+      "description": "The open source server management software for SSH, VNC & RDP",
+      "logo": "https://docs.nexterm.dev/logo.png",
+      "name": "nexterm",
+      "platform": "linux",
+      "repository": {
+        "stackfile": "Template/Stack/nexterm.yml",
+        "url": "https://github.com/xneo1/portainer_templates"
+      },
+      "title": "Nexterm",
+      "type": 3,
+      "maintainer": " https://github.com/xneo1/portainer_templates/"
+    },
+    {
+      "id": 379,
+      "categories": [
+        "Multimedia"
+      ],
+      "description": "Your next YouTube media manager",
+      "logo": "https://github.com/kieraneglin/pinchflat/raw/master/priv/static/images/originals/logo-white-wordmark-with-background.png",
+      "name": "pinchflat",
+      "platform": "linux",
+      "repository": {
+        "stackfile": "Template/Stack/pinchflat.yml",
+        "url": "https://github.com/xneo1/portainer_templates"
+      },
+      "title": "Pinchflat",
+      "type": 3,
+      "maintainer": " https://github.com/xneo1/portainer_templates/"
+    },
+    {
+      "id": 380,
+      "categories": [
+        "Automation",
+        "Ai"
+      ],
+      "description": "Automate your marketing, sales and operations",
+      "logo": "https://cdn.activepieces.com/brand/full-logo-white.svg",
+      "name": "activepieces",
+      "platform": "linux",
+      "repository": {
+        "stackfile": "Template/Stack/activepieces.yml",
+        "url": "https://github.com/xneo1/portainer_templates"
+      },
+      "title": "Activepieces",
+      "type": 3,
+      "maintainer": " https://github.com/xneo1/portainer_templates/"
+    },
+    {
+      "id": 381,
+      "categories": [
+        "Management"
+      ],
+      "description": "A fancy, easy-to-use and reactive self-hosted docker compose.yaml stack-oriented manager.",
+      "logo": "https://github.com/louislam/dockge/raw/master/frontend/public/icon.svg",
+      "name": "dockge",
+      "platform": "linux",
+      "repository": {
+        "stackfile": "Template/Stack/dockge.yml",
+        "url": "https://github.com/xneo1/portainer_templates"
+      },
+      "title": "Dockge",
+      "type": 3,
+      "maintainer": " https://github.com/xneo1/portainer_templates/"
+    },
+    {
+      "id": 382,
+      "categories": [
+        "Management"
+      ],
+      "description": "Deploy compose files, start/stop containers, delete unused images, view logs",
+      "logo": "https://dokemon.dev/logo/dokemon-dark-medium.svg",
+      "name": "dokemon",
+      "platform": "linux",
+      "repository": {
+        "stackfile": "Template/Stack/dokemon.yml",
+        "url": "https://github.com/xneo1/portainer_templates"
+      },
+      "title": "Dokemon",
+      "type": 3,
+      "maintainer": " https://github.com/xneo1/portainer_templates/"
+    },
+    {
+      "id": 383,
+      "categories": [
+        "Tracking"
+      ],
+      "description": "Hauk is a fully open source, self-hosted location sharing service. Install the backend code on a PHP-compatible web server, install the companion app on your phone, and you're good to go!",
+      "logo": "https://github.com/bilde2910/Hauk/raw/master/frontend/assets/logo.svg",
+      "name": "hauk",
+      "platform": "linux",
+      "repository": {
+        "stackfile": "Template/Stack/hauk.yml",
+        "url": "https://github.com/xneo1/portainer_templates"
+      },
+      "title": "Hauk",
+      "type": 3,
+      "maintainer": " https://github.com/xneo1/portainer_templates/"
+    },
+    {
+      "id": 384,
+      "categories": [
+        "Projectmanagement",
+        "Productivity"
+      ],
+      "description": "Project management tool from the future. An open-source software development tool to manage issues, sprints, and product roadmaps with peace of mind.",
+      "logo": "https://plane-marketing.s3.ap-south-1.amazonaws.com/plane-assets/logo/text-logo.svg",
+      "name": "plane",
+      "platform": "linux",
+      "repository": {
+        "stackfile": "Template/Stack/plane.yml",
+        "url": "https://github.com/xneo1/portainer_templates"
+      },
+      "title": "Plane",
+      "type": 3,
+      "maintainer": " https://github.com/xneo1/portainer_templates/"
+    },
+    {
+      "id": 385,
+      "categories": [
+        "Linksharing"
+      ],
+      "description": "The personal, minimalist, super fast, database-free, bookmarking service.",
+      "logo": "https://github.com/shaarli/Shaarli/raw/master/doc/md/images/doc-logo.png",
+      "name": "shaarli",
+      "platform": "linux",
+      "repository": {
+        "stackfile": "Template/Stack/shaarli.yml",
+        "url": "https://github.com/xneo1/portainer_templates"
+      },
+      "title": "Shaarli",
+      "type": 3,
+      "maintainer": " https://github.com/xneo1/portainer_templates/"
+    },
+    {
+      "id": 386,
+      "categories": [
+        "Ai",
+        "Llm"
+      ],
+      "description": "Open source UI visual tool to build your customized LLM flow using LangchainJS, written in Node Typescript/Javascript",
+      "logo": "https://flowiseai.com/_next/static/images/flowise_logo_dark-6c1a356f4868d3deb7864323ff93a0fa.png",
+      "name": "flowiseai",
+      "platform": "linux",
+      "repository": {
+        "stackfile": "Template/Stack/flowiseai.yml",
+        "url": "https://github.com/xneo1/portainer_templates"
+      },
+      "title": "Flowiseai",
+      "type": 3,
+      "maintainer": " https://github.com/xneo1/portainer_templates/"
+    },
+    {
+      "id": 387,
+      "categories": [
+        "News"
+      ],
+      "description": "FeedCord is a dead-simple RSS Reader designed to integrate seamlessly with Discord. With just a few configuration steps, you can have a news feed text channel up and running in your server.",
+      "logo": "",
+      "name": "feedcord",
+      "platform": "linux",
+      "repository": {
+        "stackfile": "Template/Stack/feedcord.yml",
+        "url": "https://github.com/xneo1/portainer_templates"
+      },
+      "title": "Feedcord",
+      "type": 3,
+      "maintainer": " https://github.com/xneo1/portainer_templates/"
+    },
+    {
+      "id": 388,
+      "categories": [
+        "System"
+      ],
+      "description": "FetchCord grabs your OS info and displays it as Discord Rich Presence",
+      "logo": "https://camo.githubusercontent.com/508dbb305be551d7278b5b1decb1a68dbac2558c4a2053da1db44690660d0386/68747470733a2f2f63646e2e646973636f72646170702e636f6d2f6174746163686d656e74732f3639353138323834393437363635373232332f3734323036343435323432313238383037372f46657463684469732e706e67",
+      "name": "fetchcord",
+      "platform": "linux",
+      "repository": {
+        "stackfile": "Template/Stack/fetchcord.yml",
+        "url": "https://github.com/xneo1/portainer_templates"
+      },
+      "title": "Fetchcord",
+      "type": 3,
+      "maintainer": " https://github.com/xneo1/portainer_templates/"
+    },
+    {
+      "id": 389,
+      "categories": [
+        "Multimedia"
+      ],
+      "description": "Tubearchivist is your self hosted YouTube media server",
+      "logo": "https://nas.mengkai.fun:88/images/2023/11/17/tube-archivist.png",
+      "name": "tubearchivist",
+      "platform": "linux",
+      "repository": {
+        "stackfile": "Template/Stack/tubearchivist.yml",
+        "url": "https://github.com/xneo1/portainer_templates"
+      },
+      "title": "Tubearchivist",
+      "type": 3,
+      "maintainer": " https://github.com/xneo1/portainer_templates/"
+    },
+    {
+      "id": 390,
+      "categories": [
+        "Finance"
+      ],
+      "description": "Actual is a super fast privacy-focused app for managing your finances. ",
+      "logo": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAPcAAABOCAYAAAD8SYDuAAAACXBIWXMAABYlAAAWJQFJUiTwAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAABARSURBVHgB7Z1NbBvHFcffLEVJkftBJ00TtAdtkKJ1bKeW0QDOJTF9SnKK3aCApaIwfUiTm+RTLwG8AtICOck6Fj2YRlE5bZBaPiU5lXYvMdBCdONITi+mW7QI6jhRG0S2JXGn781yV+RqZz/4Ie2S7wdQJrncXXK9/3lv3rx5I6ADrONLBRjLHwdpHAIhiwCiACBNSCWiBhJq+KQKwr4O9kbFevtwDRimTxGQEBK03JMvCdt42RF0hpGigkK/YC0cLAPD9BmJxD07tXJWivoMiqIA/UUNlT7LImf6iVjitk5+VATDOI9PTehvarAhT1jvHKwCw2QcI+oDZK1R2H+C/hc2YUJeLKnfzDAZR2u5nWDZ6ByAXYLBpGwtHDgNDJNR9OKe+ngJ/5mAwaYKa+vHrMXDq8AwGSPQLbemVqh/PejCJiZgbHgOGCaDbBO3098cWFc8iBL3wZks0uKWW1M30FqLJWC2Y9vHrLefrgDDZASf5RaXgAnGGQpkmMzgiRutdgkGY7irXUxr6iMLGCYjNFluwf3KSIxpNUTIMBlAiZutdmwK8qF8CRgmAziWWxingImFAONlYJgMIKyTSyYYw7eAic/a+l5ObGHSjgFGvghMMmgOO8OkHHTLJWeiJUVy9h6TfgwQuUOQUh4bH4HCt/KQOoRxFBgm5Rgg01kW6dDzBXj9V0/C0VcehfQheTiMST0ULTchhUw8X/D+TaH1NoFhUk5ksYbdwHxqDz7GvNfptN4Mk26GIIX4xUzW+8q7d2D1sw1gtpidXDkljfq5sJp2OC5vnV14ahaYzKOGrcXI+W2FSYU4Z/1u/xn/51NnuckFb7baLkdeehiYVqSwrahilRJsS9XAY7KPMTQTWHFYypmg/+PUWW6dC66s9x8/g/tf1YHBVnzybzTWbsb6sAFF/FuBDNBIqmqZ5yAAanJtfX7gE4eoIdfVTjKE6X8rVeImq+0G0ohPb9+Hx8dH1fPRsRwceeFhFPgdYBCRS5AGq9KLLcgCxvC2YpyS/jyU34t/Z4CJTarccr/V/v3cP6G2sua9fhZd89E9ORh0rJKamVZKsIuZBdfcOrligs4bEYJz+hOSGnH7rXb16iqs3tlQgTQX13oPPOttpL8KwSmzA0ZqxO232tevOt2r2spXbL230YYVE4Jn/g0YqRC3EyHf470mMTcLmq33FirgBKC3wlLUNFsKqXfN6/c586+LpCKgNnG0AIVHt7LQrrz7n5btrvV2h8jIel/74PPBjJyHzeKz4TIY9Sp+KLiqjuOaV6BDvMUgpTiEBy2CsAtOJFeuqsaFHsK+HGclVV90vBjyUdOaXL6kzuFir8/6j0/fTYyNTuMQoOm9KQV+rwfzcVZ17XR/7zjYkApj6KiUcgIj3BOdXKN2SYW4Dz231WBTokqz1XYh622+Ma6eD3TknAprSKnZKBfBHqqAYevETa552xHnJiGisL1z0s3feKrG3PFGppmG2JAYw7S4RTlIhB40dhs3OCjkcd++t8E/CjA2fB6Fedy3H/4ZoZl8xyCKseE56S/tTfuLYTrmE1G7K+9I5M7SeDQeZ6u+cCfXqE123S2nCSJhVtuF+94NccmwZZNzaAWeqoFatTSQtl1zyoaDXJ7KXpcgGSUa3kKrG9yV6P6KscHTceMvN637nPnm1PJ42I7WT5fn1Lp6yZe2pmt0S13jLrLr4i7+eCuQRla7evW/2s8OfN87zCWX0hU2Yl/QHyN5Sa3ZqeVpKexyB0I08Ya/1O2bN00oYUvZ0Tg8XWNtI9gGuyruuFbbhaz3p7cfeK8HznqH1bqTsCVoO7RffTxJBVey9BLkOegCePOeawQE+wpVYLRDYXsIeb5bFXZ3VdxJrLbLtffves8HyXrHccm9zzoro9Q0HyzA6FD8SjLRizFggEjOY4syq/7VR+udc9PEh2ZkzsI/ZfUI35casEXvs/Swh8qQCkLKgqNHhX9OY5/6CedhH8P3LoQcrABjQ11pKHYtoJbUarvc/Mv/4IWfPaaETQxM5Dy2S+5Crrkuap6bhhhR88iS1yTmexuWL+d7xlm8QXduWSTL5O7T+N5qqWSVoSakrlhnzbp44ASkjIgc/0Xr4kH/d67ho4LXaJXq4AfuJXNdqfSza5b72Rcf8Z7rIuTNjOMwGIl6ev77nrAJen7ouW9C3yNgWrut2SV3CXPNGwKD6JOGLVRRxht3Jmgyh7XwtIVfYF63Y1/Vfh+pVxzPBb0Koaw0DkUqAVfBNs5o9xvetLTbRHeqI+2K5aaElcfHR7zX1StOqqmf0TEDjrz0SGQ1Fmoorr3/OfQrjksuQlzpLZfc2wddc7S8KLzAIFihUcG1DNpzqqi6qduON274HHG6edeHAxskIURq6/YlxSqrxi2xG0374RCYbrMJXWBXxL0t1fTPW40/CfrQ83th3zNfa8laC4Pce3Lz3ZTVfkOK/HGh3Rjkknsb0aILjeungnNl0J5TTLR3Tge6ec9O3jgjBAQJeR4GHFoWWo2D95AdF7e/GIM7QYTcbrLQ+575hhJ4EPfXbDUNlPrnFDWfnv+e56JTcK5Z3HQMmi4a5e5nAbR0yVxyFxtdRUPjzgs50dz3DTjnUf0p4TLEYPbiwa5E2bOK8rjq+QLkYUIKKAjboHFyEwy7KKXd81TbHRd3UDGGX/xmn1bQBAn0EwykVdHC3/9qq7W79t7n3vFc6716Zx2K+B5Z/ftrdXjr1U8gy1g/WSJ33NR+QBgh7spmDf1j3UZ33bNgAQp05zWZcAKMGjDb8NJybeMoCVjlBTRua5Uk56b1SQE7wY6K2z+tk/C/diErfe29u45l19RO+xD72VR+ybXex1/7Tst2ep+8hExb7/xQKXS7kHPW5LLOOpuhuzrrnmmsK1kWzU0o6/3Z/+mARqKPJZz88R0TcBg7Im6yyj9Ad/vZF8PHpEnQ1atfoJX+MlKQTt+8oCx5c/Tcj7l/T8Zd88iFB822o6u+YSmmPayplfMqHz0Fgm6mp+KmfvS+Z76O1nlvpNtNySmUgdbsdrd7zCSNRJqJjFh3Ab1rTu6+ZoJKQL2uQaURGCvF+Chdzxpe0ivoEFUbc/K7lmoaRNfF7Q5f0fBUO/3osGPGXaDg8q//BTdR2JnH6P3SylrX3LZvY787cB/sivc8GNQLeuGlhApboogFjoGvbSz6z2uVlhZxqDBb4n58/KGWtNIgSNgX3qxBFGSl3eCYDrdv3tz3PoINS1+IO3x+c3fQuOZos6so7cDGJbyvvoXqh8oA6yTrs40U2Z0lnzeBkks0NPLeTYhJhGe1GJZRFzHO3RW6Lm7lWmOU2hUaiY9uleZ+cViqKQma+slhlp+OSWmoNPTV7Ha7kXMKomU9kBbDJV9tPOJiarc4ucxW81tCyqrOcqsGAYUQNv+YtqsJJ4GHENdhN0ot59V8cK24hTF6KsnYc2gugG2HjuWrIpfr0FN60uemIapxFKjrdr/2yyc9cQelmsZNXAlz5f2R86OvfBtqMbyD1BLmkktRsy7ujywc0AxaiUug6+MF5DJHZLhBYwKIvviBr/Z46/n0AusYQVVOdAFGYxobnXJQo4S/dYIWcIBEp5LaEYUhI3crdOf13q/x3hNxV6hCSqNKStgEkW4Gx8hbaB737gPrXdRvsmMlkbTugpbEMIJvKLTEVIjgjYX9t1s3UM600E8AobJH8sGZZrGonPU9I2dRYCXQsj1dNgbm2cnlmdmL+8O7A7KOXoFR1GzFcefhJTzOrNi0K5DbwMZryFTlkBIKW51KilWdc7MJdZoMYwVtc5YFgjldvLI9VNJRufmdng+F+ad1Ul+YBBgVHCNRqky0f9yPDLi59Iv1jnTJN/Vpo1pGN6toLbSWOPBmHN48Bw9GTmmH2qjskZEnkVe82mb0ngxd4risS12l98O8BUFj+lMfn3K24/nW1o9tC5CFZeU5FOg4kCdVOgk+PlecjhcrYBjadQHjLDYiq+Leg7I3A86tzybqM20VvhAYbdcuOQIlvDZFUFNwxSx6dos9nRXmt9okOspGI8EHCZusNFVbeevnN1XAjQQeV9jO/o71dnGtd+aIcsnfOZjYrXUmOIiK/rgBrjntI5XoIeT7FBq1zUrqEXbT0nztqAknwoj6bRN4IFP9GzAvXQXqRMjvDEPNJ7fj571TgwlSG/dQjcjY8BfW1PItetBz5SG0W9HGjoxTmODUZ5ujFz0Vtz9qHuR6O273qhLzW6/eVC59EkH7IetNInch6509ZEh/rA2XfOu4+n1VkGx7fTUSi5RSP3UxCXU4EzXhBOr12CuSUkAreIPd3veVduxzE9T44WhAjH2oMfJ5P6oCamjRhu1ENCZNmOQl9Ezcfqvth6zyB7/9FOZn/o7j0v/uWt+YhF29slXRhSaPZKkUkzP5P8z6yUVol+GNxdCbwwju56sJILJ+IrJSip5V2BQnrD/sj/zuzhBZPJHppo5aC+jZ2PI0JMLG4bmDZUiIc20SitQpbXwMEuJ4Una834VeTc/E3VyMwYWs9Ifv31VWmh7KynZgpXVc++Cu5+JT45GpKi1CFLXbyCXvYHxY3Rxhbq/UzwSzLv5wUd2QSW9kCvLYxuE4wvbOtfC0pbyFyMZEP8fdEao8HKNBchoeVWAinM21B4F1wKyLB0txGyRVdgmvY6QHo8H5f4jR0IpcoScBNX8xhnaCY51AU0jJxc8k9tA5MDaDrasQ7Vttl7o4DUa91M7xGzdkyTq5YuGBimBQCiW5m8rTwH/dum0SXXm4Lu5tlNvNCCOLiK5lGUZxyEigR2HAVllhtUiAvI1diXLYMZQFB3jCqSVONcKb5pbbQFH1Ctx7UGn5jlSXzdjcfjCZq4b9Fmoc8LqU1XXJwSlQWXyuB0YLEcAV8rpaGmeqHydo5p6PiL61EjglydDvUt6WaCq5jNcFaKj0wKLACFtXA/LEvh99HV5+/bsqc+xDsqI7IOidxlo4kK5ZAgzjoyeW++Zfv4SbWbWcDNMnUJ+7BkxSasAwKcdoWViNiYekZAKGSTcG3qhXgEnKdWCYlINuuehdEn+/0suJDwzTJQwnsYFJRlsTHxhmRzGcxIY2c3EHkRg1uxkmDagMNWl3kq88YITVCWeYFKHELUY2yjET0gcblf6ZPP+YYXYDJW5nOqAc+CVeIkk4a4hhdpOWFEprcvlWt1YY7DvaKG3EMLtJ66ywqIn5g4ywU7c2NMOE0SLuJHNpBwt7tjHDiGEyQ+DMJmvyRhmHx3peED8TSHnBma/LMNkiuFjDyMYMAGdhUSYaC5vJKoHiVqshLBw43EbVjf6Bfvu99cSlcBgmLUQWHLCmPrKoTCsMFNTHji67wzBpJlY1EVqNAaRxqe+HyVThuvrpXVnHimG6TKJSQdbJGyUQaMX7T+SrVK+arTXTT7RVB0yJXBWBC6nUmQWkrEiAy50U8mOYtNJRkT/r5Iqpqj0KmFCVJaXA171dLL4Dal4VSlr8PGDNZIbpJ/4Po+cuMuwZqbUAAAAASUVORK5CYII=",
+      "name": "actual",
+      "platform": "linux",
+      "repository": {
+        "stackfile": "Template/Stack/actual.yml",
+        "url": "https://github.com/xneo1/portainer_templates"
+      },
+      "title": "Actual",
+      "type": 3,
+      "maintainer": " https://github.com/xneo1/portainer_templates/"
+    },
+    {
+      "id": 391,
+      "categories": [
+        "Calendar",
+        "Productivity"
+      ],
+      "description": "Baïkal is a lightweight CalDAV+CardDAV server. It offers an extensive web interface with easy management of users, address books and calendars.",
+      "logo": "https://sabre.io/img/logo.png",
+      "name": "baikal",
+      "platform": "linux",
+      "repository": {
+        "stackfile": "Template/Stack/baikal.yml",
+        "url": "https://github.com/xneo1/portainer_templates"
+      },
+      "title": "Baikal",
+      "type": 3,
+      "maintainer": " https://github.com/xneo1/portainer_templates/"
+    },
+    {
+      "id": 392,
+      "categories": [
+        "Downloaders",
+        "Multimedia"
+      ],
+      "description": "Autobrr is the modern download automation tool for torrents.",
+      "logo": "https://autobrr.com/img/logo.png",
+      "name": "autobrr",
+      "platform": "linux",
+      "repository": {
+        "stackfile": "Template/Stack/autobrr.yml",
+        "url": "https://github.com/xneo1/portainer_templates"
+      },
+      "title": "Autobrr",
+      "type": 3,
+      "maintainer": " https://github.com/xneo1/portainer_templates/"
+    },
+    {
+      "id": 393,
+      "categories": [
+        "Monitoring"
+      ],
+      "description": "Glances is an open-source system cross-platform monitoring tool. It allows real-time monitoring of various aspects of your system such as CPU, memory, disk, network usage etc.",
+      "logo": "https://raw.githubusercontent.com/nicolargo/glances/develop/docs/_static/glances-responsive-webdesign.png",
+      "name": "glances",
+      "platform": "linux",
+      "repository": {
+        "stackfile": "Template/Stack/glances.yml",
+        "url": "https://github.com/xneo1/portainer_templates"
+      },
+      "title": "Glances",
+      "type": 3,
+      "maintainer": " https://github.com/xneo1/portainer_templates/"
+    },
+    {
+      "id": 394,
+      "categories": [
+        "Wiki",
+        "Knowledgebase"
+      ],
+      "description": "Documize Community is an open source, modern, self-hosted, enterprise-grade knowledge management solution.",
+      "logo": "",
+      "name": "documize",
+      "platform": "linux",
+      "repository": {
+        "stackfile": "Template/Stack/documize.yml",
+        "url": "https://github.com/xneo1/portainer_templates"
+      },
+      "title": "Documize",
+      "type": 3,
+      "maintainer": " https://github.com/xneo1/portainer_templates/"
+    },
+    {
+      "id": 395,
+      "categories": [
+        "Remotecontrol"
+      ],
+      "description": "RPort is free remote access and remote management, now acquired by RealVNC",
+      "logo": "https://images.g2crowd.com/uploads/product/image/large_detail/large_detail_634014ae8000cebecce8a571f9ea316f/cloudradar-gmbh-rport.png",
+      "name": "Rport",
+      "platform": "linux",
+      "repository": {
+        "stackfile": "Template/Stack/rport.yml",
+        "url": "https://github.com/xneo1/portainer_templates"
+      },
+      "title": "Rport",
+      "type": 3,
+      "maintainer": " https://github.com/xneo1/portainer_templates/"
+    },
+    {
+      "id": 396,
+      "categories": [
+        "Remotecontrol"
+      ],
+      "description": "Remotely is a remote control and remote scripting solution, built with .NET 6, Blazor, and SignalR Core.",
+      "logo": "",
+      "name": "Remotely",
+      "platform": "linux",
+      "repository": {
+        "stackfile": "Template/Stack/remotely.yml",
+        "url": "https://github.com/xneo1/portainer_templates"
+      },
+      "title": "Remotely",
+      "type": 3,
+      "maintainer": " https://github.com/xneo1/portainer_templates/"
+    },
+    {
+      "id": 397,
+      "categories": [
+        "Productivity",
+        "Devtools"
+      ],
+      "description": "Tabby is an infinitely customizable cross-platform terminal app for local shells, serial, SSH and Telnet connections.",
+      "logo": "https://tabby.sh/32bf32ff6c87e8d18932.svg",
+      "name": "Tabby",
+      "platform": "linux",
+      "repository": {
+        "stackfile": "Template/Stack/tabby.yml",
+        "url": "https://github.com/xneo1/portainer_templates"
+      },
+      "title": "Tabby",
+      "type": 3,
+      "maintainer": " https://github.com/xneo1/portainer_templates/"
+    },
+    {
+      "id": 398,
+      "categories": [
+        "Productivity",
+        "Drawing"
+      ],
+      "description": "Virtual whiteboard for sketching hand-drawn like diagrams. Collaborative and end-to-end encrypted.",
+      "logo": "https://github.com/excalidraw/excalidraw/raw/master/public/og-image-sm.png",
+      "name": "excalidraw",
+      "platform": "linux",
+      "repository": {
+        "stackfile": "Template/Stack/excalidraw.yml",
+        "url": "https://github.com/xneo1/portainer_templates"
+      },
+      "title": "Excalidraw",
+      "type": 3,
+      "maintainer": " https://github.com/xneo1/portainer_templates/"
+    },
+    {
+      "id": 399,
+      "categories": [
+        "Network"
+      ],
+      "description": "UpSnap is a simple wake on lan app written with SvelteKit, Go, PocketBase and nmap.",
+      "logo": "https://github.com/seriousm4x/UpSnap/raw/master/frontend/static/favicon.png",
+      "name": "upsnap",
+      "platform": "linux",
+      "repository": {
+        "stackfile": "Template/Stack/upsnap.yml",
+        "url": "https://github.com/xneo1/portainer_templates"
+      },
+      "title": "Upsnap",
+      "type": 3,
+      "maintainer": " https://github.com/xneo1/portainer_templates/"
+    },
+    {
+      "id": 400,
+      "categories": [
+        "Development",
+        "Lowcode",
+        "Nocode"
+      ],
+      "description": "Tooljet is an Open-source low-code application development platform for building and deploying business applications.",
+      "logo": "https://uploads-ssl.webflow.com/6266634263b9179f76b2236e/63aaa161e3b3be42ec50eb6f_Logomark.svg",
+      "name": "tooljet",
+      "platform": "linux",
+      "repository": {
+        "stackfile": "Template/Stack/tooljet.yml",
+        "url": "https://github.com/xneo1/portainer_templates"
+      },
+      "title": "Tooljet",
+      "type": 3,
+      "maintainer": " https://github.com/xneo1/portainer_templates/"
+    },
+    {
+      "id": 401,
+      "categories": [
+        "Productivity",
+        "Development",
+        "Lowcode",
+        "Nocode"
+      ],
+      "description": "Budibase allows no-code users to build apps quickly, with more functionality available with a little bit of inline code.",
+      "logo": "https://files.readme.io/593b386-budibase-logo-website.svg",
+      "name": "budibase",
+      "platform": "linux",
+      "repository": {
+        "stackfile": "Template/Stack/budibase.yml",
+        "url": "https://github.com/xneo1/portainer_templates"
+      },
+      "title": "Budibase",
+      "type": 3,
+      "maintainer": " https://github.com/xneo1/portainer_templates/"
+    },
+    {
+      "id": 402,
+      "categories": [
+        "Search"
+      ],
+      "description": "Meilisearch is a **RESTful search API**. It aims to be a **ready-to-go solution** for everyone who wants a **fast and relevant search experience** for their end-users",
+      "logo": "https://docs.meilisearch.com/logo.svg",
+      "name": "Meilisearch",
+      "platform": "linux",
+      "repository": {
+        "stackfile": "Template/Stack/meilisearch.yml",
+        "url": "https://github.com/xneo1/portainer_templates"
+      },
+      "title": "Meilisearch",
+      "type": 3,
+      "maintainer": " https://github.com/xneo1/portainer_templates/"
+    },
+    {
+      "id": 403,
+      "categories": [
+        "Identitymanagement",
+        "Accessproxy"
+      ],
+      "description": "Ory Kratos with Oathkeeper is _the_ developer-friendly, security-hardened and battle-test Identity, User Management and Authentication system for the Cloud.",
+      "logo": "https://raw.githubusercontent.com/ory/meta/master/static/banners/kratos.svg",
+      "name": "Ory Kratos",
+      "platform": "linux",
+      "repository": {
+        "stackfile": "Template/Stack/ory-kratos-standalone.yml",
+        "url": "https://github.com/xneo1/portainer_templates"
+      },
+      "title": "Ory Kratos (Standalone)",
+      "type": 3,
+      "maintainer": " https://github.com/xneo1/portainer_templates/"
+    },
+    {
+      "id": 404,
+      "categories": [
+        "Identitymanagement",
+        "Security"
+      ],
+      "description": "Ory Kratos with Oathkeeper (ORY Oathkeeper is an Identity & Access Proxy (IAP) and Access Control Decision API that authorizes HTTP requests based on sets of Access Rules.) ",
+      "logo": "https://raw.githubusercontent.com/ory/meta/master/static/banners/oathkeeper.svg",
+      "name": "Ory Kratos Oathkeeper",
+      "platform": "linux",
+      "repository": {
+        "stackfile": "Template/Stack/ory-kratos-oathkeeper.yml",
+        "url": "https://github.com/xneo1/portainer_templates"
+      },
+      "title": "Ory Kratos (Oathkeeper)",
+      "type": 3,
+      "maintainer": " https://github.com/xneo1/portainer_templates/"
+    },
+    {
+      "id": 405,
+      "categories": [
+        "Productivity",
+        "Development",
+        "Lowcode"
+      ],
+      "description": "Appsmith (www.appsmith.com) is the first open-source low-code tool that helps developers build dashboards and admin panels very quickly.",
+      "logo": "https://cdn-images.himalayas.app/vr60veq4neiptamhqm6qxwi3toi3",
+      "name": "appsmith",
+      "platform": "linux",
+      "repository": {
+        "stackfile": "Template/Stack/appsmith.yml",
+        "url": "https://github.com/xneo1/portainer_templates"
+      },
+      "title": "Appsmith",
+      "type": 3,
+      "maintainer": " https://github.com/xneo1/portainer_templates/"
+    },
+    {
+      "id": 406,
+      "categories": [
+        "Email"
+      ],
+      "description": "Mailpile is an e-mail client!/search engine and a personal webmail server/easy way to encrypt your e-mail/easy way to encrypt your e-mail ",
+      "logo": "https://www.mailpile.is/img/icon-512x512.png",
+      "name": "mailpile",
+      "platform": "linux",
+      "repository": {
+        "stackfile": "Template/Stack/mailpile.yml",
+        "url": "https://github.com/xneo1/portainer_templates"
+      },
+      "title": "Mailpile",
+      "type": 3,
+      "maintainer": " https://github.com/xneo1/portainer_templates/"
+    },
+    {
+      "id": 407,
+      "categories": [
+        "Mail"
+      ],
+      "description": "Full stack mailserver solution with  TLS support. POP3s, SMTP(s), IMAPs, RSPAMD, Clamav, Roundcube(HTTPS), SPF, DKIM with simple installation and web administration.",
+      "logo": "",
+      "name": "poste.io",
+      "platform": "linux",
+      "repository": {
+        "stackfile": "Template/Stack/posteio.yml",
+        "url": "https://github.com/xneo1/portainer_templates"
+      },
+      "title": "Poste.io",
+      "type": 3,
+      "maintainer": " https://github.com/xneo1/portainer_templates/"
+    },
+    {
+      "id": 408,
+      "categories": [
+        "Network"
+      ],
+      "description": "IPerf3 Docker Build for Network Performance and Bandwidth Testing",
+      "logo": "",
+      "name": "iperf",
+      "platform": "linux",
+      "repository": {
+        "stackfile": "Template/Stack/iperf.yml",
+        "url": "https://github.com/xneo1/portainer_templates"
+      },
+      "title": "iperf",
+      "type": 3,
+      "maintainer": " https://github.com/xneo1/portainer_templates/"
+    },
+    {
+      "id": 409,
+      "categories": [
+        "Docker"
+      ],
+      "description": "Lazytainer monitors network traffic to containers. If there is traffic, the container runs, otherwise the container is stopped/paused.",
+      "logo": "",
+      "name": "lazytainer",
+      "platform": "linux",
+      "repository": {
+        "stackfile": "Template/Stack/lazytainer.yml",
+        "url": "https://github.com/xneo1/portainer_templates"
+      },
+      "title": "Lazytainer",
+      "type": 3,
+      "maintainer": " https://github.com/xneo1/portainer_templates/"
+    },
+    {
+      "id": 410,
+      "categories": [
+        "Finance"
+      ],
+      "description": "I hate money is a web application made to ease shared budget management. It keeps track of who bought what, when, and for whom; and helps to settle the bills.",
+      "logo": "",
+      "name": "ihatemoney",
+      "platform": "linux",
+      "repository": {
+        "stackfile": "Template/Stack/ihatemoney.yml",
+        "url": "https://github.com/xneo1/portainer_templates"
+      },
+      "title": "I hate money",
+      "type": 3,
+      "maintainer": " https://github.com/xneo1/portainer_templates/"
+    },
+    {
+      "id": 411,
+      "categories": [
+        "Finance"
+      ],
+      "description": "OpenBudgeteer is a budgeting app based on the Bucket Budgeting Principle and inspired by YNAB and Buckets.",
+      "logo": "https://github.com/TheAxelander/OpenBudgeteer/raw/master/assets/banner.png",
+      "name": "openbudgeteer",
+      "platform": "linux",
+      "repository": {
+        "stackfile": "Template/Stack/openbudgeteer.yml",
+        "url": "https://github.com/xneo1/portainer_templates"
+      },
+      "title": "OpenBudgeteer",
+      "type": 3,
+      "maintainer": " https://github.com/xneo1/portainer_templates/"
+    },
+    {
+      "id": 412,
+      "categories": [
+        "Multimedia"
+      ],
+      "description": "Fireshare: Share your game clips, videos, or other media via unique links.",
+      "logo": "https://github.com/ShaneIsrael/fireshare/raw/main/app/client/src/assets/logo.png",
+      "name": "fireshare",
+      "platform": "linux",
+      "repository": {
+        "stackfile": "Template/Stack/fireshare.yml",
+        "url": "https://github.com/xneo1/portainer_templates"
+      },
+      "title": "Fireshare",
+      "type": 3,
+      "maintainer": " https://github.com/xneo1/portainer_templates/"
+    },
+    {
+      "id": 413,
+      "categories": [
+        "Downloaders"
+      ],
+      "description": "Peer-to-peer file transfers in your browser",
+      "logo": "https://raw.githubusercontent.com/kern/filepizza/master/src/static/images/wordmark.png",
+      "name": "filepizza",
+      "platform": "linux",
+      "repository": {
+        "stackfile": "Template/Stack/filepizza.yml",
+        "url": "https://github.com/xneo1/portainer_templates"
+      },
+      "title": "Filepizza",
+      "type": 3,
+      "maintainer": " https://github.com/xneo1/portainer_templates/"
+    },
+    {
+      "id": 414,
+      "categories": [
+        "Dashboard"
+      ],
+      "description": "Jump is yet another self-hosted startpage for your server designed to be simple, stylish, fast and secure.",
+      "logo": "",
+      "name": "jump",
+      "platform": "linux",
+      "repository": {
+        "stackfile": "Template/Stack/jump.yml",
+        "url": "https://github.com/xneo1/portainer_templates"
+      },
+      "title": "Jump",
+      "type": 3,
+      "maintainer": " https://github.com/xneo1/portainer_templates/"
+    },
+    {
+      "id": 415,
+      "categories": [
+        "Productivity"
+      ],
+      "description": "Hasty Paste is a fast and minimal paste bin, written in Python using Quart.",
+      "logo": "",
+      "name": "hasty-paste",
+      "platform": "linux",
+      "repository": {
+        "stackfile": "Template/Stack/hasty-paste.yml",
+        "url": "https://github.com/xneo1/portainer_templates"
+      },
+      "title": "Hasty-Paste",
+      "type": 3,
+      "maintainer": " https://github.com/xneo1/portainer_templates/"
+    },
+    {
+      "id": 416,
+      "categories": [
+        "Wiki"
+      ],
+      "description": "Xwiki s a free wiki software platform written in Java with a design emphasis on extensibility. XWiki is an enterprise wiki.",
+      "logo": "https://upload.wikimedia.org/wikipedia/commons/e/e2/Logo-xwikiorange.svg",
+      "name": "xwiki",
+      "platform": "linux",
+      "repository": {
+        "stackfile": "Template/Stack/xwiki.yml",
+        "url": "https://github.com/xneo1/portainer_templates"
+      },
+      "title": "Xwiki",
+      "type": 3,
+      "maintainer": " https://github.com/xneo1/portainer_templates/"
+    },
+    {
+      "id": 417,
+      "categories": [
+        "Productivity"
+      ],
+      "description": "Leantime is an open source project management solution to make your ideas reality.",
+      "logo": "https://s3-us-west-2.amazonaws.com/leantime-website/wp-content/uploads/2022/07/24022056/logo-large.png",
+      "name": "leantime",
+      "platform": "linux",
+      "repository": {
+        "stackfile": "Template/Stack/leantime.yml",
+        "url": "https://github.com/xneo1/portainer_templates"
+      },
+      "title": "Leantime",
+      "type": 3,
+      "maintainer": " https://github.com/xneo1/portainer_templates/"
+    },
+    {
+      "id": 418,
+      "categories": [
+        "Entertainment"
+      ],
+      "description": "Jellyseerr is a free and open source fork of Overseerr for managing requests for your media library. It integrates with your existing services, such as Sonarr, Radarr, and Jellyfin!",
+      "logo": "https://raw.githubusercontent.com/Fallenbagel/jellyseerr/develop/public/logo_full.svg",
+      "name": "jellyseer",
+      "platform": "linux",
+      "repository": {
+        "stackfile": "Template/Stack/jellyseer.yml",
+        "url": "https://github.com/xneo1/portainer_templates"
+      },
+      "title": "Jellyseer",
+      "type": 3,
+      "maintainer": " https://github.com/xneo1/portainer_templates/"
+    },
+    {
+      "id": 419,
+      "categories": [
+        "Productivity"
+      ],
+      "description": "Trudesk is an Open Source Help Desk Software and Ticketing System",
+      "logo": "https://trudesk.io/wp-content/uploads/2019/10/logo-med.png",
+      "name": "trudesk",
+      "platform": "linux",
+      "repository": {
+        "stackfile": "Template/Stack/trudesk.yml",
+        "url": "https://github.com/xneo1/portainer_templates"
+      },
+      "title": "Trudesk",
+      "type": 3,
+      "maintainer": " https://github.com/xneo1/portainer_templates/"
+    },
+    {
+      "id": 420,
+      "categories": [
+        "System"
+      ],
+      "description": "Dashdot is a modern server dashboard, running on the latest tech, designed with glassmorphism in mind. It is intended to be used for smaller VPS and private servers.",
+      "logo": "https://getdashdot.com/img/logo512.png",
+      "name": "dashdot",
+      "platform": "linux",
+      "repository": {
+        "stackfile": "Template/Stack/dashdot.yml",
+        "url": "https://github.com/xneo1/portainer_templates"
+      },
+      "title": "Dashdot",
+      "type": 3,
+      "maintainer": " https://github.com/xneo1/portainer_templates/"
+    },
+    {
+      "id": 421,
+      "categories": [
+        "Productivity",
+        "Development",
+        "Nocode"
+      ],
+      "description": "Turns any MySQL, PostgreSQL, SQL Server, SQLite & MariaDB into a smart-spreadsheet.",
+      "logo": "https://github.com/nocodb/nocodb/raw/develop/packages/nc-gui/assets/img/icons/512x512.png",
+      "name": "NocoDB",
+      "platform": "linux",
+      "repository": {
+        "stackfile": "Template/Stack/nocodb.yml",
+        "url": "https://github.com/xneo1/portainer_templates"
+      },
+      "title": "NocoDB",
+      "type": 3,
+      "maintainer": " https://github.com/xneo1/portainer_templates/"
+    },
+    {
+      "id": 422,
+      "categories": [
+        "Smarthome"
+      ],
+      "description": "BroadlinkManager is a Flask powerd, easy to use system that hepls you to work with Broadlink Devices.",
+      "logo": "https://raw.githubusercontent.com/xneo1/portainer_templates/master/Images/broadlink.png",
+      "name": "broadlink-manager",
+      "platform": "linux",
+      "repository": {
+        "stackfile": "Template/Stack/broadlink-manager.yml",
+        "url": "https://github.com/xneo1/portainer_templates"
+      },
+      "title": "Broadlink Manager",
+      "type": 3,
+      "maintainer": " https://github.com/xneo1/portainer_templates/"
+    },
+    {
+      "id": 423,
+      "categories": [
+        "Analytics"
+      ],
+      "description": "Umami is a simple, easy to use, self-hosted web analytics solution. The goal is to provide you with a friendlier, privacy-focused alternative to Google Analytics and a free, open-sourced alternative to paid solutions",
+      "logo": "https://icons.duckduckgo.com/ip3/umami.is.ico",
+      "name": "umami",
+      "platform": "linux",
+      "repository": {
+        "stackfile": "Template/Stack/umami.yml",
+        "url": "https://github.com/xneo1/portainer_templates"
+      },
+      "ports": [
+        "3000:3000/tcp"
+      ],
+      "title": "Umami.is",
+      "type": 3,
+      "maintainer": " https://github.com/xneo1/portainer_templates/"
+    },
+    {
+      "id": 424,
+      "categories": [
+        "Analytics"
+      ],
+      "description": "Google Analytics alternative that protects your data and your customers' privacy",
+      "logo": "https://gallery.ncnet.nl/upload/2020/05/22/20200522171613-9205fa32.png",
+      "name": "matomo",
+      "platform": "linux",
+      "repository": {
+        "stackfile": "Template/Stack/matomo.yml",
+        "url": "https://github.com/xneo1/portainer_templates"
+      },
+      "ports": [
+        "8282:80/tcp"
+      ],
+      "title": "Matomo",
+      "type": 3,
+      "maintainer": " https://github.com/xneo1/portainer_templates/"
+    },
+    {
+      "id": 425,
+      "categories": [
+        "Other"
+      ],
+      "description": "Simple room management system for n.eko. Self hosted rabb.it alternative. --Please add .env file as stated in neko.yml",
+      "logo": "https://raw.githubusercontent.com/m1k1o/neko/master/docs/_media/logo.png",
+      "name": "neko",
+      "platform": "linux",
+      "repository": {
+        "stackfile": "Template/Stack/neko.yml",
+        "url": "https://github.com/xneo1/portainer_templates"
+      },
+      "title": "Neko",
+      "type": 3,
+      "maintainer": " https://github.com/xneo1/portainer_templates/"
+    },
+    {
+      "id": 426,
+      "type": 3,
+      "title": "Immich {shmolf}",
+      "name": "immich",
+      "categories": [
+        "Photos",
+        "Backup"
+      ],
+      "description": "Self-hosted backup solution for photos and videos on mobile device.",
+      "logo": "https://raw.githubusercontent.com/shmolf/portainer-templates/main/assets/logos/immich-logo.svg",
+      "note": "<a target='_blank' href='https://immich.app'>Application documentation 🗗</a>",
+      "env": [
+        {
+          "default": "1000",
+          "label": "PUID",
+          "name": "PUID"
+        },
+        {
+          "label": "PGID",
+          "name": "PGID",
+          "default": "1000"
+        },
+        {
+          "label": "Immich version",
+          "name": "IMMICH_VERSION",
+          "default": "release",
+          "description": "To want to lock to a specific tag, provide a value such as 'v1.71.0'"
+        },
+        {
+          "label": "Database username",
+          "name": "DB_USERNAME",
+          "default": "postgres"
+        },
+        {
+          "label": "Database password",
+          "name": "DB_PASSWORD",
+          "default": "please-change-this-to-a-random-secret",
+          "description": "This should be changed to a random secret"
+        },
+        {
+          "label": "Database name",
+          "name": "DB_DATABASE_NAME",
+          "default": "immich"
+        },
+        {
+          "label": "Database hostname",
+          "name": "DB_HOSTNAME",
+          "default": "immich_postgres",
+          "description": "The default value references a service within the stack"
+        },
+        {
+          "label": "File backup location",
+          "name": "UPLOAD_LOCATION",
+          "default": "/portainer/Files/AppData/Immich/upload",
+          "description": "You can leave this path as-is, and the system will auto-create the needed folders. Feel free to change if you desire an alternative location."
+        },
+        {
+          "label": "Redis hostname",
+          "name": "REDIS_HOSTNAME",
+          "default": "immich_redis",
+          "description": "The default value references a service within the stack"
+        },
+        {
+          "default": "2283",
+          "label": "Http Port",
+          "name": "PORT"
+        }
+      ],
+      "platform": "linux",
+      "repository": {
+        "stackfile": "stacks/immich/docker-compose.yml",
+        "url": "https://github.com/shmolf/portainer-templates"
+      },
+      "maintainer": " https://github.com/shmolf/portainer-templates/"
+    },
+    {
+      "id": 427,
+      "type": 3,
+      "title": "Penpot (http) {shmolf}",
+      "name": "penpot-http",
+      "categories": [
+        "Graphicdesign"
+      ],
+      "description": "Penpot is the first Open Source design and prototyping platform meant for cross-domain teams.",
+      "logo": "https://raw.githubusercontent.com/shmolf/portainer-templates/main/assets/logos/penpot-logo.svg",
+      "note": "<a target='_blank' href='https://community.penpot.app/'>Application documentation 🗗</a>. See <a target='_blank' href='https://help.penpot.app/technical-guide/configuration/#advanced-configuration'>documentation 🗗</a> for more details regarding the flags.",
+      "env": [
+        {
+          "default": "1000",
+          "label": "PUID",
+          "name": "PUID"
+        },
+        {
+          "label": "PGID",
+          "name": "PGID",
+          "default": "1000"
+        },
+        {
+          "label": "Frontend Flags",
+          "name": "PENPOT_FLAGS_FE",
+          "default": "enable-registration disable-secure-session-cookies enable-insecure-register enable-login-with-password"
+        },
+        {
+          "label": "Backend Flags",
+          "name": "PENPOT_FLAGS_BE",
+          "default": "enable-registration disable-secure-session-cookies enable-insecure-register disable-email-verification"
+        },
+        {
+          "label": "Public URI",
+          "name": "PUBLIC_URI",
+          "default": "http://192.168.1.1:8624",
+          "description": "Public URI. If you are going to expose this instance to the internet and use it under different domain than 'localhost', you will need to adjust it to the final domain."
+        },
+        {
+          "label": "Penpot Telemetry Enabled?",
+          "name": "TELEMETRY_ENABLED",
+          "select": [
+            {
+              "text": "Yes, enable telemetry",
+              "value": "true",
+              "default": true
+            },
+            {
+              "text": "No, disable telemetry",
+              "value": "false"
+            }
+          ],
+          "description": "When enabled, a periodical process will send anonymous data about this instance."
+        },
+        {
+          "default": "8624",
+          "label": "Http Port",
+          "name": "PORT",
+          "description": "This should match the port specified in the Public URI, or 80/443 if using standard ports."
+        }
+      ],
+      "platform": "linux",
+      "repository": {
+        "stackfile": "stacks/penpot/docker-compose-http.yml",
+        "url": "https://github.com/shmolf/portainer-templates"
+      },
+      "maintainer": " https://github.com/shmolf/portainer-templates/"
+    },
+    {
+      "id": 428,
+      "type": 1,
+      "title": "Watchtower {shmolf}",
+      "name": "watchtower",
+      "categories": [
+        "Docker"
+      ],
+      "description": "A container-based solution for automating Docker container base image updates",
+      "note": "<a target='_blank' href='https://containrrr.dev/watchtower/'>Application documentation 🗗</a>",
+      "logo": "https://raw.githubusercontent.com/shmolf/portainer-templates/main/assets/logos/watchtower-logo.png",
+      "platform": "linux",
+      "image": "containrrr/watchtower",
+      "ports": [
+        "9001/tcp"
+      ],
+      "restart_policy": "always",
+      "volumes": [
+        {
+          "container": "/var/run/docker.sock",
+          "bind": "/var/run/docker.sock"
+        }
+      ],
+      "maintainer": " https://github.com/shmolf/portainer-templates/"
+    },
+    {
+      "id": 429,
+      "type": 1,
+      "title": "Stirling PDF {shmolf}",
+      "name": "stirling-pdf",
+      "categories": [
+        "Tools",
+        "Pdf"
+      ],
+      "description": "Your locally hosted one-stop-shop for all your PDF needs.",
+      "note": "To support multiple languages for OCR, per the <a target='_blank' href='https://github.com/Stirling-Tools/Stirling-PDF/blob/main/HowToUseOCR.md'>Official documentation 🗗</a>, download your Tess Data from <a target='_blank' href='https://github.com/tesseract-ocr/tessdata'>from another repo 🗗</a>. <br>Then, place said 'traineddata' files into <code>/portainer/Files/AppData/Libraries/StirlingPDF/tessdata</code> <br>For more information about login, read <a target='_blank' href='https://github.com/Stirling-Tools/Stirling-PDF?tab=readme-ov-file#prerequisites'>the official documentation 🗗</a>.",
+      "logo": "https://raw.githubusercontent.com/shmolf/portainer-templates/main/assets/logos/stirling-pdf.svg",
+      "platform": "linux",
+      "image": "frooodle/s-pdf:0.18.1",
+      "ports": [
+        "5417:8080/tcp"
+      ],
+      "restart_policy": "unless-stopped",
+      "env": [
+        {
+          "label": "PUID",
+          "name": "PUID",
+          "default": "1000"
+        },
+        {
+          "label": "PGID",
+          "name": "PGID",
+          "default": "1000"
+        },
+        {
+          "label": "Enable Login",
+          "name": "DOCKER_ENABLE_SECURITY",
+          "select": [
+            {
+              "text": "Yes, enable login",
+              "value": "true"
+            },
+            {
+              "text": "No, disable login",
+              "value": "false",
+              "default": true
+            }
+          ],
+          "description": "If you want to enable the login, you'll also need to enable login through the Config's settings.yml"
+        }
+      ],
+      "volumes": [
+        {
+          "bind": "/portainer/Files/AppData/Config/StirlingPDF",
+          "container": "/configs"
+        },
+        {
+          "bind": "/portainer/Files/AppData/Libraries/StirlingPDF/tessdata",
+          "container": "/usr/share/tesseract-ocr/5/tessdata"
+        }
+      ],
+      "maintainer": " https://github.com/shmolf/portainer-templates/"
+    },
+    {
+      "id": 430,
+      "type": 1,
+      "title": "Terraria Server {shmolf}",
+      "name": "terraria-server",
+      "categories": [
+        "Games"
+      ],
+      "description": "Docker container for a Terraria dedicated server.",
+      "note": "Link to <a target='_blank' href='https://terraria.fandom.com/wiki/Guide:Setting_up_a_Terraria_server'>Official documentation 🗗</a> for setting up the server.",
+      "logo": "https://raw.githubusercontent.com/shmolf/portainer-templates/main/assets/logos/terraria-server.png",
+      "platform": "linux",
+      "image": "passivelemon/terraria-docker:latest",
+      "ports": [
+        "7777:7777/tcp"
+      ],
+      "restart_policy": "unless-stopped",
+      "env": [
+        {
+          "label": "PUID",
+          "name": "PUID",
+          "default": "1000"
+        },
+        {
+          "label": "PGID",
+          "name": "PGID",
+          "default": "1000"
+        },
+        {
+          "label": "World name",
+          "name": "WORLD",
+          "default": "dockerworld"
+        }
+      ],
+      "volumes": [
+        {
+          "bind": "/portainer/Files/AppData/Libraries/StirlingPDF/tessdata",
+          "container": "/usr/share/tesseract-ocr/5/tessdata"
+        }
+      ],
+      "maintainer": " https://github.com/shmolf/portainer-templates/"
+    },
+    {
+      "id": 431,
+      "type": 1,
+      "title": "Cockpit {shmolf}",
+      "name": "cockpit-cms",
+      "categories": [
+        "Cms"
+      ],
+      "description": "Cockpit is a headless CMS with an API-first approach that puts content first.",
+      "note": "Link to <a target='_blank' href='https://v1.getcockpit.com/'>Official documentation 🗗</a>.<br>After deployment, continue to setup by visiting <a target='_blank' href='http://localhost:8088/install'>http://localhost:8088/install</a>",
+      "logo": "https://raw.githubusercontent.com/shmolf/portainer-templates/main/assets/logos/cockpit.svg",
+      "platform": "linux",
+      "image": "agentejo/cockpit:latest",
+      "ports": [
+        "8088:80/tcp"
+      ],
+      "restart_policy": "unless-stopped",
+      "maintainer": " https://github.com/shmolf/portainer-templates/"
+    },
+    {
+      "id": 432,
+      "type": 3,
+      "title": "Asciinema {shmolf}",
+      "name": "asciinema",
+      "categories": [
+        "Tools"
+      ],
+      "description": "Self-hosted terminal recording and playback",
+      "logo": "https://raw.githubusercontent.com/shmolf/portainer-templates/main/assets/logos/asciinema.svg",
+      "note": "<a target='_blank' href='https://docs.asciinema.org/getting-started/#self-hosting-the-server'>Application documentation 🗗</a><br>For the application secret key, you can use the terminal command <code>tr -dc A-Za-z0-9 &lt;/dev/urandom | head -c 64; echo</code>",
+      "env": [
+        {
+          "default": "1000",
+          "label": "PUID",
+          "name": "PUID"
+        },
+        {
+          "label": "PGID",
+          "name": "PGID",
+          "default": "1000"
+        },
+        {
+          "label": "Hostname",
+          "name": "HOST_NAME",
+          "default": "localhost",
+          "description": "Localhost for use within the application runtime"
+        },
+        {
+          "label": "Host Port",
+          "name": "HOST_PORT",
+          "default": "3033",
+          "description": "Published port for use within the application runtime"
+        },
+        {
+          "label": "Secret Application Key",
+          "name": "SECRET_KEY",
+          "default": "please-change-this-to-a-random-secret"
+        }
+      ],
+      "platform": "linux",
+      "repository": {
+        "stackfile": "stacks/asciinema/docker-compose.yml",
+        "url": "https://github.com/shmolf/portainer-templates"
+      },
+      "maintainer": " https://github.com/shmolf/portainer-templates/"
+    },
+    {
+      "id": 433,
+      "type": 1,
+      "title": "Code-server {shmolf}",
+      "name": "code-server",
+      "note": "Portainer App Templates by <a href='https://www.technorabilia.com' target='_blank'>Technorabilia</a> based on data provided by <a href='https://www.linuxserver.io' target='_blank'>LinuxServer.io</a>.</p><p>This will bind to the following directory on the host filesystem:</p><p><code>/portainer/Files/AppData/Config/code-server</code></p><ul><li>Proxy Domain: See <a href='https://github.com/cdr/code-server/blob/master/docs/FAQ.md#sub-domains' target='_blank'>Documentation 🗗</a></li><li>Timezones: See <a href='https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List' target='_blank'>list 🗗</a></li></ul>",
+      "description": "Code-server (https://coder.com) is VS Code running on a remote server, accessible through the browser. - Code on your Chromebook, tablet, and laptop with a consistent dev environment. - If you have a Windows or Mac workstation, more easily develop for Linux. - Take advantage of large cloud servers to speed up tests, compilations, downloads, and more. - Preserve battery life when you're on the go. - All intensive computation runs on your server. - You're no longer running excess instances of Chrome.",
+      "categories": [
+        "Development"
+      ],
+      "platform": "linux",
+      "logo": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/code-server-banner.png",
+      "image": "linuxserver/code-server:latest",
+      "env": [
+        {
+          "name": "PUID",
+          "label": "PUID",
+          "default": "1000",
+          "description": "for UserID"
+        },
+        {
+          "name": "PGID",
+          "label": "PGID",
+          "default": "1000",
+          "description": "for GroupID"
+        },
+        {
+          "name": "TZ",
+          "label": "TZ",
+          "default": "Europe/Amsterdam",
+          "description": "specify a timezone to use"
+        },
+        {
+          "name": "PASSWORD",
+          "label": "PASSWORD",
+          "default": "password",
+          "description": "Optional web gui password, if `PASSWORD` or `HASHED_PASSWORD` is not provided, there will be no auth."
+        },
+        {
+          "name": "HASHED_PASSWORD",
+          "label": "HASHED_PASSWORD",
+          "default": "",
+          "description": "Optional web gui password, overrides `PASSWORD`, instructions on how to create it is below."
+        },
+        {
+          "name": "SUDO_PASSWORD",
+          "label": "SUDO_PASSWORD",
+          "default": "password",
+          "description": "If this optional variable is set, user will have sudo access in the code-server terminal with the specified password."
+        },
+        {
+          "name": "SUDO_PASSWORD_HASH",
+          "label": "SUDO_PASSWORD_HASH",
+          "default": "",
+          "description": "Optionally set sudo password via hash (takes priority over `SUDO_PASSWORD` var). Format is `$type$salt$hashed`."
+        },
+        {
+          "name": "PROXY_DOMAIN",
+          "label": "PROXY_DOMAIN",
+          "default": "code-server.my.domain",
+          "description": "If this optional variable is set, this domain will be proxied for subdomain proxying."
+        },
+        {
+          "name": "DEFAULT_WORKSPACE",
+          "label": "DEFAULT_WORKSPACE",
+          "default": "/config/workspace",
+          "description": "If this optional variable is set, code-server will open this directory by default"
+        }
+      ],
+      "ports": [
+        "8443:8443/tcp"
+      ],
+      "volumes": [
+        {
+          "container": "/config",
+          "bind": "/portainer/Files/AppData/Config/code-server"
+        }
+      ],
+      "restart_policy": "unless-stopped",
+      "maintainer": " https://github.com/shmolf/portainer-templates/"
+    },
+    {
+      "id": 434,
+      "type": 3,
+      "title": "Infisical {shmolf}",
+      "name": "infisical",
+      "categories": [
+        "Secrets",
+        "Management"
+      ],
+      "description": "The open-source secret management platform: Sync secrets/configs across your team/infrastructure and prevent secret leaks.",
+      "logo": "https://raw.githubusercontent.com/shmolf/portainer-templates/main/assets/logos/infisical-black.webp",
+      "note": "<a target='_blank' href='https://infisical.com/docs/documentation/getting-started/introduction'>Application documentation 🗗</a>",
+      "env": [
+        {
+          "default": "8078",
+          "label": "Http Port",
+          "name": "PORT"
+        },
+        {
+          "default": "c6606cd2daad581c4de96531427aae0d",
+          "label": "Encryption Key",
+          "name": "ENCRYPTION_KEY",
+          "description": "Required key for platform encryption/decryption ops. 32 character hex string"
+        },
+        {
+          "default": "5lrMXKKWCVocS/uerPsl7V+TX/aaUaI7iDkgl3tSmLE=",
+          "label": "JWT Key",
+          "name": "AUTH_SECRET",
+          "description": "Required secrets to sign JWT tokens"
+        },
+        {
+          "default": "postgres_password",
+          "label": "Postgres Password",
+          "name": "POSTGRES_PASSWORD"
+        },
+        {
+          "default": "infisical",
+          "label": "Postgres User",
+          "name": "POSTGRES_USER"
+        },
+        {
+          "default": "infisical",
+          "label": "Postgres Database",
+          "name": "POSTGRES_DB"
+        },
+        {
+          "default": "postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB}",
+          "label": "DB Connection URI",
+          "name": "DB_CONNECTION_URI"
+        },
+        {
+          "default": "http://localhost:8078",
+          "label": "Website URL",
+          "name": "SITE_URL"
+        },
+        {
+          "default": "redis://redis:6379",
+          "label": "Redis URL",
+          "name": "REDIS_URL"
+        },
+        {
+          "default": "",
+          "label": "Email Host (Optional)",
+          "name": "SMTP_HOST"
+        },
+        {
+          "default": "",
+          "label": "Email Port (Optional)",
+          "name": "SMTP_PORT"
+        },
+        {
+          "default": "",
+          "label": "Email Name (Optional)",
+          "name": "SMTP_NAME"
+        },
+        {
+          "default": "",
+          "label": "Email Username (Optional)",
+          "name": "SMTP_USERNAME"
+        },
+        {
+          "default": "",
+          "label": "Email Password (Optional)",
+          "name": "SMTP_PASSWORD"
+        },
+        {
+          "default": "",
+          "label": "Heroku Client ID (Optional)",
+          "name": "CLIENT_ID_HEROKU",
+          "description": "Optional, only needed if integration is used"
+        },
+        {
+          "default": "",
+          "label": "Heroku Client Secret (Optional)",
+          "name": "CLIENT_SECRET_HEROKU",
+          "description": "Optional, only needed if integration is used"
+        },
+        {
+          "default": "",
+          "label": "Vercel Client ID (Optional)",
+          "name": "CLIENT_ID_VERCEL",
+          "description": "Optional, only needed if integration is used"
+        },
+        {
+          "default": "",
+          "label": "Vercel Client Secret (Optional)",
+          "name": "CLIENT_SECRET_VERCEL",
+          "description": "Optional, only needed if integration is used"
+        },
+        {
+          "default": "",
+          "label": "Vercel Client Slug (Optional)",
+          "name": "CLIENT_SLUG_VERCEL",
+          "description": "Optional, only needed if integration is used"
+        },
+        {
+          "default": "",
+          "label": "Netlify Client ID (Optional)",
+          "name": "CLIENT_ID_NETLIFY",
+          "description": "Optional, only needed if integration is used"
+        },
+        {
+          "default": "",
+          "label": "Netlify Client Secret (Optional)",
+          "name": "CLIENT_SECRET_NETLIFY",
+          "description": "Optional, only needed if integration is used"
+        },
+        {
+          "default": "",
+          "label": "GitHub Client ID (Optional)",
+          "name": "CLIENT_ID_GITHUB",
+          "description": "Optional, only needed if integration is used"
+        },
+        {
+          "default": "",
+          "label": "GitHub Client Secret (Optional)",
+          "name": "CLIENT_SECRET_GITHUB",
+          "description": "Optional, only needed if integration is used"
+        },
+        {
+          "default": "",
+          "label": "GitLab Client ID (Optional)",
+          "name": "CLIENT_ID_GITLAB",
+          "description": "Optional, only needed if integration is used"
+        },
+        {
+          "default": "",
+          "label": "GitLab Client Secret (Optional)",
+          "name": "CLIENT_SECRET_GITLAB",
+          "description": "Optional, only needed if integration is used"
+        },
+        {
+          "default": "",
+          "label": "Bitbucket Client ID (Optional)",
+          "name": "CLIENT_ID_BITBUCKET",
+          "description": "Optional, only needed if integration is used"
+        },
+        {
+          "default": "",
+          "label": "Bitbucket Client Secret (Optional)",
+          "name": "CLIENT_SECRET_BITBUCKET",
+          "description": "Optional, only needed if integration is used"
+        },
+        {
+          "default": "",
+          "label": "Sentry DSN (Optional)",
+          "name": "SENTRY_DSN",
+          "description": "Optional, only needed if monitoring is used"
+        },
+        {
+          "default": "",
+          "label": "Google Client ID (Optional)",
+          "name": "CLIENT_ID_GOOGLE_LOGIN",
+          "description": "Optional, only needed if SSO is used"
+        },
+        {
+          "default": "",
+          "label": "Google Client Secret (Optional)",
+          "name": "CLIENT_SECRET_GOOGLE_LOGIN",
+          "description": "Optional, only needed if SSO is used"
+        },
+        {
+          "default": "",
+          "label": "GitHub Client ID (Optional)",
+          "name": "CLIENT_ID_GITHUB_LOGIN",
+          "description": "Optional, only needed if SSO is used"
+        },
+        {
+          "default": "",
+          "label": "GitHub Client Secret (Optional)",
+          "name": "CLIENT_SECRET_GITHUB_LOGIN",
+          "description": "Optional, only needed if SSO is used"
+        },
+        {
+          "default": "",
+          "label": "GitLab Client ID (Optional)",
+          "name": "CLIENT_ID_GITLAB_LOGIN",
+          "description": "Optional, only needed if SSO is used"
+        },
+        {
+          "default": "",
+          "label": "GitLab Client Secret (Optional)",
+          "name": "CLIENT_SECRET_GITLAB_LOGIN",
+          "description": "Optional, only needed if SSO is used"
+        },
+        {
+          "default": "",
+          "label": "Captcha Secret (Optional)",
+          "name": "CAPTCHA_SECRET",
+          "description": "Optional, only needed if captcha is used"
+        },
+        {
+          "default": "",
+          "label": "Captcha Site Key (Optional)",
+          "name": "NEXT_PUBLIC_CAPTCHA_SITE_KEY",
+          "description": "Optional, only needed if captcha is used"
+        },
+        {
+          "default": "",
+          "label": "Plain API Key (Optional)",
+          "name": "PLAIN_API_KEY",
+          "description": "Optional, only needed if Plain is used"
+        },
+        {
+          "default": "",
+          "label": "Plain Wish Label IDs (Optional)",
+          "name": "PLAIN_WISH_LABEL_IDS",
+          "description": "Optional, only needed if Plain is used"
+        }
+      ],
+      "platform": "linux",
+      "repository": {
+        "stackfile": "stacks/infisical/compose.yml",
+        "url": "https://github.com/shmolf/portainer-templates"
+      },
+      "restart_policy": "unless-stopped",
+      "maintainer": " https://github.com/shmolf/portainer-templates/"
+    },
+    {
+      "id": 435,
+      "categories": [
+        "Web",
+        "Tools"
+      ],
+      "description": "Git with a cup of tea! Painless self-hosted all-in-one software development service, including Git hosting, code review, team collaboration, package registry and CI/CD.",
+      "env": [
+        {
+          "default": "1000",
+          "label": "PUID",
+          "name": "PUID"
+        },
+        {
+          "default": "100",
+          "label": "PGID",
+          "name": "PGID"
+        }
+      ],
+      "image": "gitea/gitea:latest",
+      "logo": "https://raw.githubusercontent.com/Qballjos/portainer_templates/master/Images/gitea.png",
+      "name": "gitea",
+      "note": "Use SQLite3 for the database unless you have an external one setup.",
+      "ports": [
+        "3000:3000/tcp",
+        "222:22/tcp"
+      ],
+      "platform": "linux",
+      "restart_policy": "unless-stopped",
+      "title": "Gitea",
+      "type": 1,
+      "volumes": [
+        {
+          "bind": "/portainer/Files/AppData/Config/Gitea",
+          "container": "/data"
+        },
+        {
+          "bind": " /etc/timezone",
+          "container": "/etc/timezone:ro"
+        },
+        {
+          "bind": "/etc/localtime",
+          "container": "/etc/localtime:ro"
+        }
+      ],
+      "maintainer": " https://github.com/Qballjos/portainer_templates/"
+    },
+    {
+      "id": 436,
+      "categories": [
+        "Other",
+        "Tools"
+      ],
+      "description": "Jellyseer is a free and open source software application for managing requests for your media library.",
+      "env": [
+        {
+          "default": "1000",
+          "label": "PUID",
+          "name": "PUID"
+        },
+        {
+          "default": "100",
+          "label": "PGID",
+          "name": "PGID"
+        }
+      ],
+      "image": "fallenbagel/jellyseerr:latest",
+      "logo": "https://raw.githubusercontent.com/Qballjos/portainer_templates/master/Images/jellyseerr.png",
+      "name": "Jellyseerr",
+      "platform": "linux",
+      "ports": [
+        "5055:5055/tcp"
+      ],
+      "restart_policy": "unless-stopped",
+      "title": "Jellyseerr",
+      "type": 1,
+      "volumes": [
+        {
+          "bind": "/portainer/Files/AppData/Config/Jellyseerr",
+          "container": "/app/config"
+        }
+      ],
+      "maintainer": " https://github.com/Qballjos/portainer_templates/"
+    },
+    {
+      "id": 437,
+      "categories": [
+        "Other",
+        "Tools"
+      ],
+      "description": "Passky is a simple, modern, lightweight, open-source and secure password manager.",
+      "image": "rabbitcompany/passky-client:latest",
+      "logo": "https://raw.githubusercontent.com/Qballjos/portainer_templates/master/Images/passky-icon.png",
+      "name": "passky-client",
+      "platform": "linux",
+      "ports": [
+        "8081:80/tcp"
+      ],
+      "restart_policy": "unless-stopped",
+      "title": "Passky Client",
+      "type": 1,
+      "maintainer": " https://github.com/Qballjos/portainer_templates/"
+    },
+    {
+      "id": 438,
+      "categories": [
+        "Other",
+        "Tools"
+      ],
+      "description": "Passky is a simple, modern, lightweight, open-source and secure password manager.",
+      "env": [
+        {
+          "default": "admin",
+          "label": "ADMIN_USERNAME",
+          "name": "ADMIN_USERNAME"
+        },
+        {
+          "label": "ADMIN_PASSWORD",
+          "name": "ADMIN_PASSWORD"
+        }
+      ],
+      "image": "rabbitcompany/passky-server:latest",
+      "logo": "https://raw.githubusercontent.com/Qballjos/portainer_templates/master/Images/passky-icon.png",
+      "name": "passky-server",
+      "note": "Do not forget to perform regular backups, especially before each update.",
+      "platform": "linux",
+      "ports": [
+        "8080:80/tcp"
+      ],
+      "restart_policy": "unless-stopped",
+      "title": "Passky Server",
+      "type": 1,
+      "volumes": [
+        {
+          "bind": "/portainer/Files/AppData/Passky-Server",
+          "container": "/var/www/html/databases"
+        }
+      ],
+      "maintainer": " https://github.com/Qballjos/portainer_templates/"
+    },
+    {
+      "id": 439,
+      "categories": [
+        "Tools",
+        "Other"
+      ],
+      "description": "A simple script that will watch a stream for you and earn the channel points.",
+      "image": "rdavidoff/twitch-channel-points-miner-v2:latest",
+      "logo": "https://raw.githubusercontent.com/Qballjos/portainer_templates/master/Images/twitchpointsminer.png",
+      "name": "twitch-points-miner",
+      "note": "Requires run.py, this is your starter script with your configuration. Please copy and modify accordingly <a href='https://github.com/rdavydov/Twitch-Channel-Points-Miner-v2/tree/master?tab=readme-ov-file#how-to-use'/>Here</a>",
+      "platform": "linux",
+      "ports": [
+        "5000:5000/tcp"
+      ],
+      "restart_policy": "unless-stopped",
+      "title": "Twitch Points Miner",
+      "type": 1,
+      "volumes": [
+        {
+          "bind": "/portainer/Files/AppData/Config/TwitchPointsMiner/run.py",
+          "container": "/usr/src/app/run.py"
+        },
+        {
+          "bind": "/portainer/Files/AppData/TwitchPointsMiner/cookies",
+          "container": "/usr/src/app/cookies"
+        },
+        {
+          "bind": "/portainer/Files/AppData/TwitchPointsMiner/logs",
+          "container": "/usr/src/app/logs"
+        },
+        {
+          "bind": "/portainer/Files/AppData/TwitchPointsMiner/analytics",
+          "container": "/usr/src/app/analytics"
+        }
+      ],
+      "maintainer": " https://github.com/Qballjos/portainer_templates/"
+    },
+    {
+      "id": 440,
+      "type": 1,
+      "title": "Adguardhome-sync",
+      "name": "Adguardhome-sync",
+      "note": "Portainer App Templates by <a href='https://www.technorabilia.com' target='_blank'>Technorabilia</a> based on data provided by <a href='https://www.linuxserver.io' target='_blank'>LinuxServer.io</a>.</p><p>Don't forget to create the volume directories on the host file system.</p><p>mkdir -p /volume1/docker/adguardhome-sync/config</p>",
+      "description": "[Adguardhome-sync](https://github.com/bakito/adguardhome-sync/) is a tool to synchronize AdGuardHome config to replica instances.",
+      "platform": "linux",
+      "logo": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/adguardhomesync-icon.png",
+      "image": "linuxserver/adguardhome-sync:latest",
+      "env": [
+        {
+          "name": "PUID",
+          "label": "PUID",
+          "default": "1024",
+          "description": "for UserID"
+        },
+        {
+          "name": "PGID",
+          "label": "PGID",
+          "default": "100",
+          "description": "for GroupID"
+        },
+        {
+          "name": "TZ",
+          "label": "TZ",
+          "default": "Europe/Amsterdam",
+          "description": "specify a timezone to use, see this [list](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List)."
+        },
+        {
+          "name": "CONFIGFILE",
+          "label": "CONFIGFILE",
+          "default": "/config/adguardhome-sync.yaml",
+          "description": "Set a custom config file."
+        }
+      ],
+      "ports": [
+        "8080:8080/tcp"
+      ],
+      "volumes": [
+        {
+          "container": "/config",
+          "bind": "/volume1/docker/adguardhome-sync/config"
+        }
+      ],
+      "restart_policy": "unless-stopped",
+      "maintainer": " https://github.com/technorabilia/portainer-templates/",
+      "categories": []
+    },
+    {
+      "id": 441,
+      "type": 1,
+      "title": "Altus",
+      "name": "Altus",
+      "note": "Portainer App Templates by <a href='https://www.technorabilia.com' target='_blank'>Technorabilia</a> based on data provided by <a href='https://www.linuxserver.io' target='_blank'>LinuxServer.io</a>.</p><p>Don't forget to create the volume directories on the host file system.</p><p>mkdir -p /volume1/docker/altus/config</p>",
+      "description": "[Altus](https://github.com/amanharwara/altus) is an Electron-based WhatsApp client with themes and multiple account support.",
+      "platform": "linux",
+      "logo": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/altus-logo.png",
+      "image": "linuxserver/altus:latest",
+      "env": [
+        {
+          "name": "PUID",
+          "label": "PUID",
+          "default": "1024",
+          "description": "for UserID"
+        },
+        {
+          "name": "PGID",
+          "label": "PGID",
+          "default": "100",
+          "description": "for GroupID"
+        },
+        {
+          "name": "TZ",
+          "label": "TZ",
+          "default": "Europe/Amsterdam",
+          "description": "specify a timezone to use, see this [list](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List)."
+        }
+      ],
+      "ports": [
+        "3000:3000/tcp",
+        "3001:3001/tcp"
+      ],
+      "volumes": [
+        {
+          "container": "/config",
+          "bind": "/volume1/docker/altus/config"
+        }
+      ],
+      "restart_policy": "unless-stopped",
+      "maintainer": " https://github.com/technorabilia/portainer-templates/",
+      "categories": []
+    },
+    {
+      "id": 442,
+      "type": 1,
+      "title": "Ardour",
+      "name": "Ardour",
+      "note": "Portainer App Templates by <a href='https://www.technorabilia.com' target='_blank'>Technorabilia</a> based on data provided by <a href='https://www.linuxserver.io' target='_blank'>LinuxServer.io</a>.</p><p>Don't forget to create the volume directories on the host file system.</p><p>mkdir -p /volume1/docker/ardour/config</p>",
+      "description": "[Ardour](https://ardour.org/) is an open source, collaborative effort of a worldwide team including musicians, programmers, and professional recording engineers.",
+      "platform": "linux",
+      "logo": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/ardour-logo.png",
+      "image": "linuxserver/ardour:latest",
+      "env": [
+        {
+          "name": "PUID",
+          "label": "PUID",
+          "default": "1024",
+          "description": "for UserID"
+        },
+        {
+          "name": "PGID",
+          "label": "PGID",
+          "default": "100",
+          "description": "for GroupID"
+        },
+        {
+          "name": "TZ",
+          "label": "TZ",
+          "default": "Europe/Amsterdam",
+          "description": "specify a timezone to use, see this [list](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List)."
+        },
+        {
+          "name": "SUBFOLDER",
+          "label": "SUBFOLDER",
+          "default": "/",
+          "description": "Specify a subfolder to use with reverse proxies, IE `/subfolder/`"
+        }
+      ],
+      "ports": [
+        "3000:3000/tcp",
+        "3001:3001/tcp"
+      ],
+      "volumes": [
+        {
+          "container": "/config",
+          "bind": "/volume1/docker/ardour/config"
+        }
+      ],
+      "restart_policy": "unless-stopped",
+      "maintainer": " https://github.com/technorabilia/portainer-templates/",
+      "categories": []
+    },
+    {
+      "id": 443,
+      "type": 1,
+      "title": "Babybuddy",
+      "name": "Babybuddy",
+      "note": "Portainer App Templates by <a href='https://www.technorabilia.com' target='_blank'>Technorabilia</a> based on data provided by <a href='https://www.linuxserver.io' target='_blank'>LinuxServer.io</a>.</p><p>Don't forget to create the volume directories on the host file system.</p><p>mkdir -p /volume1/docker/babybuddy/config</p>",
+      "description": "[Babybuddy](https://github.com/babybuddy/babybuddy) is a buddy for babies! Helps caregivers track sleep, feedings, diaper changes, tummy time and more to learn about and predict baby's needs without (as much) guess work.",
+      "platform": "linux",
+      "logo": "https://github.com/linuxserver/docker-templates/raw/master/linuxserver.io/img/babybuddy-logo.png",
+      "image": "linuxserver/babybuddy:latest",
+      "env": [
+        {
+          "name": "PUID",
+          "label": "PUID",
+          "default": "1024",
+          "description": "for UserID"
+        },
+        {
+          "name": "PGID",
+          "label": "PGID",
+          "default": "100",
+          "description": "for GroupID"
+        },
+        {
+          "name": "TZ",
+          "label": "TZ",
+          "default": "Europe/Amsterdam",
+          "description": "specify a timezone to use, see this [list](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List)."
+        },
+        {
+          "name": "CSRF_TRUSTED_ORIGINS",
+          "label": "CSRF_TRUSTED_ORIGINS",
+          "default": "http://127.0.0.1:8000,https://babybuddy.domain.com",
+          "description": "Add any address you'd like to access babybuddy at (comma separated, no spaces)"
+        }
+      ],
+      "ports": [
+        "8000:8000/tcp"
+      ],
+      "volumes": [
+        {
+          "container": "/config",
+          "bind": "/volume1/docker/babybuddy/config"
+        }
+      ],
+      "restart_policy": "unless-stopped",
+      "maintainer": " https://github.com/technorabilia/portainer-templates/",
+      "categories": []
+    },
+    {
+      "id": 444,
+      "type": 1,
+      "title": "Bambustudio",
+      "name": "Bambustudio",
+      "note": "Portainer App Templates by <a href='https://www.technorabilia.com' target='_blank'>Technorabilia</a> based on data provided by <a href='https://www.linuxserver.io' target='_blank'>LinuxServer.io</a>.</p><p>Don't forget to create the volume directories on the host file system.</p><p>mkdir -p /volume1/docker/bambustudio/config</p>",
+      "description": "[Bambu Studio](https://bambulab.com/en/download/studio) Bambu Studio is an open-source, cutting-edge, feature-rich slicing software. It contains project-based workflows, systematically optimized slicing algorithms, and an easy-to-use graphical interface, bringing users an incredibly smooth printing experience.",
+      "platform": "linux",
+      "logo": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/bambustudio-logo.png",
+      "image": "linuxserver/bambustudio:latest",
+      "env": [
+        {
+          "name": "PUID",
+          "label": "PUID",
+          "default": "1024",
+          "description": "for UserID"
+        },
+        {
+          "name": "PGID",
+          "label": "PGID",
+          "default": "100",
+          "description": "for GroupID"
+        },
+        {
+          "name": "TZ",
+          "label": "TZ",
+          "default": "Europe/Amsterdam",
+          "description": "specify a timezone to use, see this [list](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List)."
+        },
+        {
+          "name": "DARK_MODE",
+          "label": "DARK_MODE",
+          "default": "true",
+          "description": "Set this to true to enable dark mode for Bambu Studio."
+        }
+      ],
+      "ports": [
+        "3000:3000/tcp",
+        "3001:3001/tcp"
+      ],
+      "volumes": [
+        {
+          "container": "/config",
+          "bind": "/volume1/docker/bambustudio/config"
+        }
+      ],
+      "restart_policy": "unless-stopped",
+      "maintainer": " https://github.com/technorabilia/portainer-templates/",
+      "categories": []
+    },
+    {
+      "id": 445,
+      "type": 1,
+      "title": "Blender",
+      "name": "Blender",
+      "note": "Portainer App Templates by <a href='https://www.technorabilia.com' target='_blank'>Technorabilia</a> based on data provided by <a href='https://www.linuxserver.io' target='_blank'>LinuxServer.io</a>.</p><p>Don't forget to create the volume directories on the host file system.</p><p>mkdir -p /volume1/docker/blender/config</p>",
+      "description": "[Blender](https://www.blender.org/) is a free and open-source 3D computer graphics software toolset used for creating animated films, visual effects, art, 3D printed models, motion graphics, interactive 3D applications, virtual reality, and computer games. **This image does not support GPU rendering out of the box only accelerated workspace experience**",
+      "platform": "linux",
+      "logo": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/blender-logo.png",
+      "image": "linuxserver/blender:latest",
+      "env": [
+        {
+          "name": "PUID",
+          "label": "PUID",
+          "default": "1024",
+          "description": "for UserID"
+        },
+        {
+          "name": "PGID",
+          "label": "PGID",
+          "default": "100",
+          "description": "for GroupID"
+        },
+        {
+          "name": "TZ",
+          "label": "TZ",
+          "default": "Europe/Amsterdam",
+          "description": "specify a timezone to use, see this [list](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List)."
+        },
+        {
+          "name": "SUBFOLDER",
+          "label": "SUBFOLDER",
+          "default": "/",
+          "description": "Specify a subfolder to use with reverse proxies, IE `/subfolder/`"
+        }
+      ],
+      "ports": [
+        "3000:3000/tcp",
+        "3001:3001/tcp"
+      ],
+      "volumes": [
+        {
+          "container": "/config",
+          "bind": "/volume1/docker/blender/config"
+        }
+      ],
+      "restart_policy": "unless-stopped",
+      "maintainer": " https://github.com/technorabilia/portainer-templates/",
+      "categories": []
+    },
+    {
+      "id": 446,
+      "type": 1,
+      "title": "Boinc",
+      "name": "Boinc",
+      "note": "Portainer App Templates by <a href='https://www.technorabilia.com' target='_blank'>Technorabilia</a> based on data provided by <a href='https://www.linuxserver.io' target='_blank'>LinuxServer.io</a>.</p><p>Don't forget to create the volume directories on the host file system.</p><p>mkdir -p /volume1/docker/boinc/config</p>",
+      "description": "[BOINC](https://boinc.berkeley.edu/) is a platform for high-throughput computing on a large scale (thousands or millions of computers). It can be used for volunteer computing (using consumer devices) or grid computing (using organizational resources). It supports virtualized, parallel, and GPU-based applications.",
+      "categories": [
+        "Research"
+      ],
+      "platform": "linux",
+      "logo": "https://raw.githubusercontent.com/BOINC/boinc/master/doc/logo/boinc_logo_black.jpg",
+      "image": "linuxserver/boinc:latest",
+      "env": [
+        {
+          "name": "PUID",
+          "label": "PUID",
+          "default": "1024",
+          "description": "for UserID"
+        },
+        {
+          "name": "PGID",
+          "label": "PGID",
+          "default": "100",
+          "description": "for GroupID"
+        },
+        {
+          "name": "TZ",
+          "label": "TZ",
+          "default": "Europe/Amsterdam",
+          "description": "specify a timezone to use, see this [list](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List)."
+        },
+        {
+          "name": "PASSWORD",
+          "label": "PASSWORD",
+          "default": "",
+          "description": "Optionally set a password for the gui."
+        }
+      ],
+      "ports": [
+        "8080:8080/tcp",
+        "8181:8181/tcp"
+      ],
+      "volumes": [
+        {
+          "container": "/config",
+          "bind": "/volume1/docker/boinc/config"
+        }
+      ],
+      "restart_policy": "unless-stopped",
+      "maintainer": " https://github.com/technorabilia/portainer-templates/"
+    },
+    {
+      "id": 447,
+      "type": 1,
+      "title": "Budge",
+      "name": "Budge",
+      "note": "Portainer App Templates by <a href='https://www.technorabilia.com' target='_blank'>Technorabilia</a> based on data provided by <a href='https://www.linuxserver.io' target='_blank'>LinuxServer.io</a>.</p><p>Don't forget to create the volume directories on the host file system.</p><p>mkdir -p /volume1/docker/budge/config</p>",
+      "description": "[Budge](https://github.com/linuxserver/budge) is an open source 'budgeting with envelopes' personal finance app.",
+      "platform": "linux",
+      "logo": "",
+      "image": "linuxserver/budge:latest",
+      "env": [
+        {
+          "name": "PUID",
+          "label": "PUID",
+          "default": "1024",
+          "description": "for UserID"
+        },
+        {
+          "name": "PGID",
+          "label": "PGID",
+          "default": "100",
+          "description": "for GroupID"
+        },
+        {
+          "name": "TZ",
+          "label": "TZ",
+          "default": "Europe/Amsterdam",
+          "description": "specify a timezone to use, see this [list](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List)."
+        }
+      ],
+      "ports": [
+        "80:80/tcp",
+        "443:443/tcp"
+      ],
+      "volumes": [
+        {
+          "container": "/config",
+          "bind": "/volume1/docker/budge/config"
+        }
+      ],
+      "restart_policy": "unless-stopped",
+      "maintainer": " https://github.com/technorabilia/portainer-templates/",
+      "categories": []
+    },
+    {
+      "id": 448,
+      "type": 1,
+      "title": "Build-agent",
+      "name": "Build-agent",
+      "note": "Portainer App Templates by <a href='https://www.technorabilia.com' target='_blank'>Technorabilia</a> based on data provided by <a href='https://www.linuxserver.io' target='_blank'>LinuxServer.io</a>.</p><p>Don't forget to create the volume directories on the host file system.</p><p>mkdir -p /volume1/docker/build-agent/config</p>",
+      "description": "# This container needs special attention. Please check https://hub.docker.com/r/linuxserver/build-agent for details.",
+      "platform": "linux",
+      "logo": "",
+      "image": "linuxserver/build-agent:latest",
+      "env": [
+        {
+          "name": "PUID",
+          "label": "PUID",
+          "default": "1024",
+          "description": "for UserID"
+        },
+        {
+          "name": "PGID",
+          "label": "PGID",
+          "default": "100",
+          "description": "for GroupID"
+        },
+        {
+          "name": "TZ",
+          "label": "TZ",
+          "default": "Europe/Amsterdam",
+          "description": "specify a timezone to use, see this [list](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List)."
+        }
+      ],
+      "ports": [
+        "80:80/tcp"
+      ],
+      "volumes": [
+        {
+          "container": "/config",
+          "bind": "/volume1/docker/build-agent/config"
+        }
+      ],
+      "restart_policy": "unless-stopped",
+      "maintainer": " https://github.com/technorabilia/portainer-templates/",
+      "categories": []
+    },
+    {
+      "id": 449,
+      "type": 1,
+      "title": "Calligra",
+      "name": "Calligra",
+      "note": "Portainer App Templates by <a href='https://www.technorabilia.com' target='_blank'>Technorabilia</a> based on data provided by <a href='https://www.linuxserver.io' target='_blank'>LinuxServer.io</a>.</p><p>Don't forget to create the volume directories on the host file system.</p><p>mkdir -p /volume1/docker/calligra/config</p>",
+      "description": "[Calligra](https://calligra.org/) is an office and graphic art suite by KDE. It is available for desktop PCs, tablet computers, and smartphones. It contains applications for word processing, spreadsheets, presentation, vector graphics, and editing databases.",
+      "platform": "linux",
+      "logo": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/calligra-logo.png",
+      "image": "linuxserver/calligra:latest",
+      "env": [
+        {
+          "name": "PUID",
+          "label": "PUID",
+          "default": "1024",
+          "description": "for UserID"
+        },
+        {
+          "name": "PGID",
+          "label": "PGID",
+          "default": "100",
+          "description": "for GroupID"
+        },
+        {
+          "name": "TZ",
+          "label": "TZ",
+          "default": "Europe/Amsterdam",
+          "description": "specify a timezone to use, see this [list](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List)."
+        }
+      ],
+      "ports": [
+        "3000:3000/tcp",
+        "3001:3001/tcp"
+      ],
+      "volumes": [
+        {
+          "container": "/config",
+          "bind": "/volume1/docker/calligra/config"
+        }
+      ],
+      "restart_policy": "unless-stopped",
+      "maintainer": " https://github.com/technorabilia/portainer-templates/",
+      "categories": []
+    },
+    {
+      "id": 450,
+      "type": 1,
+      "title": "Changedetection.io",
+      "name": "Changedetection.io",
+      "note": "Portainer App Templates by <a href='https://www.technorabilia.com' target='_blank'>Technorabilia</a> based on data provided by <a href='https://www.linuxserver.io' target='_blank'>LinuxServer.io</a>.</p><p>Don't forget to create the volume directories on the host file system.</p><p>mkdir -p /volume1/docker/changedetection.io/config</p>",
+      "description": "[Changedetection.io](https://github.com/dgtlmoon/changedetection.io) provides free, open-source web page monitoring, notification and change detection.",
+      "platform": "linux",
+      "logo": "https://github.com/linuxserver/docker-templates/raw/master/linuxserver.io/img/changedetection-icon.png",
+      "image": "linuxserver/changedetection.io:latest",
+      "env": [
+        {
+          "name": "PUID",
+          "label": "PUID",
+          "default": "1024",
+          "description": "for UserID"
+        },
+        {
+          "name": "PGID",
+          "label": "PGID",
+          "default": "100",
+          "description": "for GroupID"
+        },
+        {
+          "name": "TZ",
+          "label": "TZ",
+          "default": "Europe/Amsterdam",
+          "description": "specify a timezone to use, see this [list](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List)."
+        },
+        {
+          "name": "BASE_URL",
+          "label": "BASE_URL",
+          "default": "",
+          "description": "Specify the full URL (including protocol) when running behind a reverse proxy"
+        },
+        {
+          "name": "PLAYWRIGHT_DRIVER_URL",
+          "label": "PLAYWRIGHT_DRIVER_URL",
+          "default": "",
+          "description": "Specify the full URL to your chrome driver instance. See the [wiki](https://github.com/dgtlmoon/changedetection.io/wiki/Playwright-content-fetcher) for details."
+        }
+      ],
+      "ports": [
+        "5000:5000/tcp"
+      ],
+      "volumes": [
+        {
+          "container": "/config",
+          "bind": "/volume1/docker/changedetection.io/config"
+        }
+      ],
+      "restart_policy": "unless-stopped",
+      "maintainer": " https://github.com/technorabilia/portainer-templates/",
+      "categories": []
+    },
+    {
+      "id": 451,
+      "type": 1,
+      "title": "Chromium",
+      "name": "Chromium",
+      "note": "Portainer App Templates by <a href='https://www.technorabilia.com' target='_blank'>Technorabilia</a> based on data provided by <a href='https://www.linuxserver.io' target='_blank'>LinuxServer.io</a>.</p><p>Don't forget to create the volume directories on the host file system.</p><p>mkdir -p /volume1/docker/chromium/config</p>",
+      "description": "[Chromium](https://www.chromium.org/chromium-projects/) is an open-source browser project that aims to build a safer, faster, and more stable way for all users to experience the web.",
+      "platform": "linux",
+      "logo": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/chromium-logo.png",
+      "image": "linuxserver/chromium:latest",
+      "env": [
+        {
+          "name": "PUID",
+          "label": "PUID",
+          "default": "1024",
+          "description": "for UserID"
+        },
+        {
+          "name": "PGID",
+          "label": "PGID",
+          "default": "100",
+          "description": "for GroupID"
+        },
+        {
+          "name": "TZ",
+          "label": "TZ",
+          "default": "Europe/Amsterdam",
+          "description": "specify a timezone to use, see this [list](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List)."
+        },
+        {
+          "name": "CHROME_CLI",
+          "label": "CHROME_CLI",
+          "default": "https://www.linuxserver.io/",
+          "description": "Specify one or multiple Chromium CLI flags, this string will be passed to the application in full."
+        }
+      ],
+      "ports": [
+        "3000:3000/tcp",
+        "3001:3001/tcp"
+      ],
+      "volumes": [
+        {
+          "container": "/config",
+          "bind": "/volume1/docker/chromium/config"
+        }
+      ],
+      "restart_policy": "unless-stopped",
+      "maintainer": " https://github.com/technorabilia/portainer-templates/",
+      "categories": []
+    },
+    {
+      "id": 452,
+      "type": 1,
+      "title": "Ci",
+      "name": "Ci",
+      "note": "Portainer App Templates by <a href='https://www.technorabilia.com' target='_blank'>Technorabilia</a> based on data provided by <a href='https://www.linuxserver.io' target='_blank'>LinuxServer.io</a>.</p><p>Don't forget to create the volume directories on the host file system.</p><p>mkdir -p /volume1/docker/ci/config</p>",
+      "description": "# This container needs special attention. Please check https://hub.docker.com/r/linuxserver/ci for details.",
+      "platform": "linux",
+      "logo": "",
+      "image": "linuxserver/ci:latest",
+      "env": [
+        {
+          "name": "PUID",
+          "label": "PUID",
+          "default": "1024",
+          "description": "for UserID"
+        },
+        {
+          "name": "PGID",
+          "label": "PGID",
+          "default": "100",
+          "description": "for GroupID"
+        },
+        {
+          "name": "TZ",
+          "label": "TZ",
+          "default": "Europe/Amsterdam",
+          "description": "specify a timezone to use, see this [list](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List)."
+        }
+      ],
+      "ports": [
+        "80:80/tcp"
+      ],
+      "volumes": [
+        {
+          "container": "/config",
+          "bind": "/volume1/docker/ci/config"
+        }
+      ],
+      "restart_policy": "unless-stopped",
+      "maintainer": " https://github.com/technorabilia/portainer-templates/",
+      "categories": []
+    },
+    {
+      "id": 453,
+      "type": 1,
+      "title": "Cura",
+      "name": "Cura",
+      "note": "Portainer App Templates by <a href='https://www.technorabilia.com' target='_blank'>Technorabilia</a> based on data provided by <a href='https://www.linuxserver.io' target='_blank'>LinuxServer.io</a>.</p><p>Don't forget to create the volume directories on the host file system.</p><p>mkdir -p /volume1/docker/cura/config</p>",
+      "description": "[UltiMaker Cura](https://ultimaker.com/software/ultimaker-cura/) is free, easy-to-use 3D printing software trusted by millions of users. Fine-tune your 3D model with 400+ settings for the best slicing and printing results.",
+      "platform": "linux",
+      "logo": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/cura-logo.png",
+      "image": "linuxserver/cura:latest",
+      "env": [
+        {
+          "name": "PUID",
+          "label": "PUID",
+          "default": "1024",
+          "description": "for UserID"
+        },
+        {
+          "name": "PGID",
+          "label": "PGID",
+          "default": "100",
+          "description": "for GroupID"
+        },
+        {
+          "name": "TZ",
+          "label": "TZ",
+          "default": "Europe/Amsterdam",
+          "description": "specify a timezone to use, see this [list](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List)."
+        }
+      ],
+      "ports": [
+        "3000:3000/tcp",
+        "3001:3001/tcp"
+      ],
+      "volumes": [
+        {
+          "container": "/config",
+          "bind": "/volume1/docker/cura/config"
+        }
+      ],
+      "restart_policy": "unless-stopped",
+      "maintainer": " https://github.com/technorabilia/portainer-templates/",
+      "categories": []
+    },
+    {
+      "id": 454,
+      "type": 1,
+      "title": "Darktable",
+      "name": "Darktable",
+      "note": "Portainer App Templates by <a href='https://www.technorabilia.com' target='_blank'>Technorabilia</a> based on data provided by <a href='https://www.linuxserver.io' target='_blank'>LinuxServer.io</a>.</p><p>Don't forget to create the volume directories on the host file system.</p><p>mkdir -p /volume1/docker/darktable/config</p>",
+      "description": "[darktable](https://www.darktable.org/) is an open source photography workflow application and raw developer. A virtual lighttable and darkroom for photographers. It manages your digital negatives in a database, lets you view them through a zoomable lighttable and enables you to develop raw images and enhance them.",
+      "categories": [
+        "Productivity"
+      ],
+      "platform": "linux",
+      "logo": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/darktable-logo.png",
+      "image": "linuxserver/darktable:latest",
+      "env": [
+        {
+          "name": "PUID",
+          "label": "PUID",
+          "default": "1024",
+          "description": "for UserID"
+        },
+        {
+          "name": "PGID",
+          "label": "PGID",
+          "default": "100",
+          "description": "for GroupID"
+        },
+        {
+          "name": "TZ",
+          "label": "TZ",
+          "default": "Europe/Amsterdam",
+          "description": "specify a timezone to use, see this [list](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List)."
+        }
+      ],
+      "ports": [
+        "3000:3000/tcp",
+        "3001:3001/tcp"
+      ],
+      "volumes": [
+        {
+          "container": "/config",
+          "bind": "/volume1/docker/darktable/config"
+        }
+      ],
+      "restart_policy": "unless-stopped",
+      "maintainer": " https://github.com/technorabilia/portainer-templates/"
+    },
+    {
+      "id": 455,
+      "type": 1,
+      "title": "Ddclient",
+      "name": "Ddclient",
+      "note": "Portainer App Templates by <a href='https://www.technorabilia.com' target='_blank'>Technorabilia</a> based on data provided by <a href='https://www.linuxserver.io' target='_blank'>LinuxServer.io</a>.</p><p>Don't forget to create the volume directories on the host file system.</p><p>mkdir -p /volume1/docker/ddclient/config</p>",
+      "description": "[Ddclient](https://github.com/ddclient/ddclient) is a Perl client used to update dynamic DNS entries for accounts on Dynamic DNS Network Service Provider. It was originally written by Paul Burry and is now mostly by wimpunk. It has the capability to update more than just dyndns and it can fetch your WAN-ipaddress in a few different ways.",
+      "categories": [
+        "Networking"
+      ],
+      "platform": "linux",
+      "logo": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/ddclient-logo.png",
+      "image": "linuxserver/ddclient:latest",
+      "env": [
+        {
+          "name": "PUID",
+          "label": "PUID",
+          "default": "1024",
+          "description": "for UserID"
+        },
+        {
+          "name": "PGID",
+          "label": "PGID",
+          "default": "100",
+          "description": "for GroupID"
+        },
+        {
+          "name": "TZ",
+          "label": "TZ",
+          "default": "Europe/Amsterdam",
+          "description": "specify a timezone to use, see this [list](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List)."
+        }
+      ],
+      "ports": [
+        "80:80/tcp"
+      ],
+      "volumes": [
+        {
+          "container": "/config",
+          "bind": "/volume1/docker/ddclient/config"
+        }
+      ],
+      "restart_policy": "unless-stopped",
+      "maintainer": " https://github.com/technorabilia/portainer-templates/"
+    },
+    {
+      "id": 456,
+      "type": 1,
+      "title": "Digikam",
+      "name": "Digikam",
+      "note": "Portainer App Templates by <a href='https://www.technorabilia.com' target='_blank'>Technorabilia</a> based on data provided by <a href='https://www.linuxserver.io' target='_blank'>LinuxServer.io</a>.</p><p>Don't forget to create the volume directories on the host file system.</p><p>mkdir -p /volume1/docker/digikam/config</p>",
+      "description": "[digiKam](https://www.digikam.org/): Professional Photo Management with the Power of Open Source",
+      "categories": [
+        "Photography"
+      ],
+      "platform": "linux",
+      "logo": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/digikam.png",
+      "image": "linuxserver/digikam:latest",
+      "env": [
+        {
+          "name": "PUID",
+          "label": "PUID",
+          "default": "1024",
+          "description": "for UserID"
+        },
+        {
+          "name": "PGID",
+          "label": "PGID",
+          "default": "100",
+          "description": "for GroupID"
+        },
+        {
+          "name": "TZ",
+          "label": "TZ",
+          "default": "Europe/Amsterdam",
+          "description": "specify a timezone to use, see this [list](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List)."
+        },
+        {
+          "name": "SUBFOLDER",
+          "label": "SUBFOLDER",
+          "default": "/",
+          "description": "Specify a subfolder to use with reverse proxies, IE `/subfolder/`"
+        }
+      ],
+      "ports": [
+        "3000:3000/tcp",
+        "3001:3001/tcp"
+      ],
+      "volumes": [
+        {
+          "container": "/config",
+          "bind": "/volume1/docker/digikam/config"
+        }
+      ],
+      "restart_policy": "unless-stopped",
+      "maintainer": " https://github.com/technorabilia/portainer-templates/"
+    },
+    {
+      "id": 457,
+      "type": 1,
+      "title": "Diskover",
+      "name": "Diskover",
+      "note": "Portainer App Templates by <a href='https://www.technorabilia.com' target='_blank'>Technorabilia</a> based on data provided by <a href='https://www.linuxserver.io' target='_blank'>LinuxServer.io</a>.</p><p>Don't forget to create the volume directories on the host file system.</p><p>mkdir -p /volume1/docker/diskover/config<br>mkdir -p /volume1/docker/diskover/data</p>",
+      "description": "[Diskover](https://github.com/diskoverdata/diskover-community) is an open source file system indexer that uses Elasticsearch to index and manage data across heterogeneous storage systems.",
+      "categories": [
+        "Productivity"
+      ],
+      "platform": "linux",
+      "logo": "https://raw.githubusercontent.com/diskoverdata/diskover-community/master/diskover-web/public/images/diskover.png",
+      "image": "linuxserver/diskover:latest",
+      "env": [
+        {
+          "name": "PUID",
+          "label": "PUID",
+          "default": "1024",
+          "description": "for UserID"
+        },
+        {
+          "name": "PGID",
+          "label": "PGID",
+          "default": "100",
+          "description": "for GroupID"
+        },
+        {
+          "name": "TZ",
+          "label": "TZ",
+          "default": "Europe/Amsterdam",
+          "description": "specify a timezone to use, see this [list](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List)."
+        },
+        {
+          "name": "ES_HOST",
+          "label": "ES_HOST",
+          "default": "elasticsearch",
+          "description": "ElasticSearch host (optional)"
+        },
+        {
+          "name": "ES_PORT",
+          "label": "ES_PORT",
+          "default": "9200",
+          "description": "ElasticSearch port (optional)"
+        }
+      ],
+      "ports": [
+        "80:80/tcp"
+      ],
+      "volumes": [
+        {
+          "container": "/config",
+          "bind": "/volume1/docker/diskover/config"
+        },
+        {
+          "container": "/data",
+          "bind": "/volume1/docker/diskover/data"
+        }
+      ],
+      "restart_policy": "unless-stopped",
+      "maintainer": " https://github.com/technorabilia/portainer-templates/"
+    },
+    {
+      "id": 458,
+      "type": 1,
+      "title": "Doplarr",
+      "name": "Doplarr",
+      "note": "Portainer App Templates by <a href='https://www.technorabilia.com' target='_blank'>Technorabilia</a> based on data provided by <a href='https://www.linuxserver.io' target='_blank'>LinuxServer.io</a>.</p><p>Don't forget to create the volume directories on the host file system.</p><p>mkdir -p /volume1/docker/doplarr/config</p>",
+      "description": "[Doplarr](https://github.com/kiranshila/Doplarr) is an *arr request bot for Discord.'",
+      "platform": "linux",
+      "logo": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/doplarr-logo_title.png",
+      "image": "linuxserver/doplarr:latest",
+      "env": [
+        {
+          "name": "PUID",
+          "label": "PUID",
+          "default": "1024",
+          "description": "for UserID"
+        },
+        {
+          "name": "PGID",
+          "label": "PGID",
+          "default": "100",
+          "description": "for GroupID"
+        },
+        {
+          "name": "TZ",
+          "label": "TZ",
+          "default": "Europe/Amsterdam",
+          "description": "specify a timezone to use, see this [list](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List)."
+        },
+        {
+          "name": "DISCORD__TOKEN",
+          "label": "DISCORD__TOKEN",
+          "default": "",
+          "description": "Specify your discord bot token."
+        },
+        {
+          "name": "OVERSEERR__API",
+          "label": "OVERSEERR__API",
+          "default": "",
+          "description": "Specify your Overseerr API key. Leave blank if using Radarr/Sonarr."
+        },
+        {
+          "name": "OVERSEERR__URL",
+          "label": "OVERSEERR__URL",
+          "default": "http://localhost:5055",
+          "description": "Specify your Overseerr URL. Leave blank if using Radarr/Sonarr."
+        },
+        {
+          "name": "RADARR__API",
+          "label": "RADARR__API",
+          "default": "",
+          "description": "Specify your Radarr API key. Leave blank if using Overseerr."
+        },
+        {
+          "name": "RADARR__URL",
+          "label": "RADARR__URL",
+          "default": "http://localhost:7878",
+          "description": "Specify your Radarr URL. Leave blank if using Overseerr."
+        },
+        {
+          "name": "SONARR__API",
+          "label": "SONARR__API",
+          "default": "",
+          "description": "Specify your Sonarr API key. Leave blank if using Overseerr."
+        },
+        {
+          "name": "SONARR__URL",
+          "label": "SONARR__URL",
+          "default": "http://localhost:8989",
+          "description": "Specify your Sonarr URL. Leave blank if using Overseerr."
+        },
+        {
+          "name": "DISCORD__MAX_RESULTS",
+          "label": "DISCORD__MAX_RESULTS",
+          "default": "25",
+          "description": "Sets the maximum size of the search results selection"
+        },
+        {
+          "name": "DISCORD__REQUESTED_MSG_STYLE",
+          "label": "DISCORD__REQUESTED_MSG_STYLE",
+          "default": ":plain",
+          "description": "Sets the style of the request alert message. One of `:plain` `:embed` `:none`"
+        },
+        {
+          "name": "SONARR__QUALITY_PROFILE",
+          "label": "SONARR__QUALITY_PROFILE",
+          "default": "",
+          "description": "The name of the quality profile to use by default for Sonarr"
+        },
+        {
+          "name": "RADARR__QUALITY_PROFILE",
+          "label": "RADARR__QUALITY_PROFILE",
+          "default": "",
+          "description": "The name of the quality profile to use by default for Radarr"
+        },
+        {
+          "name": "SONARR__ROOTFOLDER",
+          "label": "SONARR__ROOTFOLDER",
+          "default": "",
+          "description": "The root folder to use by default for Sonarr"
+        },
+        {
+          "name": "RADARR__ROOTFOLDER",
+          "label": "RADARR__ROOTFOLDER",
+          "default": "",
+          "description": "The root folder to use by default for Radarr"
+        },
+        {
+          "name": "SONARR__LANGUAGE_PROFILE",
+          "label": "SONARR__LANGUAGE_PROFILE",
+          "default": "",
+          "description": "The name of the language profile to use by default for Sonarr"
+        },
+        {
+          "name": "OVERSEERR__DEFAULT_ID",
+          "label": "OVERSEERR__DEFAULT_ID",
+          "default": "",
+          "description": "The Overseerr user id to use by default if there is no associated discord account for the requester"
+        },
+        {
+          "name": "PARTIAL_SEASONS",
+          "label": "PARTIAL_SEASONS",
+          "default": "true",
+          "description": "Sets whether users can request partial seasons."
+        },
+        {
+          "name": "LOG_LEVEL",
+          "label": "LOG_LEVEL",
+          "default": ":info",
+          "description": "The log level for the logging backend. This can be changed for debugging purposes. One of trace `:debug` `:info` `:warn` `:error` `:fatal` `:report`"
+        },
+        {
+          "name": "JAVA_OPTS",
+          "label": "JAVA_OPTS",
+          "default": "",
+          "description": "For passing additional java options."
+        }
+      ],
+      "ports": [
+        "80:80/tcp"
+      ],
+      "volumes": [
+        {
+          "container": "/config",
+          "bind": "/volume1/docker/doplarr/config"
+        }
+      ],
+      "restart_policy": "unless-stopped",
+      "maintainer": " https://github.com/technorabilia/portainer-templates/",
+      "categories": []
+    },
+    {
+      "id": 459,
+      "type": 1,
+      "title": "Doublecommander",
+      "name": "Doublecommander",
+      "note": "Portainer App Templates by <a href='https://www.technorabilia.com' target='_blank'>Technorabilia</a> based on data provided by <a href='https://www.linuxserver.io' target='_blank'>LinuxServer.io</a>.</p><p>Don't forget to create the volume directories on the host file system.</p><p>mkdir -p /volume1/docker/doublecommander/config<br>mkdir -p /volume1/docker/doublecommander/data</p>",
+      "description": "[Double Commander](https://doublecmd.sourceforge.io/) is a free cross platform open source file manager with two panels side by side. It is inspired by Total Commander and features some new ideas.",
+      "categories": [
+        "Filemanagement"
+      ],
+      "platform": "linux",
+      "logo": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/doublecommander-icon.png",
+      "image": "linuxserver/doublecommander:latest",
+      "env": [
+        {
+          "name": "PUID",
+          "label": "PUID",
+          "default": "1024",
+          "description": "for UserID"
+        },
+        {
+          "name": "PGID",
+          "label": "PGID",
+          "default": "100",
+          "description": "for GroupID"
+        },
+        {
+          "name": "TZ",
+          "label": "TZ",
+          "default": "Europe/Amsterdam",
+          "description": "specify a timezone to use, see this [list](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List)."
+        }
+      ],
+      "ports": [
+        "3000:3000/tcp",
+        "3001:3001/tcp"
+      ],
+      "volumes": [
+        {
+          "container": "/config",
+          "bind": "/volume1/docker/doublecommander/config"
+        },
+        {
+          "container": "/data",
+          "bind": "/volume1/docker/doublecommander/data"
+        }
+      ],
+      "restart_policy": "unless-stopped",
+      "maintainer": " https://github.com/technorabilia/portainer-templates/"
+    },
+    {
+      "id": 460,
+      "type": 1,
+      "title": "Fail2ban",
+      "name": "Fail2ban",
+      "note": "Portainer App Templates by <a href='https://www.technorabilia.com' target='_blank'>Technorabilia</a> based on data provided by <a href='https://www.linuxserver.io' target='_blank'>LinuxServer.io</a>.</p><p>Don't forget to create the volume directories on the host file system.</p><p>mkdir -p /volume1/docker/fail2ban/config<br>mkdir -p /volume1/docker/fail2ban/var/log:ro<br>mkdir -p /volume1/docker/fail2ban/remotelogs/airsonic:ro<br>mkdir -p /volume1/docker/fail2ban/remotelogs/apache2:ro<br>mkdir -p /volume1/docker/fail2ban/remotelogs/authelia:ro<br>mkdir -p /volume1/docker/fail2ban/remotelogs/emby:ro<br>mkdir -p /volume1/docker/fail2ban/remotelogs/filebrowser:ro<br>mkdir -p /volume1/docker/fail2ban/remotelogs/homeassistant:ro<br>mkdir -p /volume1/docker/fail2ban/remotelogs/lighttpd:ro<br>mkdir -p /volume1/docker/fail2ban/remotelogs/nextcloud:ro<br>mkdir -p /volume1/docker/fail2ban/remotelogs/nginx:ro<br>mkdir -p /volume1/docker/fail2ban/remotelogs/nzbget:ro<br>mkdir -p /volume1/docker/fail2ban/remotelogs/overseerr:ro<br>mkdir -p /volume1/docker/fail2ban/remotelogs/prowlarr:ro<br>mkdir -p /volume1/docker/fail2ban/remotelogs/radarr:ro<br>mkdir -p /volume1/docker/fail2ban/remotelogs/sabnzbd:ro<br>mkdir -p /volume1/docker/fail2ban/remotelogs/sonarr:ro<br>mkdir -p /volume1/docker/fail2ban/remotelogs/unificontroller:ro<br>mkdir -p /volume1/docker/fail2ban/remotelogs/vaultwarden:ro</p>",
+      "description": "[Fail2ban](http://www.fail2ban.org/) is a daemon to ban hosts that cause multiple authentication errors.",
+      "platform": "linux",
+      "logo": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/fail2ban-logo.png",
+      "image": "linuxserver/fail2ban:latest",
+      "network": "host",
+      "env": [
+        {
+          "name": "PUID",
+          "label": "PUID",
+          "default": "1024",
+          "description": "for UserID"
+        },
+        {
+          "name": "PGID",
+          "label": "PGID",
+          "default": "100",
+          "description": "for GroupID"
+        },
+        {
+          "name": "TZ",
+          "label": "TZ",
+          "default": "Europe/Amsterdam",
+          "description": "specify a timezone to use, see this [list](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List)."
+        },
+        {
+          "name": "VERBOSITY",
+          "label": "VERBOSITY",
+          "default": "-vv",
+          "description": "Set the container log verbosity. Valid options are -v, -vv, -vvv, -vvvv, or leaving the value blank or not setting the variable."
+        }
+      ],
+      "ports": [
+        "80:80/tcp"
+      ],
+      "volumes": [
+        {
+          "container": "/config",
+          "bind": "/volume1/docker/fail2ban/config"
+        },
+        {
+          "container": "/var/log:ro",
+          "bind": "/volume1/docker/fail2ban/var/log:ro"
+        },
+        {
+          "container": "/remotelogs/airsonic:ro",
+          "bind": "/volume1/docker/fail2ban/remotelogs/airsonic:ro"
+        },
+        {
+          "container": "/remotelogs/apache2:ro",
+          "bind": "/volume1/docker/fail2ban/remotelogs/apache2:ro"
+        },
+        {
+          "container": "/remotelogs/authelia:ro",
+          "bind": "/volume1/docker/fail2ban/remotelogs/authelia:ro"
+        },
+        {
+          "container": "/remotelogs/emby:ro",
+          "bind": "/volume1/docker/fail2ban/remotelogs/emby:ro"
+        },
+        {
+          "container": "/remotelogs/filebrowser:ro",
+          "bind": "/volume1/docker/fail2ban/remotelogs/filebrowser:ro"
+        },
+        {
+          "container": "/remotelogs/homeassistant:ro",
+          "bind": "/volume1/docker/fail2ban/remotelogs/homeassistant:ro"
+        },
+        {
+          "container": "/remotelogs/lighttpd:ro",
+          "bind": "/volume1/docker/fail2ban/remotelogs/lighttpd:ro"
+        },
+        {
+          "container": "/remotelogs/nextcloud:ro",
+          "bind": "/volume1/docker/fail2ban/remotelogs/nextcloud:ro"
+        },
+        {
+          "container": "/remotelogs/nginx:ro",
+          "bind": "/volume1/docker/fail2ban/remotelogs/nginx:ro"
+        },
+        {
+          "container": "/remotelogs/nzbget:ro",
+          "bind": "/volume1/docker/fail2ban/remotelogs/nzbget:ro"
+        },
+        {
+          "container": "/remotelogs/overseerr:ro",
+          "bind": "/volume1/docker/fail2ban/remotelogs/overseerr:ro"
+        },
+        {
+          "container": "/remotelogs/prowlarr:ro",
+          "bind": "/volume1/docker/fail2ban/remotelogs/prowlarr:ro"
+        },
+        {
+          "container": "/remotelogs/radarr:ro",
+          "bind": "/volume1/docker/fail2ban/remotelogs/radarr:ro"
+        },
+        {
+          "container": "/remotelogs/sabnzbd:ro",
+          "bind": "/volume1/docker/fail2ban/remotelogs/sabnzbd:ro"
+        },
+        {
+          "container": "/remotelogs/sonarr:ro",
+          "bind": "/volume1/docker/fail2ban/remotelogs/sonarr:ro"
+        },
+        {
+          "container": "/remotelogs/unificontroller:ro",
+          "bind": "/volume1/docker/fail2ban/remotelogs/unificontroller:ro"
+        },
+        {
+          "container": "/remotelogs/vaultwarden:ro",
+          "bind": "/volume1/docker/fail2ban/remotelogs/vaultwarden:ro"
+        }
+      ],
+      "restart_policy": "unless-stopped",
+      "maintainer": " https://github.com/technorabilia/portainer-templates/",
+      "categories": []
+    },
+    {
+      "id": 461,
+      "type": 1,
+      "title": "Faster-whisper",
+      "name": "Faster-whisper",
+      "note": "Portainer App Templates by <a href='https://www.technorabilia.com' target='_blank'>Technorabilia</a> based on data provided by <a href='https://www.linuxserver.io' target='_blank'>LinuxServer.io</a>.</p><p>Don't forget to create the volume directories on the host file system.</p><p>mkdir -p /volume1/docker/faster-whisper/config</p>",
+      "description": "[Faster-whisper](https://github.com/SYSTRAN/faster-whisper) is a reimplementation of OpenAI's Whisper model using CTranslate2, which is a fast inference engine for Transformer models. This container provides a Wyoming protocol server for faster-whisper.",
+      "platform": "linux",
+      "logo": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/faster-whisper-logo.png",
+      "image": "linuxserver/faster-whisper:latest",
+      "env": [
+        {
+          "name": "PUID",
+          "label": "PUID",
+          "default": "1024",
+          "description": "for UserID"
+        },
+        {
+          "name": "PGID",
+          "label": "PGID",
+          "default": "100",
+          "description": "for GroupID"
+        },
+        {
+          "name": "TZ",
+          "label": "TZ",
+          "default": "Europe/Amsterdam",
+          "description": "specify a timezone to use, see this [list](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List)."
+        },
+        {
+          "name": "WHISPER_MODEL",
+          "label": "WHISPER_MODEL",
+          "default": "tiny-int8",
+          "description": "Whisper model that will be used for transcription. From `tiny`, `base`, `small` and `medium`, all with `-int8` compressed variants"
+        },
+        {
+          "name": "WHISPER_BEAM",
+          "label": "WHISPER_BEAM",
+          "default": "1",
+          "description": "Number of candidates to consider simultaneously during transcription."
+        },
+        {
+          "name": "WHISPER_LANG",
+          "label": "WHISPER_LANG",
+          "default": "en",
+          "description": "Language that you will speak to the add-on."
+        }
+      ],
+      "ports": [
+        "10300:10300/tcp"
+      ],
+      "volumes": [
+        {
+          "container": "/config",
+          "bind": "/volume1/docker/faster-whisper/config"
+        }
+      ],
+      "restart_policy": "unless-stopped",
+      "maintainer": " https://github.com/technorabilia/portainer-templates/",
+      "categories": []
+    },
+    {
+      "id": 462,
+      "type": 1,
+      "title": "Feed2toot",
+      "name": "Feed2toot",
+      "note": "Portainer App Templates by <a href='https://www.technorabilia.com' target='_blank'>Technorabilia</a> based on data provided by <a href='https://www.linuxserver.io' target='_blank'>LinuxServer.io</a>.</p><p>Don't forget to create the volume directories on the host file system.</p><p>mkdir -p /volume1/docker/feed2toot/config</p>",
+      "description": "[Feed2toot](https://gitlab.com/chaica/feed2toot) automatically parses rss feeds, identifies new posts and posts them on the Mastodon social network.",
+      "platform": "linux",
+      "logo": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/feed2toot-banner.png",
+      "image": "linuxserver/feed2toot:latest",
+      "env": [
+        {
+          "name": "PUID",
+          "label": "PUID",
+          "default": "1024",
+          "description": "for UserID"
+        },
+        {
+          "name": "PGID",
+          "label": "PGID",
+          "default": "100",
+          "description": "for GroupID"
+        },
+        {
+          "name": "TZ",
+          "label": "TZ",
+          "default": "Europe/Amsterdam",
+          "description": "specify a timezone to use, see this [list](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List)."
+        },
+        {
+          "name": "FEED_LIMIT",
+          "label": "FEED_LIMIT",
+          "default": "5",
+          "description": "Limit number of RSS entries published at each execution."
+        }
+      ],
+      "volumes": [
+        {
+          "container": "/config",
+          "bind": "/volume1/docker/feed2toot/config"
+        }
+      ],
+      "restart_policy": "unless-stopped",
+      "maintainer": " https://github.com/technorabilia/portainer-templates/",
+      "categories": []
+    },
+    {
+      "id": 463,
+      "type": 1,
+      "title": "Fleet",
+      "name": "Fleet",
+      "note": "Portainer App Templates by <a href='https://www.technorabilia.com' target='_blank'>Technorabilia</a> based on data provided by <a href='https://www.linuxserver.io' target='_blank'>LinuxServer.io</a>.</p><p>Don't forget to create the volume directories on the host file system.</p><p>mkdir -p /volume1/docker/fleet/config</p>",
+      "description": "[Fleet](https://github.com/linuxserver/fleet) provides an online web interface which displays a set of maintained images from one or more owned repositories.",
+      "platform": "linux",
+      "logo": "",
+      "image": "linuxserver/fleet:latest",
+      "env": [
+        {
+          "name": "PUID",
+          "label": "PUID",
+          "default": "1024",
+          "description": "for UserID"
+        },
+        {
+          "name": "PGID",
+          "label": "PGID",
+          "default": "100",
+          "description": "for GroupID"
+        },
+        {
+          "name": "TZ",
+          "label": "TZ",
+          "default": "Europe/Amsterdam",
+          "description": "specify a timezone to use, see this [list](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List)."
+        },
+        {
+          "name": "fleet_admin_authentication_type",
+          "label": "fleet_admin_authentication_type",
+          "default": "DATABASE",
+          "description": "A switch to define how Fleet manages user logins. If set to DATABASE, see the related optional params. Can be set to either DATABASE or PROPERTIES."
+        },
+        {
+          "name": "fleet_database_url",
+          "label": "fleet_database_url",
+          "default": "jdbc:mariadb://<url>:3306/fleet",
+          "description": "The full JDBC connection string to the Fleet database"
+        },
+        {
+          "name": "fleet_database_username",
+          "label": "fleet_database_username",
+          "default": "fleet_user",
+          "description": "The username with the relevant GRANT permissions for the database"
+        },
+        {
+          "name": "fleet_database_password",
+          "label": "fleet_database_password",
+          "default": "dbuserpassword",
+          "description": "The database user's password."
+        },
+        {
+          "name": "fleet_admin_secret",
+          "label": "fleet_admin_secret",
+          "default": "randomstring",
+          "description": "A string used as part of the password key derivation process."
+        }
+      ],
+      "ports": [
+        "8080:8080/tcp"
+      ],
+      "volumes": [
+        {
+          "container": "/config",
+          "bind": "/volume1/docker/fleet/config"
+        }
+      ],
+      "restart_policy": "unless-stopped",
+      "maintainer": " https://github.com/technorabilia/portainer-templates/",
+      "categories": []
+    },
+    {
+      "id": 464,
+      "type": 1,
+      "title": "Flexget",
+      "name": "Flexget",
+      "note": "Portainer App Templates by <a href='https://www.technorabilia.com' target='_blank'>Technorabilia</a> based on data provided by <a href='https://www.linuxserver.io' target='_blank'>LinuxServer.io</a>.</p><p>Don't forget to create the volume directories on the host file system.</p><p>mkdir -p /volume1/docker/flexget/config<br>mkdir -p /volume1/docker/flexget/data</p>",
+      "description": "[Flexget](http://flexget.com/) is a multipurpose automation tool for all of your media.",
+      "platform": "linux",
+      "logo": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/flexget-banner.png",
+      "image": "linuxserver/flexget:latest",
+      "env": [
+        {
+          "name": "PUID",
+          "label": "PUID",
+          "default": "1024",
+          "description": "for UserID"
+        },
+        {
+          "name": "PGID",
+          "label": "PGID",
+          "default": "100",
+          "description": "for GroupID"
+        },
+        {
+          "name": "TZ",
+          "label": "TZ",
+          "default": "Europe/Amsterdam",
+          "description": "specify a timezone to use, see this [list](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List)."
+        },
+        {
+          "name": "FG_LOG_LEVEL",
+          "label": "FG_LOG_LEVEL",
+          "default": "info",
+          "description": "Set the FlexGet logging level."
+        },
+        {
+          "name": "FG_LOG_FILE",
+          "label": "FG_LOG_FILE",
+          "default": "/config/flexget.log",
+          "description": "Set the FlexGet log file location."
+        },
+        {
+          "name": "FG_CONFIG_FILE",
+          "label": "FG_CONFIG_FILE",
+          "default": "/config/.flexget/config.yml",
+          "description": "Set the FlexGet config file location."
+        },
+        {
+          "name": "FG_WEBUI_PASSWORD",
+          "label": "FG_WEBUI_PASSWORD",
+          "default": "info",
+          "description": "Set the FlexGet webui password. Pay attention to Bash/YAML reserved characters."
+        }
+      ],
+      "ports": [
+        "5050:5050/tcp"
+      ],
+      "volumes": [
+        {
+          "container": "/config",
+          "bind": "/volume1/docker/flexget/config"
+        },
+        {
+          "container": "/data",
+          "bind": "/volume1/docker/flexget/data"
+        }
+      ],
+      "restart_policy": "unless-stopped",
+      "maintainer": " https://github.com/technorabilia/portainer-templates/",
+      "categories": []
+    },
+    {
+      "id": 465,
+      "type": 1,
+      "title": "Freecad",
+      "name": "Freecad",
+      "note": "Portainer App Templates by <a href='https://www.technorabilia.com' target='_blank'>Technorabilia</a> based on data provided by <a href='https://www.linuxserver.io' target='_blank'>LinuxServer.io</a>.</p><p>Don't forget to create the volume directories on the host file system.</p><p>mkdir -p /volume1/docker/freecad/config</p>",
+      "description": "[FreeCAD](https://www.freecad.org/) is a general-purpose parametric 3D computer-aided design (CAD) modeler and a building information modeling (BIM) software application with finite element method (FEM) support.",
+      "platform": "linux",
+      "logo": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/freecad-logo.png",
+      "image": "linuxserver/freecad:latest",
+      "env": [
+        {
+          "name": "PUID",
+          "label": "PUID",
+          "default": "1024",
+          "description": "for UserID"
+        },
+        {
+          "name": "PGID",
+          "label": "PGID",
+          "default": "100",
+          "description": "for GroupID"
+        },
+        {
+          "name": "TZ",
+          "label": "TZ",
+          "default": "Europe/Amsterdam",
+          "description": "specify a timezone to use, see this [list](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List)."
+        }
+      ],
+      "ports": [
+        "3000:3000/tcp",
+        "3001:3001/tcp"
+      ],
+      "volumes": [
+        {
+          "container": "/config",
+          "bind": "/volume1/docker/freecad/config"
+        }
+      ],
+      "restart_policy": "unless-stopped",
+      "maintainer": " https://github.com/technorabilia/portainer-templates/",
+      "categories": []
+    },
+    {
+      "id": 466,
+      "type": 1,
+      "title": "Freetube",
+      "name": "Freetube",
+      "note": "Portainer App Templates by <a href='https://www.technorabilia.com' target='_blank'>Technorabilia</a> based on data provided by <a href='https://www.linuxserver.io' target='_blank'>LinuxServer.io</a>.</p><p>Don't forget to create the volume directories on the host file system.</p><p>mkdir -p /volume1/docker/freetube/config</p>",
+      "description": "[FreeTube](https://freetubeapp.io/) is a feature-rich and user-friendly YouTube client with a focus on privacy.",
+      "platform": "linux",
+      "logo": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/freetube-logo.png",
+      "image": "linuxserver/freetube:latest",
+      "env": [
+        {
+          "name": "PUID",
+          "label": "PUID",
+          "default": "1024",
+          "description": "for UserID"
+        },
+        {
+          "name": "PGID",
+          "label": "PGID",
+          "default": "100",
+          "description": "for GroupID"
+        },
+        {
+          "name": "TZ",
+          "label": "TZ",
+          "default": "Europe/Amsterdam",
+          "description": "specify a timezone to use, see this [list](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List)."
+        }
+      ],
+      "ports": [
+        "3000:3000/tcp",
+        "3001:3001/tcp"
+      ],
+      "volumes": [
+        {
+          "container": "/config",
+          "bind": "/volume1/docker/freetube/config"
+        }
+      ],
+      "restart_policy": "unless-stopped",
+      "maintainer": " https://github.com/technorabilia/portainer-templates/",
+      "categories": []
+    },
+    {
+      "id": 467,
+      "type": 1,
+      "title": "Gimp",
+      "name": "Gimp",
+      "note": "Portainer App Templates by <a href='https://www.technorabilia.com' target='_blank'>Technorabilia</a> based on data provided by <a href='https://www.linuxserver.io' target='_blank'>LinuxServer.io</a>.</p><p>Don't forget to create the volume directories on the host file system.</p><p>mkdir -p /volume1/docker/gimp/config</p>",
+      "description": "[GIMP](https://www.gimp.org/) is a free and open-source raster graphics editor used for image manipulation (retouching) and image editing, free-form drawing, transcoding between different image file formats, and more specialized tasks. It is extensible by means of plugins, and scriptable.",
+      "platform": "linux",
+      "logo": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/gimp-logo.png",
+      "image": "linuxserver/gimp:latest",
+      "env": [
+        {
+          "name": "PUID",
+          "label": "PUID",
+          "default": "1024",
+          "description": "for UserID"
+        },
+        {
+          "name": "PGID",
+          "label": "PGID",
+          "default": "100",
+          "description": "for GroupID"
+        },
+        {
+          "name": "TZ",
+          "label": "TZ",
+          "default": "Europe/Amsterdam",
+          "description": "specify a timezone to use, see this [list](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List)."
+        }
+      ],
+      "ports": [
+        "3000:3000/tcp",
+        "3001:3001/tcp"
+      ],
+      "volumes": [
+        {
+          "container": "/config",
+          "bind": "/volume1/docker/gimp/config"
+        }
+      ],
+      "restart_policy": "unless-stopped",
+      "maintainer": " https://github.com/technorabilia/portainer-templates/",
+      "categories": []
+    },
+    {
+      "id": 468,
+      "type": 1,
+      "title": "Github-desktop",
+      "name": "Github-desktop",
+      "note": "Portainer App Templates by <a href='https://www.technorabilia.com' target='_blank'>Technorabilia</a> based on data provided by <a href='https://www.linuxserver.io' target='_blank'>LinuxServer.io</a>.</p><p>Don't forget to create the volume directories on the host file system.</p><p>mkdir -p /volume1/docker/github-desktop/config</p>",
+      "description": "[Github Desktop](https://desktop.github.com/) is an open source Electron-based GitHub app. It is written in TypeScript and uses React.",
+      "platform": "linux",
+      "logo": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/github-desktop-icon.png",
+      "image": "linuxserver/github-desktop:latest",
+      "env": [
+        {
+          "name": "PUID",
+          "label": "PUID",
+          "default": "1024",
+          "description": "for UserID"
+        },
+        {
+          "name": "PGID",
+          "label": "PGID",
+          "default": "100",
+          "description": "for GroupID"
+        },
+        {
+          "name": "TZ",
+          "label": "TZ",
+          "default": "Europe/Amsterdam",
+          "description": "specify a timezone to use, see this [list](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List)."
+        }
+      ],
+      "ports": [
+        "3000:3000/tcp",
+        "3001:3001/tcp"
+      ],
+      "volumes": [
+        {
+          "container": "/config",
+          "bind": "/volume1/docker/github-desktop/config"
+        }
+      ],
+      "restart_policy": "unless-stopped",
+      "maintainer": " https://github.com/technorabilia/portainer-templates/",
+      "categories": []
+    },
+    {
+      "id": 469,
+      "type": 1,
+      "title": "Gitqlient",
+      "name": "Gitqlient",
+      "note": "Portainer App Templates by <a href='https://www.technorabilia.com' target='_blank'>Technorabilia</a> based on data provided by <a href='https://www.linuxserver.io' target='_blank'>LinuxServer.io</a>.</p><p>Don't forget to create the volume directories on the host file system.</p><p>mkdir -p /volume1/docker/gitqlient/config</p>",
+      "description": "[GitQlient](https://github.com/francescmm/GitQlient) is a multi-platform Git client originally forked from QGit. Nowadays it goes beyond of just a fork and adds a lot of new functionality.",
+      "platform": "linux",
+      "logo": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/gitqlient-icon.png",
+      "image": "linuxserver/gitqlient:latest",
+      "env": [
+        {
+          "name": "PUID",
+          "label": "PUID",
+          "default": "1024",
+          "description": "for UserID"
+        },
+        {
+          "name": "PGID",
+          "label": "PGID",
+          "default": "100",
+          "description": "for GroupID"
+        },
+        {
+          "name": "TZ",
+          "label": "TZ",
+          "default": "Europe/Amsterdam",
+          "description": "specify a timezone to use, see this [list](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List)."
+        }
+      ],
+      "ports": [
+        "3000:3000/tcp",
+        "3001:3001/tcp"
+      ],
+      "volumes": [
+        {
+          "container": "/config",
+          "bind": "/volume1/docker/gitqlient/config"
+        }
+      ],
+      "restart_policy": "unless-stopped",
+      "maintainer": " https://github.com/technorabilia/portainer-templates/",
+      "categories": []
+    },
+    {
+      "id": 470,
+      "type": 1,
+      "title": "Grav",
+      "name": "Grav",
+      "note": "Portainer App Templates by <a href='https://www.technorabilia.com' target='_blank'>Technorabilia</a> based on data provided by <a href='https://www.linuxserver.io' target='_blank'>LinuxServer.io</a>.</p><p>Don't forget to create the volume directories on the host file system.</p><p>mkdir -p /volume1/docker/grav/config</p>",
+      "description": "[Grav](https://github.com/getgrav/grav/) is a Fast, Simple, and Flexible, file-based Web-platform.",
+      "categories": [
+        "Webplatform"
+      ],
+      "platform": "linux",
+      "logo": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/grav-logo.png",
+      "image": "linuxserver/grav:latest",
+      "env": [
+        {
+          "name": "PUID",
+          "label": "PUID",
+          "default": "1024",
+          "description": "for UserID"
+        },
+        {
+          "name": "PGID",
+          "label": "PGID",
+          "default": "100",
+          "description": "for GroupID"
+        },
+        {
+          "name": "TZ",
+          "label": "TZ",
+          "default": "Europe/Amsterdam",
+          "description": "specify a timezone to use, see this [list](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List)."
+        }
+      ],
+      "ports": [
+        "80:80/tcp"
+      ],
+      "volumes": [
+        {
+          "container": "/config",
+          "bind": "/volume1/docker/grav/config"
+        }
+      ],
+      "restart_policy": "unless-stopped",
+      "maintainer": " https://github.com/technorabilia/portainer-templates/"
+    },
+    {
+      "id": 471,
+      "type": 1,
+      "title": "Hedgedoc",
+      "name": "Hedgedoc",
+      "note": "Portainer App Templates by <a href='https://www.technorabilia.com' target='_blank'>Technorabilia</a> based on data provided by <a href='https://www.linuxserver.io' target='_blank'>LinuxServer.io</a>.</p><p>Don't forget to create the volume directories on the host file system.</p><p>mkdir -p /volume1/docker/hedgedoc/config</p>",
+      "description": "[HedgeDoc](https://hedgedoc.org/) gives you access to all your files wherever you are. HedgeDoc is a real-time, multi-platform collaborative markdown note editor. This means that you can write notes with other people on your desktop, tablet or even on the phone. You can sign-in via multiple auth providers like Facebook, Twitter, GitHub and many more on the homepage.",
+      "categories": [
+        "Documentation"
+      ],
+      "platform": "linux",
+      "logo": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/hedgedoc-banner.png",
+      "image": "linuxserver/hedgedoc:latest",
+      "env": [
+        {
+          "name": "PUID",
+          "label": "PUID",
+          "default": "1024",
+          "description": "for UserID"
+        },
+        {
+          "name": "PGID",
+          "label": "PGID",
+          "default": "100",
+          "description": "for GroupID"
+        },
+        {
+          "name": "TZ",
+          "label": "TZ",
+          "default": "Europe/Amsterdam",
+          "description": "specify a timezone to use, see this [list](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List)."
+        },
+        {
+          "name": "DB_HOST",
+          "label": "DB_HOST",
+          "default": "<hostname or ip>",
+          "description": "Host address of mariadb database"
+        },
+        {
+          "name": "DB_PORT",
+          "label": "DB_PORT",
+          "default": "3306",
+          "description": "Port to access mariadb database default is 3306"
+        },
+        {
+          "name": "DB_USER",
+          "label": "DB_USER",
+          "default": "hedgedoc",
+          "description": "Database user"
+        },
+        {
+          "name": "DB_PASS",
+          "label": "DB_PASS",
+          "default": "<secret password>",
+          "description": "Database password"
+        },
+        {
+          "name": "DB_NAME",
+          "label": "DB_NAME",
+          "default": "hedgedoc",
+          "description": "Database name"
+        },
+        {
+          "name": "CMD_DOMAIN",
+          "label": "CMD_DOMAIN",
+          "default": "localhost",
+          "description": "The address the gui will be accessed at (ie. `192.168.1.1` or `hedgedoc.domain.com`)."
+        },
+        {
+          "name": "CMD_URL_ADDPORT",
+          "label": "CMD_URL_ADDPORT",
+          "default": "false",
+          "description": "Set to `true` if using a port other than `80` or `443`."
+        },
+        {
+          "name": "CMD_PROTOCOL_USESSL",
+          "label": "CMD_PROTOCOL_USESSL",
+          "default": "false",
+          "description": "Set to `true` if accessing over https via reverse proxy."
+        },
+        {
+          "name": "CMD_PORT",
+          "label": "CMD_PORT",
+          "default": "3000",
+          "description": "If you wish to access hedgedoc at a port different than 80, 443 or 3000, you need to set this to that port (ie. `CMD_PORT=5000`) and change the port mapping accordingly (5000:5000)."
+        },
+        {
+          "name": "CMD_ALLOW_ORIGIN",
+          "label": "CMD_ALLOW_ORIGIN",
+          "default": "['localhost']",
+          "description": "Comma-separated list of allowed hostnames"
+        },
+        {
+          "name": "CMD_DB_DIALECT",
+          "label": "CMD_DB_DIALECT",
+          "default": "",
+          "description": "This variable allows selecting a database engine (if DB_HOST not set up). Available options are: `mariadb`, `mysql`, `postgres`, `sqlite`."
+        }
+      ],
+      "ports": [
+        "3000:3000/tcp"
+      ],
+      "volumes": [
+        {
+          "container": "/config",
+          "bind": "/volume1/docker/hedgedoc/config"
+        }
+      ],
+      "restart_policy": "unless-stopped",
+      "maintainer": " https://github.com/technorabilia/portainer-templates/"
+    },
+    {
+      "id": 472,
+      "type": 1,
+      "title": "Hishtory-server",
+      "name": "Hishtory-server",
+      "note": "Portainer App Templates by <a href='https://www.technorabilia.com' target='_blank'>Technorabilia</a> based on data provided by <a href='https://www.linuxserver.io' target='_blank'>LinuxServer.io</a>.</p><p>Don't forget to create the volume directories on the host file system.</p><p>mkdir -p /volume1/docker/hishtory-server/config</p>",
+      "description": "[hiSHtory](https://github.com/ddworken/hishtory) is a better shell history. It stores your shell history in context (what directory you ran the command in, whether it succeeded or failed, how long it took, etc). This is all stored locally and end-to-end encrypted for syncing to to all your other computers.",
+      "platform": "linux",
+      "logo": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/hishtory-server-icon.png",
+      "image": "linuxserver/hishtory-server:latest",
+      "env": [
+        {
+          "name": "PUID",
+          "label": "PUID",
+          "default": "1024",
+          "description": "for UserID"
+        },
+        {
+          "name": "PGID",
+          "label": "PGID",
+          "default": "100",
+          "description": "for GroupID"
+        },
+        {
+          "name": "TZ",
+          "label": "TZ",
+          "default": "Europe/Amsterdam",
+          "description": "specify a timezone to use, see this [list](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List)."
+        },
+        {
+          "name": "HISHTORY_POSTGRES_DB",
+          "label": "HISHTORY_POSTGRES_DB",
+          "default": "postgresql://${HISHTORY_DB_USER}:${HISHTORY_DB_PASS}@hishtory-db:5432/hishtory?sslmode=disable",
+          "description": "Postgres DB [Connection URI](https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING). Special characters must be [URL encoded](https://en.wikipedia.org/wiki/URL_encoding)."
+        },
+        {
+          "name": "HISHTORY_SQLITE_DB",
+          "label": "HISHTORY_SQLITE_DB",
+          "default": "/config/hishtory.db",
+          "description": "SQLite database path. Needs to be a mounted volume for persistence. Don't set at the same time as HISHTORY_POSTGRES_DB."
+        }
+      ],
+      "ports": [
+        "8080:8080/tcp"
+      ],
+      "volumes": [
+        {
+          "container": "/config",
+          "bind": "/volume1/docker/hishtory-server/config"
+        }
+      ],
+      "restart_policy": "unless-stopped",
+      "maintainer": " https://github.com/technorabilia/portainer-templates/",
+      "categories": []
+    },
+    {
+      "id": 473,
+      "type": 1,
+      "title": "Inkscape",
+      "name": "Inkscape",
+      "note": "Portainer App Templates by <a href='https://www.technorabilia.com' target='_blank'>Technorabilia</a> based on data provided by <a href='https://www.linuxserver.io' target='_blank'>LinuxServer.io</a>.</p><p>Don't forget to create the volume directories on the host file system.</p><p>mkdir -p /volume1/docker/inkscape/config</p>",
+      "description": "[Inkscape](https://inkscape.org/) is professional quality vector graphics software which runs on Linux, Mac OS X and Windows desktop computers.",
+      "platform": "linux",
+      "logo": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/inkscape-logo.png",
+      "image": "linuxserver/inkscape:latest",
+      "env": [
+        {
+          "name": "PUID",
+          "label": "PUID",
+          "default": "1024",
+          "description": "for UserID"
+        },
+        {
+          "name": "PGID",
+          "label": "PGID",
+          "default": "100",
+          "description": "for GroupID"
+        },
+        {
+          "name": "TZ",
+          "label": "TZ",
+          "default": "Europe/Amsterdam",
+          "description": "specify a timezone to use, see this [list](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List)."
+        }
+      ],
+      "ports": [
+        "3000:3000/tcp",
+        "3001:3001/tcp"
+      ],
+      "volumes": [
+        {
+          "container": "/config",
+          "bind": "/volume1/docker/inkscape/config"
+        }
+      ],
+      "restart_policy": "unless-stopped",
+      "maintainer": " https://github.com/technorabilia/portainer-templates/",
+      "categories": []
+    },
+    {
+      "id": 474,
+      "type": 1,
+      "title": "Jenkins-builder",
+      "name": "Jenkins-builder",
+      "note": "Portainer App Templates by <a href='https://www.technorabilia.com' target='_blank'>Technorabilia</a> based on data provided by <a href='https://www.linuxserver.io' target='_blank'>LinuxServer.io</a>.</p><p>Don't forget to create the volume directories on the host file system.</p><p>mkdir -p /volume1/docker/jenkins-builder/config</p>",
+      "description": "# This container needs special attention. Please check https://hub.docker.com/r/linuxserver/jenkins-builder for details.",
+      "platform": "linux",
+      "logo": "",
+      "image": "linuxserver/jenkins-builder:latest",
+      "env": [
+        {
+          "name": "PUID",
+          "label": "PUID",
+          "default": "1024",
+          "description": "for UserID"
+        },
+        {
+          "name": "PGID",
+          "label": "PGID",
+          "default": "100",
+          "description": "for GroupID"
+        },
+        {
+          "name": "TZ",
+          "label": "TZ",
+          "default": "Europe/Amsterdam",
+          "description": "specify a timezone to use, see this [list](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List)."
+        }
+      ],
+      "ports": [
+        "80:80/tcp"
+      ],
+      "volumes": [
+        {
+          "container": "/config",
+          "bind": "/volume1/docker/jenkins-builder/config"
+        }
+      ],
+      "restart_policy": "unless-stopped",
+      "maintainer": " https://github.com/technorabilia/portainer-templates/",
+      "categories": []
+    },
+    {
+      "id": 475,
+      "type": 1,
+      "title": "Kali-linux",
+      "name": "Kali-linux",
+      "note": "Portainer App Templates by <a href='https://www.technorabilia.com' target='_blank'>Technorabilia</a> based on data provided by <a href='https://www.linuxserver.io' target='_blank'>LinuxServer.io</a>.</p><p>Don't forget to create the volume directories on the host file system.</p><p>mkdir -p /volume1/docker/kali-linux/config<br></p>",
+      "description": "[Kali-linux](https://github.com/linuxserver/docker-kali-linux) - is an Advanced Penetration Testing Linux distribution used for Penetration Testing, Ethical Hacking and network security assessments. KALI LINUX ™ is a trademark of OffSec.",
+      "platform": "linux",
+      "logo": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/kali-logo.png",
+      "image": "linuxserver/kali-linux:latest",
+      "env": [
+        {
+          "name": "PUID",
+          "label": "PUID",
+          "default": "1024",
+          "description": "for UserID"
+        },
+        {
+          "name": "PGID",
+          "label": "PGID",
+          "default": "100",
+          "description": "for GroupID"
+        },
+        {
+          "name": "TZ",
+          "label": "TZ",
+          "default": "Europe/Amsterdam",
+          "description": "specify a timezone to use, see this [list](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List)."
+        },
+        {
+          "name": "SUBFOLDER",
+          "label": "SUBFOLDER",
+          "default": "/",
+          "description": "Specify a subfolder to use with reverse proxies, IE `/subfolder/`"
+        },
+        {
+          "name": "TITLE",
+          "label": "TITLE",
+          "default": "Kali Linux",
+          "description": "String which will be used as page/tab title in the web browser."
+        }
+      ],
+      "ports": [
+        "3000:3000/tcp",
+        "3001:3001/tcp"
+      ],
+      "volumes": [
+        {
+          "container": "/config",
+          "bind": "/volume1/docker/kali-linux/config"
+        },
+        {
+          "container": "/var/run/docker.sock",
+          "bind": "/var/run/docker.sock"
+        }
+      ],
+      "restart_policy": "unless-stopped",
+      "maintainer": " https://github.com/technorabilia/portainer-templates/",
+      "categories": []
+    },
+    {
+      "id": 476,
+      "type": 1,
+      "title": "Kasm",
+      "name": "Kasm",
+      "note": "Portainer App Templates by <a href='https://www.technorabilia.com' target='_blank'>Technorabilia</a> based on data provided by <a href='https://www.linuxserver.io' target='_blank'>LinuxServer.io</a>.</p><p>Don't forget to create the volume directories on the host file system.</p><p>mkdir -p /volume1/docker/kasm/opt<br>mkdir -p /volume1/docker/kasm/profiles<br><br></p>",
+      "description": "[Kasm](https://www.kasmweb.com/?utm_campaign=LinuxServer&utm_source=listing) Workspaces is a docker container streaming platform for delivering browser-based access to desktops, applications, and web services. Kasm uses devops-enabled Containerized Desktop Infrastructure (CDI) to create on-demand, disposable, docker containers that are accessible via web browser. Example use-cases include Remote Browser Isolation (RBI), Data Loss Prevention (DLP), Desktop as a Service (DaaS), Secure Remote Access Services (RAS), and Open Source Intelligence (OSINT) collections. The rendering of the graphical-based containers is powered by the open-source project [KasmVNC](https://www.kasmweb.com/kasmvnc.html?utm_campaign=LinuxServer&utm_source=kasmvnc).",
+      "platform": "linux",
+      "logo": "https://kasm-ci.s3.amazonaws.com/kasm_wide.png",
+      "image": "linuxserver/kasm:latest",
+      "privileged": true,
+      "env": [
+        {
+          "name": "KASM_PORT",
+          "label": "KASM_PORT",
+          "default": "443",
+          "description": "Specify the port you bind to the outside for Kasm Workspaces."
+        },
+        {
+          "name": "DOCKER_HUB_USERNAME",
+          "label": "DOCKER_HUB_USERNAME",
+          "default": "USER",
+          "description": "Optionally specify a DockerHub Username to pull private images."
+        },
+        {
+          "name": "DOCKER_HUB_PASSWORD",
+          "label": "DOCKER_HUB_PASSWORD",
+          "default": "PASS",
+          "description": "Optionally specify a DockerHub password to pull private images."
+        },
+        {
+          "name": "DOCKER_MTU",
+          "label": "DOCKER_MTU",
+          "default": "1500",
+          "description": "Optionally specify the mtu options passed to dockerd."
+        }
+      ],
+      "ports": [
+        "3000:3000/tcp",
+        "443:443/tcp"
+      ],
+      "volumes": [
+        {
+          "container": "/opt",
+          "bind": "/volume1/docker/kasm/opt"
+        },
+        {
+          "container": "/profiles",
+          "bind": "/volume1/docker/kasm/profiles"
+        },
+        {
+          "container": "/dev/input",
+          "bind": "/dev/input"
+        },
+        {
+          "container": "/run/udev/data",
+          "bind": "/run/udev/data"
+        }
+      ],
+      "restart_policy": "unless-stopped",
+      "maintainer": " https://github.com/technorabilia/portainer-templates/",
+      "categories": []
+    },
+    {
+      "id": 477,
+      "type": 1,
+      "title": "Kdenlive",
+      "name": "Kdenlive",
+      "note": "Portainer App Templates by <a href='https://www.technorabilia.com' target='_blank'>Technorabilia</a> based on data provided by <a href='https://www.linuxserver.io' target='_blank'>LinuxServer.io</a>.</p><p>Don't forget to create the volume directories on the host file system.</p><p>mkdir -p /volume1/docker/kdenlive/config</p>",
+      "description": "[Kdenlive](https://kdenlive.org/) is a powerful free and open source cross-platform video editing program made by the KDE community. Feature rich and production ready.",
+      "platform": "linux",
+      "logo": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/kdenlive-logo.png",
+      "image": "linuxserver/kdenlive:latest",
+      "env": [
+        {
+          "name": "PUID",
+          "label": "PUID",
+          "default": "1024",
+          "description": "for UserID"
+        },
+        {
+          "name": "PGID",
+          "label": "PGID",
+          "default": "100",
+          "description": "for GroupID"
+        },
+        {
+          "name": "TZ",
+          "label": "TZ",
+          "default": "Europe/Amsterdam",
+          "description": "specify a timezone to use, see this [list](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List)."
+        },
+        {
+          "name": "SUBFOLDER",
+          "label": "SUBFOLDER",
+          "default": "/",
+          "description": "Specify a subfolder to use with reverse proxies, IE `/subfolder/`"
+        }
+      ],
+      "ports": [
+        "3000:3000/tcp",
+        "3001:3001/tcp"
+      ],
+      "volumes": [
+        {
+          "container": "/config",
+          "bind": "/volume1/docker/kdenlive/config"
+        }
+      ],
+      "restart_policy": "unless-stopped",
+      "maintainer": " https://github.com/technorabilia/portainer-templates/",
+      "categories": []
+    },
+    {
+      "id": 478,
+      "type": 1,
+      "title": "Keepassxc",
+      "name": "Keepassxc",
+      "note": "Portainer App Templates by <a href='https://www.technorabilia.com' target='_blank'>Technorabilia</a> based on data provided by <a href='https://www.linuxserver.io' target='_blank'>LinuxServer.io</a>.</p><p>Don't forget to create the volume directories on the host file system.</p><p>mkdir -p /volume1/docker/keepassxc/config</p>",
+      "description": "[KeePassXC](https://keepassxc.org/) is a free and open-source password manager. It started as a community fork of KeePassX (itself a cross-platform port of KeePass).",
+      "platform": "linux",
+      "logo": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/keepassxc-logo.png",
+      "image": "linuxserver/keepassxc:latest",
+      "env": [
+        {
+          "name": "PUID",
+          "label": "PUID",
+          "default": "1024",
+          "description": "for UserID"
+        },
+        {
+          "name": "PGID",
+          "label": "PGID",
+          "default": "100",
+          "description": "for GroupID"
+        },
+        {
+          "name": "TZ",
+          "label": "TZ",
+          "default": "Europe/Amsterdam",
+          "description": "specify a timezone to use, see this [list](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List)."
+        }
+      ],
+      "ports": [
+        "3000:3000/tcp",
+        "3001:3001/tcp"
+      ],
+      "volumes": [
+        {
+          "container": "/config",
+          "bind": "/volume1/docker/keepassxc/config"
+        }
+      ],
+      "restart_policy": "unless-stopped",
+      "maintainer": " https://github.com/technorabilia/portainer-templates/",
+      "categories": []
+    },
+    {
+      "id": 479,
+      "type": 1,
+      "title": "Kicad",
+      "name": "Kicad",
+      "note": "Portainer App Templates by <a href='https://www.technorabilia.com' target='_blank'>Technorabilia</a> based on data provided by <a href='https://www.linuxserver.io' target='_blank'>LinuxServer.io</a>.</p><p>Don't forget to create the volume directories on the host file system.</p><p>mkdir -p /volume1/docker/kicad/config</p>",
+      "description": "[KiCad](https://www.kicad.org/) - A Cross Platform and Open Source Electronics Design Automation Suite.",
+      "platform": "linux",
+      "logo": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/kicad-logo.png",
+      "image": "linuxserver/kicad:latest",
+      "env": [
+        {
+          "name": "PUID",
+          "label": "PUID",
+          "default": "1024",
+          "description": "for UserID"
+        },
+        {
+          "name": "PGID",
+          "label": "PGID",
+          "default": "100",
+          "description": "for GroupID"
+        },
+        {
+          "name": "TZ",
+          "label": "TZ",
+          "default": "Europe/Amsterdam",
+          "description": "specify a timezone to use, see this [list](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List)."
+        }
+      ],
+      "ports": [
+        "3000:3000/tcp",
+        "3001:3001/tcp"
+      ],
+      "volumes": [
+        {
+          "container": "/config",
+          "bind": "/volume1/docker/kicad/config"
+        }
+      ],
+      "restart_policy": "unless-stopped",
+      "maintainer": " https://github.com/technorabilia/portainer-templates/",
+      "categories": []
+    },
+    {
+      "id": 480,
+      "type": 1,
+      "title": "Kimai",
+      "name": "Kimai",
+      "note": "Portainer App Templates by <a href='https://www.technorabilia.com' target='_blank'>Technorabilia</a> based on data provided by <a href='https://www.linuxserver.io' target='_blank'>LinuxServer.io</a>.</p><p>Don't forget to create the volume directories on the host file system.</p><p>mkdir -p /volume1/docker/kimai/config</p>",
+      "description": "[Kimai](https://kimai.org/) is a professional grade time-tracking application, free and open-source. It handles use-cases of freelancers as well as companies with dozens or hundreds of users. Kimai was build to track your project times and ships with many advanced features, including but not limited to: JSON API, invoicing, data exports, multi-timer and punch-in punch-out mode, tagging, multi-user - multi-timezones - multi-language ([over 30 translations existing](https://hosted.weblate.org/projects/kimai/)!), authentication via SAML/LDAP/Database, two-factor authentication (2FA) with TOTP, customizable role and team permissions, responsive design, user/customer/project specific rates, advanced search & filtering, money and time budgets, advanced reporting, support for [plugins](https://www.kimai.org/store/) and so much more.",
+      "platform": "linux",
+      "logo": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/kimai-logo.png",
+      "image": "linuxserver/kimai:latest",
+      "env": [
+        {
+          "name": "PUID",
+          "label": "PUID",
+          "default": "1024",
+          "description": "for UserID"
+        },
+        {
+          "name": "PGID",
+          "label": "PGID",
+          "default": "100",
+          "description": "for GroupID"
+        },
+        {
+          "name": "TZ",
+          "label": "TZ",
+          "default": "Europe/Amsterdam",
+          "description": "specify a timezone to use, see this [list](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List)."
+        },
+        {
+          "name": "DATABASE_URL",
+          "label": "DATABASE_URL",
+          "default": "mysql://your_db_user:your_db_pass@your_db_host:3306/your_db_name?charset=your_db_charset&serverVersion=your_db_version",
+          "description": "Configure your database connection, see Application Setup instructions."
+        }
+      ],
+      "ports": [
+        "80:80/tcp",
+        "443:443/tcp"
+      ],
+      "volumes": [
+        {
+          "container": "/config",
+          "bind": "/volume1/docker/kimai/config"
+        }
+      ],
+      "restart_policy": "unless-stopped",
+      "maintainer": " https://github.com/technorabilia/portainer-templates/",
+      "categories": []
+    },
+    {
+      "id": 481,
+      "type": 1,
+      "title": "Kometa",
+      "name": "Kometa",
+      "note": "Portainer App Templates by <a href='https://www.technorabilia.com' target='_blank'>Technorabilia</a> based on data provided by <a href='https://www.linuxserver.io' target='_blank'>LinuxServer.io</a>.</p><p>Don't forget to create the volume directories on the host file system.</p><p>mkdir -p /volume1/docker/kometa/config</p>",
+      "description": "[Kometa](https://github.com/Kometa-Team/Kometa) is a powerful tool designed to give you complete control over your media libraries. With Kometa, you can take your customization to the next level, with granular control over metadata, collections, overlays, and much more.",
+      "platform": "linux",
+      "logo": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/kometa-banner.png",
+      "image": "linuxserver/kometa:latest",
+      "env": [
+        {
+          "name": "PUID",
+          "label": "PUID",
+          "default": "1024",
+          "description": "for UserID"
+        },
+        {
+          "name": "PGID",
+          "label": "PGID",
+          "default": "100",
+          "description": "for GroupID"
+        },
+        {
+          "name": "TZ",
+          "label": "TZ",
+          "default": "Europe/Amsterdam",
+          "description": "specify a timezone to use, see this [list](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List)."
+        },
+        {
+          "name": "KOMETA_CONFIG",
+          "label": "KOMETA_CONFIG",
+          "default": "/config/config.yml",
+          "description": "Specify a custom config file to use."
+        },
+        {
+          "name": "KOMETA_TIME",
+          "label": "KOMETA_TIME",
+          "default": "03:00",
+          "description": "Comma-separated list of times to update each day. Format: `HH:MM`."
+        },
+        {
+          "name": "KOMETA_RUN",
+          "label": "KOMETA_RUN",
+          "default": "False",
+          "description": "Set to `True` to run without the scheduler."
+        },
+        {
+          "name": "KOMETA_TEST",
+          "label": "KOMETA_TEST",
+          "default": "False",
+          "description": "Set to `True` to run in debug mode with only collections that have `test: true`."
+        },
+        {
+          "name": "KOMETA_NO_MISSING",
+          "label": "KOMETA_NO_MISSING",
+          "default": "False",
+          "description": "Set to `True` to run without any of the missing movie/show functions."
+        }
+      ],
+      "ports": [
+        "80:80/tcp"
+      ],
+      "volumes": [
+        {
+          "container": "/config",
+          "bind": "/volume1/docker/kometa/config"
+        }
+      ],
+      "restart_policy": "unless-stopped",
+      "maintainer": " https://github.com/technorabilia/portainer-templates/",
+      "categories": []
+    },
+    {
+      "id": 482,
+      "type": 1,
+      "title": "Krita",
+      "name": "Krita",
+      "note": "Portainer App Templates by <a href='https://www.technorabilia.com' target='_blank'>Technorabilia</a> based on data provided by <a href='https://www.linuxserver.io' target='_blank'>LinuxServer.io</a>.</p><p>Don't forget to create the volume directories on the host file system.</p><p>mkdir -p /volume1/docker/krita/config</p>",
+      "description": "[Krita](https://krita.org/en/) is a professional FREE and open source painting program. It is made by artists that want to see affordable art tools for everyone.",
+      "platform": "linux",
+      "logo": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/krita-logo.png",
+      "image": "linuxserver/krita:latest",
+      "env": [
+        {
+          "name": "PUID",
+          "label": "PUID",
+          "default": "1024",
+          "description": "for UserID"
+        },
+        {
+          "name": "PGID",
+          "label": "PGID",
+          "default": "100",
+          "description": "for GroupID"
+        },
+        {
+          "name": "TZ",
+          "label": "TZ",
+          "default": "Europe/Amsterdam",
+          "description": "specify a timezone to use, see this [list](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List)."
+        }
+      ],
+      "ports": [
+        "3000:3000/tcp",
+        "3001:3001/tcp"
+      ],
+      "volumes": [
+        {
+          "container": "/config",
+          "bind": "/volume1/docker/krita/config"
+        }
+      ],
+      "restart_policy": "unless-stopped",
+      "maintainer": " https://github.com/technorabilia/portainer-templates/",
+      "categories": []
+    },
+    {
+      "id": 483,
+      "type": 1,
+      "title": "Librewolf",
+      "name": "Librewolf",
+      "note": "Portainer App Templates by <a href='https://www.technorabilia.com' target='_blank'>Technorabilia</a> based on data provided by <a href='https://www.linuxserver.io' target='_blank'>LinuxServer.io</a>.</p><p>Don't forget to create the volume directories on the host file system.</p><p>mkdir -p /volume1/docker/librewolf/config</p>",
+      "description": "[LibreWolf](https://librewolf.net/) is a custom and independent version of Firefox, with the primary goals of privacy, security and user freedom. LibreWolf also aims to remove all the telemetry, data collection and annoyances, as well as disabling anti-freedom features like DRM.",
+      "platform": "linux",
+      "logo": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/librewolf-logo.png",
+      "image": "linuxserver/librewolf:latest",
+      "env": [
+        {
+          "name": "PUID",
+          "label": "PUID",
+          "default": "1024",
+          "description": "for UserID"
+        },
+        {
+          "name": "PGID",
+          "label": "PGID",
+          "default": "100",
+          "description": "for GroupID"
+        },
+        {
+          "name": "TZ",
+          "label": "TZ",
+          "default": "Europe/Amsterdam",
+          "description": "specify a timezone to use, see this [list](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List)."
+        },
+        {
+          "name": "LIBREWOLF_CLI",
+          "label": "LIBREWOLF_CLI",
+          "default": "https://www.linuxserver.io/",
+          "description": "Specify one or multiple LibreWolf CLI flags, this string will be passed to the application in full."
+        }
+      ],
+      "ports": [
+        "3000:3000/tcp",
+        "3001:3001/tcp"
+      ],
+      "volumes": [
+        {
+          "container": "/config",
+          "bind": "/volume1/docker/librewolf/config"
+        }
+      ],
+      "restart_policy": "unless-stopped",
+      "maintainer": " https://github.com/technorabilia/portainer-templates/",
+      "categories": []
+    },
+    {
+      "id": 484,
+      "type": 1,
+      "title": "Lollypop",
+      "name": "Lollypop",
+      "note": "Portainer App Templates by <a href='https://www.technorabilia.com' target='_blank'>Technorabilia</a> based on data provided by <a href='https://www.linuxserver.io' target='_blank'>LinuxServer.io</a>.</p><p>Don't forget to create the volume directories on the host file system.</p><p>mkdir -p /volume1/docker/lollypop/config</p>",
+      "description": "[Lollypop](https://wiki.gnome.org/Apps/Lollypop) is a lightweight modern music player designed to work excellently on the GNOME desktop environment.",
+      "platform": "linux",
+      "logo": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/lollypop-icon.png",
+      "image": "linuxserver/lollypop:latest",
+      "env": [
+        {
+          "name": "PUID",
+          "label": "PUID",
+          "default": "1024",
+          "description": "for UserID"
+        },
+        {
+          "name": "PGID",
+          "label": "PGID",
+          "default": "100",
+          "description": "for GroupID"
+        },
+        {
+          "name": "TZ",
+          "label": "TZ",
+          "default": "Europe/Amsterdam",
+          "description": "specify a timezone to use, see this [list](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List)."
+        }
+      ],
+      "ports": [
+        "3000:3000/tcp",
+        "3001:3001/tcp"
+      ],
+      "volumes": [
+        {
+          "container": "/config",
+          "bind": "/volume1/docker/lollypop/config"
+        }
+      ],
+      "restart_policy": "unless-stopped",
+      "maintainer": " https://github.com/technorabilia/portainer-templates/",
+      "categories": []
+    },
+    {
+      "id": 485,
+      "type": 1,
+      "title": "Manyfold",
+      "name": "Manyfold",
+      "note": "Portainer App Templates by <a href='https://www.technorabilia.com' target='_blank'>Technorabilia</a> based on data provided by <a href='https://www.linuxserver.io' target='_blank'>LinuxServer.io</a>.</p><p>Don't forget to create the volume directories on the host file system.</p><p>mkdir -p /volume1/docker/manyfold/config<br>mkdir -p /volume1/docker/manyfold/libraries</p>",
+      "description": "[Manyfold](https://github.com/manyfold3d/manyfold/) is an open source, self-hosted web application for managing a collection of 3D models, particularly focused on 3D printing.",
+      "platform": "linux",
+      "logo": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/manyfold-logo.png",
+      "image": "linuxserver/manyfold:latest",
+      "env": [
+        {
+          "name": "PUID",
+          "label": "PUID",
+          "default": "1024",
+          "description": "for UserID"
+        },
+        {
+          "name": "PGID",
+          "label": "PGID",
+          "default": "100",
+          "description": "for GroupID"
+        },
+        {
+          "name": "TZ",
+          "label": "TZ",
+          "default": "Europe/Amsterdam",
+          "description": "specify a timezone to use, see this [list](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List)."
+        },
+        {
+          "name": "DATABASE_URL",
+          "label": "DATABASE_URL",
+          "default": "",
+          "description": "Database connection URL. For sqlite use `sqlite3:/config/manyfold.sqlite3`. For postgres or mariadb use `<scheme>://<username>:<password>@<hostname>:<port>/<db name>` where `<scheme>` is `postgresql` or `mysql2`. Special characters in username/password must be [URL encoded](https://en.wikipedia.org/wiki/Percent-encoding)."
+        },
+        {
+          "name": "REDIS_URL",
+          "label": "REDIS_URL",
+          "default": "",
+          "description": "Redis/Valkey database URL in `redis://<hostname>:<port>/<db number>` format."
+        },
+        {
+          "name": "SECRET_KEY_BASE",
+          "label": "SECRET_KEY_BASE",
+          "default": "",
+          "description": "Browser session secret. Changing it will terminate all active browser sessions."
+        }
+      ],
+      "ports": [
+        "3214:3214/tcp"
+      ],
+      "volumes": [
+        {
+          "container": "/config",
+          "bind": "/volume1/docker/manyfold/config"
+        },
+        {
+          "container": "/libraries",
+          "bind": "/volume1/docker/manyfold/libraries"
+        }
+      ],
+      "restart_policy": "unless-stopped",
+      "maintainer": " https://github.com/technorabilia/portainer-templates/",
+      "categories": []
+    },
+    {
+      "id": 486,
+      "type": 1,
+      "title": "Mediaelch",
+      "name": "Mediaelch",
+      "note": "Portainer App Templates by <a href='https://www.technorabilia.com' target='_blank'>Technorabilia</a> based on data provided by <a href='https://www.linuxserver.io' target='_blank'>LinuxServer.io</a>.</p><p>Don't forget to create the volume directories on the host file system.</p><p>mkdir -p /volume1/docker/mediaelch/config</p>",
+      "description": "[MediaElch](https://github.com/Komet/MediaElch) is a MediaManager for Kodi. Information about Movies, TV Shows, Concerts and Music are stored as nfo files. Fanarts are downloaded automatically from fanart.tv. Using the nfo generator, MediaElch can be used with other MediaCenters as well.",
+      "platform": "linux",
+      "logo": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/mediaelch-logo.png",
+      "image": "linuxserver/mediaelch:latest",
+      "env": [
+        {
+          "name": "PUID",
+          "label": "PUID",
+          "default": "1024",
+          "description": "for UserID"
+        },
+        {
+          "name": "PGID",
+          "label": "PGID",
+          "default": "100",
+          "description": "for GroupID"
+        },
+        {
+          "name": "TZ",
+          "label": "TZ",
+          "default": "Europe/Amsterdam",
+          "description": "specify a timezone to use, see this [list](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List)."
+        }
+      ],
+      "ports": [
+        "3000:3000/tcp",
+        "3001:3001/tcp"
+      ],
+      "volumes": [
+        {
+          "container": "/config",
+          "bind": "/volume1/docker/mediaelch/config"
+        }
+      ],
+      "restart_policy": "unless-stopped",
+      "maintainer": " https://github.com/technorabilia/portainer-templates/",
+      "categories": []
+    },
+    {
+      "id": 487,
+      "type": 1,
+      "title": "Msedge",
+      "name": "Msedge",
+      "note": "Portainer App Templates by <a href='https://www.technorabilia.com' target='_blank'>Technorabilia</a> based on data provided by <a href='https://www.linuxserver.io' target='_blank'>LinuxServer.io</a>.</p><p>Don't forget to create the volume directories on the host file system.</p><p>mkdir -p /volume1/docker/msedge/config</p>",
+      "description": "[Microsoft Edge](https://www.microsoft.com/edge) is a cross-platform web browser developed by Microsoft and based on Chromium.",
+      "platform": "linux",
+      "logo": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/edge-logo.png",
+      "image": "linuxserver/msedge:latest",
+      "env": [
+        {
+          "name": "PUID",
+          "label": "PUID",
+          "default": "1024",
+          "description": "for UserID"
+        },
+        {
+          "name": "PGID",
+          "label": "PGID",
+          "default": "100",
+          "description": "for GroupID"
+        },
+        {
+          "name": "TZ",
+          "label": "TZ",
+          "default": "Europe/Amsterdam",
+          "description": "specify a timezone to use, see this [list](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List)."
+        },
+        {
+          "name": "EDGE_CLI",
+          "label": "EDGE_CLI",
+          "default": "https://www.linuxserver.io/",
+          "description": "Specify one or multiple Chromium CLI flags, this string will be passed to the application in full."
+        }
+      ],
+      "ports": [
+        "3000:3000/tcp",
+        "3001:3001/tcp"
+      ],
+      "volumes": [
+        {
+          "container": "/config",
+          "bind": "/volume1/docker/msedge/config"
+        }
+      ],
+      "restart_policy": "unless-stopped",
+      "maintainer": " https://github.com/technorabilia/portainer-templates/",
+      "categories": []
+    },
+    {
+      "id": 488,
+      "type": 1,
+      "title": "Mullvad-browser",
+      "name": "Mullvad-browser",
+      "note": "Portainer App Templates by <a href='https://www.technorabilia.com' target='_blank'>Technorabilia</a> based on data provided by <a href='https://www.linuxserver.io' target='_blank'>LinuxServer.io</a>.</p><p>Don't forget to create the volume directories on the host file system.</p><p>mkdir -p /volume1/docker/mullvad-browser/config</p>",
+      "description": "The [Mullvad Browser](https://mullvad.net/en/browser) is a privacy-focused web browser developed in a collaboration between Mullvad VPN and the Tor Project. It’s designed to minimize tracking and fingerprinting. You could say it’s a Tor Browser to use without the Tor Network. Instead, you can use it with a trustworthy VPN.",
+      "platform": "linux",
+      "logo": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/mullvad-browser-logo.png",
+      "image": "linuxserver/mullvad-browser:latest",
+      "env": [
+        {
+          "name": "PUID",
+          "label": "PUID",
+          "default": "1024",
+          "description": "for UserID"
+        },
+        {
+          "name": "PGID",
+          "label": "PGID",
+          "default": "100",
+          "description": "for GroupID"
+        },
+        {
+          "name": "TZ",
+          "label": "TZ",
+          "default": "Europe/Amsterdam",
+          "description": "specify a timezone to use, see this [list](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List)."
+        },
+        {
+          "name": "LOCAL_NET",
+          "label": "LOCAL_NET",
+          "default": "192.168.0.0/16",
+          "description": "If using a VPN, set this to your local LAN IP range using CIDR notation. Without it you will be unable to access the web interface. If you have multiple ranges or a complex LAN setup you will need to manage this yourself in the wg0.conf, see the App Setup section for details."
+        }
+      ],
+      "ports": [
+        "3000:3000/tcp",
+        "3001:3001/tcp"
+      ],
+      "volumes": [
+        {
+          "container": "/config",
+          "bind": "/volume1/docker/mullvad-browser/config"
+        }
+      ],
+      "restart_policy": "unless-stopped",
+      "maintainer": " https://github.com/technorabilia/portainer-templates/",
+      "categories": []
+    },
+    {
+      "id": 489,
+      "type": 1,
+      "title": "Mylar3",
+      "name": "Mylar3",
+      "note": "Portainer App Templates by <a href='https://www.technorabilia.com' target='_blank'>Technorabilia</a> based on data provided by <a href='https://www.linuxserver.io' target='_blank'>LinuxServer.io</a>.</p><p>Don't forget to create the volume directories on the host file system.</p><p>mkdir -p /volume1/docker/mylar3/config<br>mkdir -p /volume1/docker/mylar3/comics<br>mkdir -p /volume1/docker/mylar3/downloads</p>",
+      "description": "[Mylar3](https://github.com/mylar3/mylar3) is an automated Comic Book downloader (cbr/cbz) for use with NZB and torrents written in python. It supports SABnzbd, NZBGET, and many torrent clients in addition to DDL.",
+      "platform": "linux",
+      "logo": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/mylar-icon.png",
+      "image": "linuxserver/mylar3:latest",
+      "env": [
+        {
+          "name": "PUID",
+          "label": "PUID",
+          "default": "1024",
+          "description": "for UserID"
+        },
+        {
+          "name": "PGID",
+          "label": "PGID",
+          "default": "100",
+          "description": "for GroupID"
+        },
+        {
+          "name": "TZ",
+          "label": "TZ",
+          "default": "Europe/Amsterdam",
+          "description": "specify a timezone to use, see this [list](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List)."
+        }
+      ],
+      "ports": [
+        "8090:8090/tcp"
+      ],
+      "volumes": [
+        {
+          "container": "/config",
+          "bind": "/volume1/docker/mylar3/config"
+        },
+        {
+          "container": "/comics",
+          "bind": "/volume1/docker/mylar3/comics"
+        },
+        {
+          "container": "/downloads",
+          "bind": "/volume1/docker/mylar3/downloads"
+        }
+      ],
+      "restart_policy": "unless-stopped",
+      "maintainer": " https://github.com/technorabilia/portainer-templates/",
+      "categories": []
+    },
+    {
+      "id": 490,
+      "type": 1,
+      "title": "Mysql-workbench",
+      "name": "Mysql-workbench",
+      "note": "Portainer App Templates by <a href='https://www.technorabilia.com' target='_blank'>Technorabilia</a> based on data provided by <a href='https://www.linuxserver.io' target='_blank'>LinuxServer.io</a>.</p><p>Don't forget to create the volume directories on the host file system.</p><p>mkdir -p /volume1/docker/mysql-workbench/config</p>",
+      "description": "[MySQL Workbench](https://www.mysql.com/products/workbench/) is a unified visual tool for database architects, developers, and DBAs. MySQL Workbench provides data modeling, SQL development, and comprehensive administration tools for server configuration, user administration, backup, and much more.",
+      "platform": "linux",
+      "logo": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/mysql-workbench-icon.png",
+      "image": "linuxserver/mysql-workbench:latest",
+      "env": [
+        {
+          "name": "PUID",
+          "label": "PUID",
+          "default": "1024",
+          "description": "for UserID"
+        },
+        {
+          "name": "PGID",
+          "label": "PGID",
+          "default": "100",
+          "description": "for GroupID"
+        },
+        {
+          "name": "TZ",
+          "label": "TZ",
+          "default": "Europe/Amsterdam",
+          "description": "specify a timezone to use, see this [list](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List)."
+        }
+      ],
+      "ports": [
+        "3000:3000/tcp",
+        "3001:3001/tcp"
+      ],
+      "volumes": [
+        {
+          "container": "/config",
+          "bind": "/volume1/docker/mysql-workbench/config"
+        }
+      ],
+      "restart_policy": "unless-stopped",
+      "maintainer": " https://github.com/technorabilia/portainer-templates/",
+      "categories": []
+    },
+    {
+      "id": 491,
+      "type": 1,
+      "title": "Ngircd",
+      "name": "Ngircd",
+      "note": "Portainer App Templates by <a href='https://www.technorabilia.com' target='_blank'>Technorabilia</a> based on data provided by <a href='https://www.linuxserver.io' target='_blank'>LinuxServer.io</a>.</p><p>Don't forget to create the volume directories on the host file system.</p><p>mkdir -p /volume1/docker/ngircd/config</p>",
+      "description": "[Ngircd](https://ngircd.barton.de/) is a free, portable and lightweight Internet Relay Chat server for small or private networks, developed under the GNU General Public License (GPL). It is easy to configure, can cope with dynamic IP addresses, and supports IPv6, SSL-protected connections as well as PAM for authentication. It is written from scratch and not based on the original IRCd.",
+      "platform": "linux",
+      "logo": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/ngircd-logo.png",
+      "image": "linuxserver/ngircd:latest",
+      "env": [
+        {
+          "name": "PUID",
+          "label": "PUID",
+          "default": "1024",
+          "description": "for UserID"
+        },
+        {
+          "name": "PGID",
+          "label": "PGID",
+          "default": "100",
+          "description": "for GroupID"
+        },
+        {
+          "name": "TZ",
+          "label": "TZ",
+          "default": "Europe/Amsterdam",
+          "description": "specify a timezone to use, see this [list](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List)."
+        }
+      ],
+      "ports": [
+        "6667:6667/tcp"
+      ],
+      "volumes": [
+        {
+          "container": "/config",
+          "bind": "/volume1/docker/ngircd/config"
+        }
+      ],
+      "restart_policy": "unless-stopped",
+      "maintainer": " https://github.com/technorabilia/portainer-templates/",
+      "categories": []
+    },
+    {
+      "id": 492,
+      "type": 1,
+      "title": "Obsidian",
+      "name": "Obsidian",
+      "note": "Portainer App Templates by <a href='https://www.technorabilia.com' target='_blank'>Technorabilia</a> based on data provided by <a href='https://www.linuxserver.io' target='_blank'>LinuxServer.io</a>.</p><p>Don't forget to create the volume directories on the host file system.</p><p>mkdir -p /volume1/docker/obsidian/config</p>",
+      "description": "[Obsidian](https://obsidian.md) is a note-taking app that lets you create, link, and organize your notes on your device, with hundreds of plugins and themes to customize your workflow. You can also publish your notes online, access them offline, and sync them securely with end-to-end encryption.",
+      "platform": "linux",
+      "logo": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/obsidian-logo.png",
+      "image": "linuxserver/obsidian:latest",
+      "env": [
+        {
+          "name": "PUID",
+          "label": "PUID",
+          "default": "1024",
+          "description": "for UserID"
+        },
+        {
+          "name": "PGID",
+          "label": "PGID",
+          "default": "100",
+          "description": "for GroupID"
+        },
+        {
+          "name": "TZ",
+          "label": "TZ",
+          "default": "Europe/Amsterdam",
+          "description": "specify a timezone to use, see this [list](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List)."
+        }
+      ],
+      "ports": [
+        "3000:3000/tcp",
+        "3001:3001/tcp"
+      ],
+      "volumes": [
+        {
+          "container": "/config",
+          "bind": "/volume1/docker/obsidian/config"
+        }
+      ],
+      "restart_policy": "unless-stopped",
+      "maintainer": " https://github.com/technorabilia/portainer-templates/",
+      "categories": []
+    },
+    {
+      "id": 493,
+      "type": 1,
+      "title": "Openvscode-server",
+      "name": "Openvscode-server",
+      "note": "Portainer App Templates by <a href='https://www.technorabilia.com' target='_blank'>Technorabilia</a> based on data provided by <a href='https://www.linuxserver.io' target='_blank'>LinuxServer.io</a>.</p><p>Don't forget to create the volume directories on the host file system.</p><p>mkdir -p /volume1/docker/openvscode-server/config</p>",
+      "description": "[Openvscode-server](https://github.com/gitpod-io/openvscode-server) provides a version of VS Code that runs a server on a remote machine and allows access through a modern web browser.",
+      "platform": "linux",
+      "logo": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/openvscode-server-logo.png",
+      "image": "linuxserver/openvscode-server:latest",
+      "env": [
+        {
+          "name": "PUID",
+          "label": "PUID",
+          "default": "1024",
+          "description": "for UserID"
+        },
+        {
+          "name": "PGID",
+          "label": "PGID",
+          "default": "100",
+          "description": "for GroupID"
+        },
+        {
+          "name": "TZ",
+          "label": "TZ",
+          "default": "Europe/Amsterdam",
+          "description": "specify a timezone to use, see this [list](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List)."
+        },
+        {
+          "name": "CONNECTION_TOKEN",
+          "label": "CONNECTION_TOKEN",
+          "default": "",
+          "description": "Optional security token for accessing the Web UI (ie. `supersecrettoken`)."
+        },
+        {
+          "name": "CONNECTION_SECRET",
+          "label": "CONNECTION_SECRET",
+          "default": "",
+          "description": "Optional path to a file inside the container that contains the security token for accessing the Web UI (ie. `/path/to/file`). Overrides `CONNECTION_TOKEN`."
+        },
+        {
+          "name": "SUDO_PASSWORD",
+          "label": "SUDO_PASSWORD",
+          "default": "password",
+          "description": "If this optional variable is set, user will have sudo access in the openvscode-server terminal with the specified password."
+        },
+        {
+          "name": "SUDO_PASSWORD_HASH",
+          "label": "SUDO_PASSWORD_HASH",
+          "default": "",
+          "description": "Optionally set sudo password via hash (takes priority over `SUDO_PASSWORD` var). Format is `$type$salt$hashed`."
+        }
+      ],
+      "ports": [
+        "3000:3000/tcp"
+      ],
+      "volumes": [
+        {
+          "container": "/config",
+          "bind": "/volume1/docker/openvscode-server/config"
+        }
+      ],
+      "restart_policy": "unless-stopped",
+      "maintainer": " https://github.com/technorabilia/portainer-templates/",
+      "categories": []
+    },
+    {
+      "id": 494,
+      "type": 1,
+      "title": "Opera",
+      "name": "Opera",
+      "note": "Portainer App Templates by <a href='https://www.technorabilia.com' target='_blank'>Technorabilia</a> based on data provided by <a href='https://www.linuxserver.io' target='_blank'>LinuxServer.io</a>.</p><p>Don't forget to create the volume directories on the host file system.</p><p>mkdir -p /volume1/docker/opera/config</p>",
+      "description": "[Opera](https://www.opera.com/) is a multi-platform web browser developed by its namesake company Opera. The browser is based on Chromium, but distinguishes itself from other Chromium-based browsers (Chrome, Edge, etc.) through its user interface and other features.",
+      "platform": "linux",
+      "logo": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/opera-icon.png",
+      "image": "linuxserver/opera:latest",
+      "env": [
+        {
+          "name": "PUID",
+          "label": "PUID",
+          "default": "1024",
+          "description": "for UserID"
+        },
+        {
+          "name": "PGID",
+          "label": "PGID",
+          "default": "100",
+          "description": "for GroupID"
+        },
+        {
+          "name": "TZ",
+          "label": "TZ",
+          "default": "Europe/Amsterdam",
+          "description": "specify a timezone to use, see this [list](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List)."
+        },
+        {
+          "name": "OPERA_CLI",
+          "label": "OPERA_CLI",
+          "default": "https://www.linuxserver.io/",
+          "description": "Specify one or multiple Chromium CLI flags, this string will be passed to the application in full."
+        }
+      ],
+      "ports": [
+        "3000:3000/tcp",
+        "3001:3001/tcp"
+      ],
+      "volumes": [
+        {
+          "container": "/config",
+          "bind": "/volume1/docker/opera/config"
+        }
+      ],
+      "restart_policy": "unless-stopped",
+      "maintainer": " https://github.com/technorabilia/portainer-templates/",
+      "categories": []
+    },
+    {
+      "id": 495,
+      "type": 1,
+      "title": "Orcaslicer",
+      "name": "Orcaslicer",
+      "note": "Portainer App Templates by <a href='https://www.technorabilia.com' target='_blank'>Technorabilia</a> based on data provided by <a href='https://www.linuxserver.io' target='_blank'>LinuxServer.io</a>.</p><p>Don't forget to create the volume directories on the host file system.</p><p>mkdir -p /volume1/docker/orcaslicer/config</p>",
+      "description": "[Orca Slicer](https://github.com/SoftFever/OrcaSlicer) is an open source slicer for FDM printers. OrcaSlicer is fork of Bambu Studio, it was previously known as BambuStudio-SoftFever, Bambu Studio is forked from PrusaSlicer by Prusa Research, which is from Slic3r by Alessandro Ranellucci and the RepRap community",
+      "platform": "linux",
+      "logo": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/orcaslicer-logo.png",
+      "image": "linuxserver/orcaslicer:latest",
+      "env": [
+        {
+          "name": "PUID",
+          "label": "PUID",
+          "default": "1024",
+          "description": "for UserID"
+        },
+        {
+          "name": "PGID",
+          "label": "PGID",
+          "default": "100",
+          "description": "for GroupID"
+        },
+        {
+          "name": "TZ",
+          "label": "TZ",
+          "default": "Europe/Amsterdam",
+          "description": "specify a timezone to use, see this [list](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List)."
+        }
+      ],
+      "ports": [
+        "3000:3000/tcp",
+        "3001:3001/tcp"
+      ],
+      "volumes": [
+        {
+          "container": "/config",
+          "bind": "/volume1/docker/orcaslicer/config"
+        }
+      ],
+      "restart_policy": "unless-stopped",
+      "maintainer": " https://github.com/technorabilia/portainer-templates/",
+      "categories": []
+    },
+    {
+      "id": 496,
+      "type": 1,
+      "title": "Pairdrop",
+      "name": "Pairdrop",
+      "note": "Portainer App Templates by <a href='https://www.technorabilia.com' target='_blank'>Technorabilia</a> based on data provided by <a href='https://www.linuxserver.io' target='_blank'>LinuxServer.io</a>.</p><p>Don't forget to create the volume directories on the host file system.</p><p>mkdir -p /volume1/docker/pairdrop/config</p>",
+      "description": "[PairDrop](https://github.com/schlagmichdoch/PairDrop) is a sublime alternative to AirDrop that works on all platforms. Send images, documents or text via peer to peer connection to devices in the same local network/Wi-Fi or to paired devices.",
+      "platform": "linux",
+      "logo": "https://raw.githubusercontent.com/schlagmichdoch/PairDrop/master/public/images/android-chrome-512x512.png",
+      "image": "linuxserver/pairdrop:latest",
+      "env": [
+        {
+          "name": "PUID",
+          "label": "PUID",
+          "default": "1024",
+          "description": "for UserID"
+        },
+        {
+          "name": "PGID",
+          "label": "PGID",
+          "default": "100",
+          "description": "for GroupID"
+        },
+        {
+          "name": "TZ",
+          "label": "TZ",
+          "default": "Europe/Amsterdam",
+          "description": "specify a timezone to use, see this [list](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List)."
+        },
+        {
+          "name": "RATE_LIMIT",
+          "label": "RATE_LIMIT",
+          "default": "false",
+          "description": "Set to `true` to limit clients to 100 requests per 5 min"
+        },
+        {
+          "name": "WS_FALLBACK",
+          "label": "WS_FALLBACK",
+          "default": "false",
+          "description": "Set to `true` to enable websocket fallback if the peer to peer WebRTC connection is not available to the client (see App Setup notes)."
+        },
+        {
+          "name": "RTC_CONFIG",
+          "label": "RTC_CONFIG",
+          "default": "",
+          "description": "Path to a json file containing custom STUN/TURN config (see App Setup notes)"
+        },
+        {
+          "name": "DEBUG_MODE",
+          "label": "DEBUG_MODE",
+          "default": "false",
+          "description": "Set to `true` to debug the http server configuration by logging clients IP addresses used by PairDrop to STDOUT. [See here for more info](https://github.com/schlagmichdoch/PairDrop/blob/master/docs/host-your-own.md#debug-mode). Do not use in production!"
+        }
+      ],
+      "ports": [
+        "3000:3000/tcp"
+      ],
+      "volumes": [
+        {
+          "container": "/config",
+          "bind": "/volume1/docker/pairdrop/config"
+        }
+      ],
+      "restart_policy": "unless-stopped",
+      "maintainer": " https://github.com/technorabilia/portainer-templates/",
+      "categories": []
+    },
+    {
+      "id": 497,
+      "type": 1,
+      "title": "Piper",
+      "name": "Piper",
+      "note": "Portainer App Templates by <a href='https://www.technorabilia.com' target='_blank'>Technorabilia</a> based on data provided by <a href='https://www.linuxserver.io' target='_blank'>LinuxServer.io</a>.</p><p>Don't forget to create the volume directories on the host file system.</p><p>mkdir -p /volume1/docker/piper/config</p>",
+      "description": "[Piper](https://github.com/rhasspy/piper/) is a fast, local neural text to speech system that sounds great and is optimized for the Raspberry Pi 4. This container provides a Wyoming protocol server for Piper.",
+      "platform": "linux",
+      "logo": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/piper-logo.png",
+      "image": "linuxserver/piper:latest",
+      "env": [
+        {
+          "name": "PUID",
+          "label": "PUID",
+          "default": "1024",
+          "description": "for UserID"
+        },
+        {
+          "name": "PGID",
+          "label": "PGID",
+          "default": "100",
+          "description": "for GroupID"
+        },
+        {
+          "name": "TZ",
+          "label": "TZ",
+          "default": "Europe/Amsterdam",
+          "description": "specify a timezone to use, see this [list](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List)."
+        },
+        {
+          "name": "PIPER_VOICE",
+          "label": "PIPER_VOICE",
+          "default": "en_US-lessac-medium",
+          "description": "The [Piper voice](https://huggingface.co/rhasspy/piper-voices/tree/main) to use, in the format `<language>-<name>-<quality>`"
+        },
+        {
+          "name": "PIPER_LENGTH",
+          "label": "PIPER_LENGTH",
+          "default": "1.0",
+          "description": "Voice speaking rate, 1.0 is default with < 1.0 being faster and > 1.0 being slower."
+        },
+        {
+          "name": "PIPER_NOISE",
+          "label": "PIPER_NOISE",
+          "default": "0.667",
+          "description": "Controls the variability of the voice by adding noise. Values above 1 will start to degrade audio."
+        },
+        {
+          "name": "PIPER_NOISEW",
+          "label": "PIPER_NOISEW",
+          "default": "0.333",
+          "description": "Controls the variability of speaking cadence. Values above 1 produce extreme stutters and pauses."
+        },
+        {
+          "name": "PIPER_SPEAKER",
+          "label": "PIPER_SPEAKER",
+          "default": "0",
+          "description": "Speaker number to use if the voice supports multiple speakers."
+        },
+        {
+          "name": "PIPER_PROCS",
+          "label": "PIPER_PROCS",
+          "default": "1",
+          "description": "Number of Piper processes to run simultaneously."
+        }
+      ],
+      "ports": [
+        "10200:10200/tcp"
+      ],
+      "volumes": [
+        {
+          "container": "/config",
+          "bind": "/volume1/docker/piper/config"
+        }
+      ],
+      "restart_policy": "unless-stopped",
+      "maintainer": " https://github.com/technorabilia/portainer-templates/",
+      "categories": []
+    },
+    {
+      "id": 498,
+      "type": 1,
+      "title": "Planka",
+      "name": "Planka",
+      "note": "Portainer App Templates by <a href='https://www.technorabilia.com' target='_blank'>Technorabilia</a> based on data provided by <a href='https://www.linuxserver.io' target='_blank'>LinuxServer.io</a>.</p><p>Don't forget to create the volume directories on the host file system.</p><p>mkdir -p /volume1/docker/planka/config</p>",
+      "description": "[Planka](https://github.com/plankanban/planka/) is an elegant open source project tracking tool.",
+      "platform": "linux",
+      "logo": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/planka-logo.png",
+      "image": "linuxserver/planka:latest",
+      "env": [
+        {
+          "name": "PUID",
+          "label": "PUID",
+          "default": "1024",
+          "description": "for UserID"
+        },
+        {
+          "name": "PGID",
+          "label": "PGID",
+          "default": "100",
+          "description": "for GroupID"
+        },
+        {
+          "name": "TZ",
+          "label": "TZ",
+          "default": "Europe/Amsterdam",
+          "description": "specify a timezone to use, see this [list](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List)."
+        },
+        {
+          "name": "BASE_URL",
+          "label": "BASE_URL",
+          "default": "https://planka.example.com",
+          "description": "The URL you will use to access planka including protocol, and port if not 80/443."
+        },
+        {
+          "name": "DATABASE_URL",
+          "label": "DATABASE_URL",
+          "default": "postgresql://user:password@planka-db:5432/planka",
+          "description": "Postgres database URL. Special characters must be [url encoded](https://en.wikipedia.org/wiki/Percent-encoding)."
+        },
+        {
+          "name": "DEFAULT_ADMIN_EMAIL",
+          "label": "DEFAULT_ADMIN_EMAIL",
+          "default": "demo@demo.demo",
+          "description": "Email address for default user."
+        },
+        {
+          "name": "DEFAULT_ADMIN_USERNAME",
+          "label": "DEFAULT_ADMIN_USERNAME",
+          "default": "demo",
+          "description": "Username for default user."
+        },
+        {
+          "name": "DEFAULT_ADMIN_PASSWORD",
+          "label": "DEFAULT_ADMIN_PASSWORD",
+          "default": "demo",
+          "description": "Password for default user."
+        },
+        {
+          "name": "DEFAULT_ADMIN_NAME",
+          "label": "DEFAULT_ADMIN_NAME",
+          "default": "Demo User",
+          "description": "Display name for default user."
+        },
+        {
+          "name": "SECRET_KEY",
+          "label": "SECRET_KEY",
+          "default": "notasecretkey",
+          "description": "Session encryption key, recommended 32-64 character alphanumeric."
+        },
+        {
+          "name": "TRUST_PROXY",
+          "label": "TRUST_PROXY",
+          "default": "0",
+          "description": "Set to `1` to trust upstream proxies if reverse proxying."
+        }
+      ],
+      "ports": [
+        "1337:1337/tcp"
+      ],
+      "volumes": [
+        {
+          "container": "/config",
+          "bind": "/volume1/docker/planka/config"
+        }
+      ],
+      "restart_policy": "unless-stopped",
+      "maintainer": " https://github.com/technorabilia/portainer-templates/",
+      "categories": []
+    },
+    {
+      "id": 499,
+      "type": 1,
+      "title": "Pydio-cells",
+      "name": "Pydio-cells",
+      "note": "Portainer App Templates by <a href='https://www.technorabilia.com' target='_blank'>Technorabilia</a> based on data provided by <a href='https://www.linuxserver.io' target='_blank'>LinuxServer.io</a>.</p><p>Don't forget to create the volume directories on the host file system.</p><p>mkdir -p /volume1/docker/pydio-cells/config</p>",
+      "description": "[Pydio-cells](https://pydio.com/) is the nextgen file sharing platform for organizations. It is a full rewrite of the Pydio project using the Go language following a micro-service architecture.",
+      "platform": "linux",
+      "logo": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/pydio-cells-icon.png",
+      "image": "linuxserver/pydio-cells:latest",
+      "env": [
+        {
+          "name": "PUID",
+          "label": "PUID",
+          "default": "1024",
+          "description": "for UserID"
+        },
+        {
+          "name": "PGID",
+          "label": "PGID",
+          "default": "100",
+          "description": "for GroupID"
+        },
+        {
+          "name": "TZ",
+          "label": "TZ",
+          "default": "Europe/Amsterdam",
+          "description": "specify a timezone to use, see this [list](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List)."
+        },
+        {
+          "name": "EXTERNALURL",
+          "label": "EXTERNALURL",
+          "default": "yourdomain.url",
+          "description": "The external url you would like to use to access Pydio Cells (Can be https://domain.url or https://IP:PORT)."
+        },
+        {
+          "name": "SERVER_IP",
+          "label": "SERVER_IP",
+          "default": "0.0.0.0",
+          "description": "Enter the LAN IP of the docker server. Required for local access by IP, added to self signed cert as SAN (not required if accessing only through reverse proxy)."
+        }
+      ],
+      "ports": [
+        "8080:8080/tcp"
+      ],
+      "volumes": [
+        {
+          "container": "/config",
+          "bind": "/volume1/docker/pydio-cells/config"
+        }
+      ],
+      "restart_policy": "unless-stopped",
+      "maintainer": " https://github.com/technorabilia/portainer-templates/",
+      "categories": []
+    },
+    {
+      "id": 500,
+      "type": 1,
+      "title": "Pyload-ng",
+      "name": "Pyload-ng",
+      "note": "Portainer App Templates by <a href='https://www.technorabilia.com' target='_blank'>Technorabilia</a> based on data provided by <a href='https://www.linuxserver.io' target='_blank'>LinuxServer.io</a>.</p><p>Don't forget to create the volume directories on the host file system.</p><p>mkdir -p /volume1/docker/pyload-ng/config<br>mkdir -p /volume1/docker/pyload-ng/downloads</p>",
+      "description": "[pyLoad](https://pyload.net/) is a Free and Open Source download manager written in Python and designed to be extremely lightweight, easily extensible and fully manageable via web.",
+      "platform": "linux",
+      "logo": "https://github.com/linuxserver/docker-templates/raw/master/linuxserver.io/img/pyload-logo.png",
+      "image": "linuxserver/pyload-ng:latest",
+      "env": [
+        {
+          "name": "PUID",
+          "label": "PUID",
+          "default": "1024",
+          "description": "for UserID"
+        },
+        {
+          "name": "PGID",
+          "label": "PGID",
+          "default": "100",
+          "description": "for GroupID"
+        },
+        {
+          "name": "TZ",
+          "label": "TZ",
+          "default": "Europe/Amsterdam",
+          "description": "specify a timezone to use, see this [list](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List)."
+        }
+      ],
+      "ports": [
+        "8000:8000/tcp",
+        "9666:9666/tcp"
+      ],
+      "volumes": [
+        {
+          "container": "/config",
+          "bind": "/volume1/docker/pyload-ng/config"
+        },
+        {
+          "container": "/downloads",
+          "bind": "/volume1/docker/pyload-ng/downloads"
+        }
+      ],
+      "restart_policy": "unless-stopped",
+      "maintainer": " https://github.com/technorabilia/portainer-templates/",
+      "categories": []
+    },
+    {
+      "id": 501,
+      "type": 1,
+      "title": "Pylon",
+      "name": "Pylon",
+      "note": "Portainer App Templates by <a href='https://www.technorabilia.com' target='_blank'>Technorabilia</a> based on data provided by <a href='https://www.linuxserver.io' target='_blank'>LinuxServer.io</a>.</p><p>Don't forget to create the volume directories on the host file system.</p><p>mkdir -p /volume1/docker/pylon/config<br>mkdir -p /volume1/docker/pylon/code</p>",
+      "description": "[Pylon](https://github.com/pylonide/pylon) is a web based integrated development environment built with Node.js as a backend and with a supercharged JavaScript/HTML5 frontend, licensed under GPL version 3. This project originates from Cloud9 v2 project.",
+      "platform": "linux",
+      "logo": "https://raw.githubusercontent.com/pylonide/pylon/master/doc/screenshot02.png",
+      "image": "linuxserver/pylon:latest",
+      "env": [
+        {
+          "name": "PUID",
+          "label": "PUID",
+          "default": "1024",
+          "description": "for UserID"
+        },
+        {
+          "name": "PGID",
+          "label": "PGID",
+          "default": "100",
+          "description": "for GroupID"
+        },
+        {
+          "name": "TZ",
+          "label": "TZ",
+          "default": "Europe/Amsterdam",
+          "description": "specify a timezone to use, see this [list](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List)."
+        },
+        {
+          "name": "GITURL",
+          "label": "GITURL",
+          "default": "https://github.com/linuxserver/docker-pylon.git",
+          "description": "Specify a git repo to checkout on first startup"
+        },
+        {
+          "name": "PYUSER",
+          "label": "PYUSER",
+          "default": "myuser",
+          "description": "Specify a basic auth user."
+        },
+        {
+          "name": "PYPASS",
+          "label": "PYPASS",
+          "default": "mypass",
+          "description": "Specify a basic auth password."
+        }
+      ],
+      "ports": [
+        "3131:3131/tcp"
+      ],
+      "volumes": [
+        {
+          "container": "/config",
+          "bind": "/volume1/docker/pylon/config"
+        },
+        {
+          "container": "/code",
+          "bind": "/volume1/docker/pylon/code"
+        }
+      ],
+      "restart_policy": "unless-stopped",
+      "maintainer": " https://github.com/technorabilia/portainer-templates/",
+      "categories": []
+    },
+    {
+      "id": 502,
+      "type": 1,
+      "title": "Python",
+      "name": "Python",
+      "note": "Portainer App Templates by <a href='https://www.technorabilia.com' target='_blank'>Technorabilia</a> based on data provided by <a href='https://www.linuxserver.io' target='_blank'>LinuxServer.io</a>.</p><p>Don't forget to create the volume directories on the host file system.</p><p>mkdir -p /volume1/docker/python/config</p>",
+      "description": "# This container needs special attention. Please check https://hub.docker.com/r/linuxserver/python for details.",
+      "platform": "linux",
+      "logo": "",
+      "image": "linuxserver/python:latest",
+      "env": [
+        {
+          "name": "PUID",
+          "label": "PUID",
+          "default": "1024",
+          "description": "for UserID"
+        },
+        {
+          "name": "PGID",
+          "label": "PGID",
+          "default": "100",
+          "description": "for GroupID"
+        },
+        {
+          "name": "TZ",
+          "label": "TZ",
+          "default": "Europe/Amsterdam",
+          "description": "specify a timezone to use, see this [list](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List)."
+        }
+      ],
+      "ports": [
+        "80:80/tcp"
+      ],
+      "volumes": [
+        {
+          "container": "/config",
+          "bind": "/volume1/docker/python/config"
+        }
+      ],
+      "restart_policy": "unless-stopped",
+      "maintainer": " https://github.com/technorabilia/portainer-templates/",
+      "categories": []
+    },
+    {
+      "id": 503,
+      "type": 1,
+      "title": "Qemu-static",
+      "name": "Qemu-static",
+      "note": "Portainer App Templates by <a href='https://www.technorabilia.com' target='_blank'>Technorabilia</a> based on data provided by <a href='https://www.linuxserver.io' target='_blank'>LinuxServer.io</a>.</p><p>Don't forget to create the volume directories on the host file system.</p><p>mkdir -p /volume1/docker/qemu-static/config</p>",
+      "description": "# This container needs special attention. Please check https://hub.docker.com/r/linuxserver/qemu-static for details.",
+      "platform": "linux",
+      "logo": "",
+      "image": "linuxserver/qemu-static:latest",
+      "env": [
+        {
+          "name": "PUID",
+          "label": "PUID",
+          "default": "1024",
+          "description": "for UserID"
+        },
+        {
+          "name": "PGID",
+          "label": "PGID",
+          "default": "100",
+          "description": "for GroupID"
+        },
+        {
+          "name": "TZ",
+          "label": "TZ",
+          "default": "Europe/Amsterdam",
+          "description": "specify a timezone to use, see this [list](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List)."
+        }
+      ],
+      "ports": [
+        "80:80/tcp"
+      ],
+      "volumes": [
+        {
+          "container": "/config",
+          "bind": "/volume1/docker/qemu-static/config"
+        }
+      ],
+      "restart_policy": "unless-stopped",
+      "maintainer": " https://github.com/technorabilia/portainer-templates/",
+      "categories": []
+    },
+    {
+      "id": 504,
+      "type": 1,
+      "title": "Quassel-web",
+      "name": "Quassel-web",
+      "note": "Portainer App Templates by <a href='https://www.technorabilia.com' target='_blank'>Technorabilia</a> based on data provided by <a href='https://www.linuxserver.io' target='_blank'>LinuxServer.io</a>.</p><p>Don't forget to create the volume directories on the host file system.</p><p>mkdir -p /volume1/docker/quassel-web/config</p>",
+      "description": "[Quassel-web](https://github.com/magne4000/quassel-webserver) is a web client for Quassel. Note that a Quassel-Core instance is required, we have a container available [here.](https://hub.docker.com/r/linuxserver/quassel-core/)",
+      "platform": "linux",
+      "logo": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/quassel-web-banner.png",
+      "image": "linuxserver/quassel-web:latest",
+      "env": [
+        {
+          "name": "PUID",
+          "label": "PUID",
+          "default": "1024",
+          "description": "for UserID"
+        },
+        {
+          "name": "PGID",
+          "label": "PGID",
+          "default": "100",
+          "description": "for GroupID"
+        },
+        {
+          "name": "TZ",
+          "label": "TZ",
+          "default": "Europe/Amsterdam",
+          "description": "specify a timezone to use, see this [list](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List)."
+        },
+        {
+          "name": "QUASSEL_CORE",
+          "label": "QUASSEL_CORE",
+          "default": "192.168.1.10",
+          "description": "specify the URL or IP address of your Quassel Core instance"
+        },
+        {
+          "name": "QUASSEL_PORT",
+          "label": "QUASSEL_PORT",
+          "default": "4242",
+          "description": "specify the port of your Quassel Core instance"
+        },
+        {
+          "name": "QUASSEL_HTTPS",
+          "label": "QUASSEL_HTTPS",
+          "default": "",
+          "description": "Set to `true` to have Quassel web serve over https on port 64443 instead of http on port 64080."
+        },
+        {
+          "name": "URL_BASE",
+          "label": "URL_BASE",
+          "default": "/quassel",
+          "description": "Specify a url-base in reverse proxy setups ie. `/quassel`"
+        }
+      ],
+      "ports": [
+        "64080:64080/tcp",
+        "64443:64443/tcp"
+      ],
+      "volumes": [
+        {
+          "container": "/config",
+          "bind": "/volume1/docker/quassel-web/config"
+        }
+      ],
+      "restart_policy": "unless-stopped",
+      "maintainer": " https://github.com/technorabilia/portainer-templates/",
+      "categories": []
+    },
+    {
+      "id": 505,
+      "type": 1,
+      "title": "Raneto",
+      "name": "Raneto",
+      "note": "Portainer App Templates by <a href='https://www.technorabilia.com' target='_blank'>Technorabilia</a> based on data provided by <a href='https://www.linuxserver.io' target='_blank'>LinuxServer.io</a>.</p><p>Don't forget to create the volume directories on the host file system.</p><p>mkdir -p /volume1/docker/raneto/config</p>",
+      "description": "[Raneto](http://raneto.com/) - is an open source Knowledgebase platform that uses static Markdown files to power your Knowledgebase.",
+      "platform": "linux",
+      "logo": "https://raw.githubusercontent.com/gilbitron/Raneto/master/logo/logo_readme.png",
+      "image": "linuxserver/raneto:latest",
+      "env": [
+        {
+          "name": "PUID",
+          "label": "PUID",
+          "default": "1024",
+          "description": "for UserID"
+        },
+        {
+          "name": "PGID",
+          "label": "PGID",
+          "default": "100",
+          "description": "for GroupID"
+        },
+        {
+          "name": "TZ",
+          "label": "TZ",
+          "default": "Europe/Amsterdam",
+          "description": "specify a timezone to use, see this [list](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List)."
+        }
+      ],
+      "ports": [
+        "3000:3000/tcp"
+      ],
+      "volumes": [
+        {
+          "container": "/config",
+          "bind": "/volume1/docker/raneto/config"
+        }
+      ],
+      "restart_policy": "unless-stopped",
+      "maintainer": " https://github.com/technorabilia/portainer-templates/",
+      "categories": []
+    },
+    {
+      "id": 506,
+      "type": 1,
+      "title": "Rawtherapee",
+      "name": "Rawtherapee",
+      "note": "Portainer App Templates by <a href='https://www.technorabilia.com' target='_blank'>Technorabilia</a> based on data provided by <a href='https://www.linuxserver.io' target='_blank'>LinuxServer.io</a>.</p><p>Don't forget to create the volume directories on the host file system.</p><p>mkdir -p /volume1/docker/rawtherapee/config</p>",
+      "description": "[RawTherapee](https://rawtherapee.com/) is a free, cross-platform raw image processing program!",
+      "platform": "linux",
+      "logo": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/rawtherapee-logo.png",
+      "image": "linuxserver/rawtherapee:latest",
+      "env": [
+        {
+          "name": "PUID",
+          "label": "PUID",
+          "default": "1024",
+          "description": "for UserID"
+        },
+        {
+          "name": "PGID",
+          "label": "PGID",
+          "default": "100",
+          "description": "for GroupID"
+        },
+        {
+          "name": "TZ",
+          "label": "TZ",
+          "default": "Europe/Amsterdam",
+          "description": "specify a timezone to use, see this [list](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List)."
+        }
+      ],
+      "ports": [
+        "3000:3000/tcp",
+        "3001:3001/tcp"
+      ],
+      "volumes": [
+        {
+          "container": "/config",
+          "bind": "/volume1/docker/rawtherapee/config"
+        }
+      ],
+      "restart_policy": "unless-stopped",
+      "maintainer": " https://github.com/technorabilia/portainer-templates/",
+      "categories": []
+    },
+    {
+      "id": 507,
+      "type": 1,
+      "title": "Readme-sync",
+      "name": "Readme-sync",
+      "note": "Portainer App Templates by <a href='https://www.technorabilia.com' target='_blank'>Technorabilia</a> based on data provided by <a href='https://www.linuxserver.io' target='_blank'>LinuxServer.io</a>.</p><p>Don't forget to create the volume directories on the host file system.</p><p>mkdir -p /volume1/docker/readme-sync/config</p>",
+      "description": "# This container needs special attention. Please check https://hub.docker.com/r/linuxserver/readme-sync for details.",
+      "platform": "linux",
+      "logo": "",
+      "image": "linuxserver/readme-sync:latest",
+      "env": [
+        {
+          "name": "PUID",
+          "label": "PUID",
+          "default": "1024",
+          "description": "for UserID"
+        },
+        {
+          "name": "PGID",
+          "label": "PGID",
+          "default": "100",
+          "description": "for GroupID"
+        },
+        {
+          "name": "TZ",
+          "label": "TZ",
+          "default": "Europe/Amsterdam",
+          "description": "specify a timezone to use, see this [list](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List)."
+        }
+      ],
+      "ports": [
+        "80:80/tcp"
+      ],
+      "volumes": [
+        {
+          "container": "/config",
+          "bind": "/volume1/docker/readme-sync/config"
+        }
+      ],
+      "restart_policy": "unless-stopped",
+      "maintainer": " https://github.com/technorabilia/portainer-templates/",
+      "categories": []
+    },
+    {
+      "id": 508,
+      "type": 1,
+      "title": "Remmina",
+      "name": "Remmina",
+      "note": "Portainer App Templates by <a href='https://www.technorabilia.com' target='_blank'>Technorabilia</a> based on data provided by <a href='https://www.linuxserver.io' target='_blank'>LinuxServer.io</a>.</p><p>Don't forget to create the volume directories on the host file system.</p><p>mkdir -p /volume1/docker/remmina/config</p>",
+      "description": "[Remmina](https://remmina.org/) is a remote desktop client written in GTK, aiming to be useful for system administrators and travellers, who need to work with lots of remote computers in front of either large or tiny screens. Remmina supports multiple network protocols, in an integrated and consistent user interface. Currently RDP, VNC, SPICE, SSH and EXEC are supported.",
+      "platform": "linux",
+      "logo": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/remmina-icon.png",
+      "image": "linuxserver/remmina:latest",
+      "env": [
+        {
+          "name": "PUID",
+          "label": "PUID",
+          "default": "1024",
+          "description": "for UserID"
+        },
+        {
+          "name": "PGID",
+          "label": "PGID",
+          "default": "100",
+          "description": "for GroupID"
+        },
+        {
+          "name": "TZ",
+          "label": "TZ",
+          "default": "Europe/Amsterdam",
+          "description": "specify a timezone to use, see this [list](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List)."
+        }
+      ],
+      "ports": [
+        "3000:3000/tcp",
+        "3001:3001/tcp"
+      ],
+      "volumes": [
+        {
+          "container": "/config",
+          "bind": "/volume1/docker/remmina/config"
+        }
+      ],
+      "restart_policy": "unless-stopped",
+      "maintainer": " https://github.com/technorabilia/portainer-templates/",
+      "categories": []
+    },
+    {
+      "id": 509,
+      "type": 1,
+      "title": "Series-troxide",
+      "name": "Series-troxide",
+      "note": "Portainer App Templates by <a href='https://www.technorabilia.com' target='_blank'>Technorabilia</a> based on data provided by <a href='https://www.linuxserver.io' target='_blank'>LinuxServer.io</a>.</p><p>Don't forget to create the volume directories on the host file system.</p><p>mkdir -p /volume1/docker/series-troxide/config</p>",
+      "description": "[Series Troxide](https://github.com/MaarifaMaarifa/series-troxide) a Simple and Modern Series Tracker",
+      "platform": "linux",
+      "logo": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/series-troxide-logo.png",
+      "image": "linuxserver/series-troxide:latest",
+      "env": [
+        {
+          "name": "PUID",
+          "label": "PUID",
+          "default": "1024",
+          "description": "for UserID"
+        },
+        {
+          "name": "PGID",
+          "label": "PGID",
+          "default": "100",
+          "description": "for GroupID"
+        },
+        {
+          "name": "TZ",
+          "label": "TZ",
+          "default": "Europe/Amsterdam",
+          "description": "specify a timezone to use, see this [list](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List)."
+        }
+      ],
+      "ports": [
+        "3000:3000/tcp",
+        "3001:3001/tcp"
+      ],
+      "volumes": [
+        {
+          "container": "/config",
+          "bind": "/volume1/docker/series-troxide/config"
+        }
+      ],
+      "restart_policy": "unless-stopped",
+      "maintainer": " https://github.com/technorabilia/portainer-templates/",
+      "categories": []
+    },
+    {
+      "id": 510,
+      "type": 1,
+      "title": "Shotcut",
+      "name": "Shotcut",
+      "note": "Portainer App Templates by <a href='https://www.technorabilia.com' target='_blank'>Technorabilia</a> based on data provided by <a href='https://www.linuxserver.io' target='_blank'>LinuxServer.io</a>.</p><p>Don't forget to create the volume directories on the host file system.</p><p>mkdir -p /volume1/docker/shotcut/config</p>",
+      "description": "[Shotcut](https://www.shotcut.org/) is a free, open source, cross-platform video editor.",
+      "platform": "linux",
+      "logo": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/shotcut-logo.png",
+      "image": "linuxserver/shotcut:latest",
+      "env": [
+        {
+          "name": "PUID",
+          "label": "PUID",
+          "default": "1024",
+          "description": "for UserID"
+        },
+        {
+          "name": "PGID",
+          "label": "PGID",
+          "default": "100",
+          "description": "for GroupID"
+        },
+        {
+          "name": "TZ",
+          "label": "TZ",
+          "default": "Europe/Amsterdam",
+          "description": "specify a timezone to use, see this [list](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List)."
+        }
+      ],
+      "ports": [
+        "3000:3000/tcp",
+        "3001:3001/tcp"
+      ],
+      "volumes": [
+        {
+          "container": "/config",
+          "bind": "/volume1/docker/shotcut/config"
+        }
+      ],
+      "restart_policy": "unless-stopped",
+      "maintainer": " https://github.com/technorabilia/portainer-templates/",
+      "categories": []
+    },
+    {
+      "id": 511,
+      "type": 1,
+      "title": "Socket-proxy",
+      "name": "Socket-proxy",
+      "note": "Portainer App Templates by <a href='https://www.technorabilia.com' target='_blank'>Technorabilia</a> based on data provided by <a href='https://www.linuxserver.io' target='_blank'>LinuxServer.io</a>.</p><p>Don't forget to create the volume directories on the host file system.</p><p>mkdir -p /volume1/docker/socket-proxy/config</p>",
+      "description": "# This container needs special attention. Please check https://hub.docker.com/r/linuxserver/socket-proxy for details.",
+      "platform": "linux",
+      "logo": "",
+      "image": "linuxserver/socket-proxy:latest",
+      "env": [
+        {
+          "name": "PUID",
+          "label": "PUID",
+          "default": "1024",
+          "description": "for UserID"
+        },
+        {
+          "name": "PGID",
+          "label": "PGID",
+          "default": "100",
+          "description": "for GroupID"
+        },
+        {
+          "name": "TZ",
+          "label": "TZ",
+          "default": "Europe/Amsterdam",
+          "description": "specify a timezone to use, see this [list](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List)."
+        }
+      ],
+      "ports": [
+        "80:80/tcp"
+      ],
+      "volumes": [
+        {
+          "container": "/config",
+          "bind": "/volume1/docker/socket-proxy/config"
+        }
+      ],
+      "restart_policy": "unless-stopped",
+      "maintainer": " https://github.com/technorabilia/portainer-templates/",
+      "categories": []
+    },
+    {
+      "id": 512,
+      "type": 1,
+      "title": "Spotube",
+      "name": "Spotube",
+      "note": "Portainer App Templates by <a href='https://www.technorabilia.com' target='_blank'>Technorabilia</a> based on data provided by <a href='https://www.linuxserver.io' target='_blank'>LinuxServer.io</a>.</p><p>Don't forget to create the volume directories on the host file system.</p><p>mkdir -p /volume1/docker/spotube/config</p>",
+      "description": "[Spotube](https://spotube.krtirtho.dev/) is an open source, cross-platform Spotify client compatible across multiple platforms utilizing Spotify's data API and YouTube, Piped.video or JioSaavn as an audio source, eliminating the need for Spotify Premium",
+      "platform": "linux",
+      "logo": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/spotube-logo.png",
+      "image": "linuxserver/spotube:latest",
+      "env": [
+        {
+          "name": "PUID",
+          "label": "PUID",
+          "default": "1024",
+          "description": "for UserID"
+        },
+        {
+          "name": "PGID",
+          "label": "PGID",
+          "default": "100",
+          "description": "for GroupID"
+        },
+        {
+          "name": "TZ",
+          "label": "TZ",
+          "default": "Europe/Amsterdam",
+          "description": "specify a timezone to use, see this [list](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List)."
+        }
+      ],
+      "ports": [
+        "3000:3000/tcp",
+        "3001:3001/tcp"
+      ],
+      "volumes": [
+        {
+          "container": "/config",
+          "bind": "/volume1/docker/spotube/config"
+        }
+      ],
+      "restart_policy": "unless-stopped",
+      "maintainer": " https://github.com/technorabilia/portainer-templates/",
+      "categories": []
+    },
+    {
+      "id": 513,
+      "type": 1,
+      "title": "Sqlitebrowser",
+      "name": "Sqlitebrowser",
+      "note": "Portainer App Templates by <a href='https://www.technorabilia.com' target='_blank'>Technorabilia</a> based on data provided by <a href='https://www.linuxserver.io' target='_blank'>LinuxServer.io</a>.</p><p>Don't forget to create the volume directories on the host file system.</p><p>mkdir -p /volume1/docker/sqlitebrowser/config</p>",
+      "description": "[DB Browser for SQLite](https://sqlitebrowser.org/) is a high quality, visual, open source tool to create, design, and edit database files compatible with SQLite.",
+      "platform": "linux",
+      "logo": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/sqlitebrowser-banner.png",
+      "image": "linuxserver/sqlitebrowser:latest",
+      "env": [
+        {
+          "name": "PUID",
+          "label": "PUID",
+          "default": "1024",
+          "description": "for UserID"
+        },
+        {
+          "name": "PGID",
+          "label": "PGID",
+          "default": "100",
+          "description": "for GroupID"
+        },
+        {
+          "name": "TZ",
+          "label": "TZ",
+          "default": "Europe/Amsterdam",
+          "description": "specify a timezone to use, see this [list](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List)."
+        }
+      ],
+      "ports": [
+        "3000:3000/tcp",
+        "3001:3001/tcp"
+      ],
+      "volumes": [
+        {
+          "container": "/config",
+          "bind": "/volume1/docker/sqlitebrowser/config"
+        }
+      ],
+      "restart_policy": "unless-stopped",
+      "maintainer": " https://github.com/technorabilia/portainer-templates/",
+      "categories": []
+    },
+    {
+      "id": 514,
+      "type": 1,
+      "title": "Steamos",
+      "name": "Steamos",
+      "note": "Portainer App Templates by <a href='https://www.technorabilia.com' target='_blank'>Technorabilia</a> based on data provided by <a href='https://www.linuxserver.io' target='_blank'>LinuxServer.io</a>.</p><p>Don't forget to create the volume directories on the host file system.</p><p>mkdir -p /volume1/docker/steamos/config<br><br></p>",
+      "description": "[SteamOS](https://www.steamdeck.com/) is an Arch based Linux distribution made by Valve Software. This container is a vanilla Arch install with Steam repositories added for software support. **This container will only work with modern AMD/Intel GPUs on a real Linux Host**",
+      "platform": "linux",
+      "logo": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/steamos-logo.png",
+      "image": "linuxserver/steamos:latest",
+      "env": [
+        {
+          "name": "PUID",
+          "label": "PUID",
+          "default": "1024",
+          "description": "for UserID"
+        },
+        {
+          "name": "PGID",
+          "label": "PGID",
+          "default": "100",
+          "description": "for GroupID"
+        },
+        {
+          "name": "TZ",
+          "label": "TZ",
+          "default": "Europe/Amsterdam",
+          "description": "specify a timezone to use, see this [list](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List)."
+        },
+        {
+          "name": "DRINODE",
+          "label": "DRINODE",
+          "default": "/dev/dri/renderD128",
+          "description": "Specify the render device (GPU) for the contianer to use."
+        },
+        {
+          "name": "HOST_IP",
+          "label": "HOST_IP",
+          "default": "192.168.100.10",
+          "description": "Specify the IP of the host, needed for LAN Remote Play."
+        },
+        {
+          "name": "STARTUP",
+          "label": "STARTUP",
+          "default": "KDE",
+          "description": "KDE to boot into desktop mode, BIGPICTURE to boot into gamescope."
+        },
+        {
+          "name": "RESOLUTION",
+          "label": "RESOLUTION",
+          "default": "1920x1080",
+          "description": "When booting into BIGPICTURE mode the screen resolution will be bound to this value."
+        }
+      ],
+      "ports": [
+        "3000:3000/tcp",
+        "3001:3001/tcp",
+        "27031-27036:27031-27036/udp",
+        "27031-27036:27031-27036",
+        "47984-47990:47984-47990",
+        "48010-48010:48010-48010",
+        "47998-48000:47998-48000/udp"
+      ],
+      "volumes": [
+        {
+          "container": "/config",
+          "bind": "/volume1/docker/steamos/config"
+        },
+        {
+          "container": "/dev/input",
+          "bind": "/dev/input"
+        },
+        {
+          "container": "/run/udev/data",
+          "bind": "/run/udev/data"
+        }
+      ],
+      "restart_policy": "unless-stopped",
+      "maintainer": " https://github.com/technorabilia/portainer-templates/",
+      "categories": []
+    },
+    {
+      "id": 515,
+      "type": 1,
+      "title": "Swag",
+      "name": "Swag",
+      "note": "Portainer App Templates by <a href='https://www.technorabilia.com' target='_blank'>Technorabilia</a> based on data provided by <a href='https://www.linuxserver.io' target='_blank'>LinuxServer.io</a>.</p><p>Don't forget to create the volume directories on the host file system.</p><p>mkdir -p /volume1/docker/swag/config</p>",
+      "description": "SWAG - Secure Web Application Gateway (formerly known as letsencrypt, no relation to Let's Encrypt™) sets up an Nginx webserver and reverse proxy with php support and a built-in certbot client that automates free SSL server certificate generation and renewal processes (Let's Encrypt and ZeroSSL). It also contains fail2ban for intrusion prevention.",
+      "platform": "linux",
+      "logo": "https://github.com/linuxserver/docker-templates/raw/master/linuxserver.io/img/swag.gif",
+      "image": "linuxserver/swag:latest",
+      "env": [
+        {
+          "name": "PUID",
+          "label": "PUID",
+          "default": "1024",
+          "description": "for UserID"
+        },
+        {
+          "name": "PGID",
+          "label": "PGID",
+          "default": "100",
+          "description": "for GroupID"
+        },
+        {
+          "name": "TZ",
+          "label": "TZ",
+          "default": "Europe/Amsterdam",
+          "description": "specify a timezone to use, see this [list](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List)."
+        },
+        {
+          "name": "URL",
+          "label": "URL",
+          "default": "yourdomain.url",
+          "description": "Top url you have control over (`customdomain.com` if you own it, or `customsubdomain.ddnsprovider.com` if dynamic dns)."
+        },
+        {
+          "name": "VALIDATION",
+          "label": "VALIDATION",
+          "default": "http",
+          "description": "Certbot validation method to use, options are `http` or `dns` (`dns` method also requires `DNSPLUGIN` variable set)."
+        },
+        {
+          "name": "SUBDOMAINS",
+          "label": "SUBDOMAINS",
+          "default": "www,",
+          "description": "Subdomains you'd like the cert to cover (comma separated, no spaces) ie. `www,ftp,cloud`. For a wildcard cert, set this *exactly* to `wildcard` (wildcard cert is available via `dns` validation only)"
+        },
+        {
+          "name": "CERTPROVIDER",
+          "label": "CERTPROVIDER",
+          "default": "",
+          "description": "Optionally define the cert provider. Set to `zerossl` for ZeroSSL certs (requires existing [ZeroSSL account](https://app.zerossl.com/signup) and the e-mail address entered in `EMAIL` env var). Otherwise defaults to Let's Encrypt."
+        },
+        {
+          "name": "DNSPLUGIN",
+          "label": "DNSPLUGIN",
+          "default": "cloudflare",
+          "description": "Required if `VALIDATION` is set to `dns`. Options are `acmedns`, `aliyun`, `azure`, `bunny`, `cloudflare`, `cpanel`, `desec`, `digitalocean`, `directadmin`, `dnsimple`, `dnsmadeeasy`, `dnspod`, `do`, `domeneshop`, `dreamhost`, `duckdns`, `dynu`, `freedns`, `gandi`, `gehirn`, `glesys`, `godaddy`, `google`, `he`, `hetzner`, `infomaniak`, `inwx`, `ionos`, `linode`, `loopia`, `luadns`, `namecheap`, `netcup`, `njalla`, `nsone`, `ovh`, `porkbun`, `rfc2136`, `route53`, `sakuracloud`, `standalone`, `transip`, and `vultr`. Also need to enter the credentials into the corresponding ini (or json for some plugins) file under `/config/dns-conf`."
+        },
+        {
+          "name": "PROPAGATION",
+          "label": "PROPAGATION",
+          "default": "",
+          "description": "Optionally override (in seconds) the default propagation time for the dns plugins."
+        },
+        {
+          "name": "EMAIL",
+          "label": "EMAIL",
+          "default": "",
+          "description": "Optional e-mail address used for cert expiration notifications (Required for ZeroSSL)."
+        },
+        {
+          "name": "ONLY_SUBDOMAINS",
+          "label": "ONLY_SUBDOMAINS",
+          "default": "false",
+          "description": "If you wish to get certs only for certain subdomains, but not the main domain (main domain may be hosted on another machine and cannot be validated), set this to `true`"
+        },
+        {
+          "name": "EXTRA_DOMAINS",
+          "label": "EXTRA_DOMAINS",
+          "default": "",
+          "description": "Additional fully qualified domain names (comma separated, no spaces) ie. `extradomain.com,subdomain.anotherdomain.org,*.anotherdomain.org`"
+        },
+        {
+          "name": "STAGING",
+          "label": "STAGING",
+          "default": "false",
+          "description": "Set to `true` to retrieve certs in staging mode. Rate limits will be much higher, but the resulting cert will not pass the browser's security test. Only to be used for testing purposes."
+        }
+      ],
+      "ports": [
+        "443:443/tcp",
+        "80:80/tcp"
+      ],
+      "volumes": [
+        {
+          "container": "/config",
+          "bind": "/volume1/docker/swag/config"
+        }
+      ],
+      "restart_policy": "unless-stopped",
+      "maintainer": " https://github.com/technorabilia/portainer-templates/",
+      "categories": []
+    },
+    {
+      "id": 516,
+      "type": 1,
+      "title": "Synclounge",
+      "name": "Synclounge",
+      "note": "Portainer App Templates by <a href='https://www.technorabilia.com' target='_blank'>Technorabilia</a> based on data provided by <a href='https://www.linuxserver.io' target='_blank'>LinuxServer.io</a>.</p><p>Don't forget to create the volume directories on the host file system.</p>",
+      "description": "[Synclounge](https://github.com/samcm/synclounge) is a third party tool that allows you to watch Plex in sync with your friends/family, wherever you are.",
+      "platform": "linux",
+      "logo": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/synclounge-banner.png",
+      "image": "linuxserver/synclounge:latest",
+      "env": [
+        {
+          "name": "AUTH_LIST",
+          "label": "AUTH_LIST",
+          "default": "plexuser1,plexuser2,email1,machineid1",
+          "description": "If set, only the users defined here and the users of the plex servers defined here will be able to access the server. Use e-mails, plex usernames and/or plex server machine ids, comma separated, no spaces."
+        }
+      ],
+      "ports": [
+        "8088:8088/tcp"
+      ],
+      "restart_policy": "unless-stopped",
+      "maintainer": " https://github.com/technorabilia/portainer-templates/",
+      "categories": []
+    },
+    {
+      "id": 517,
+      "type": 1,
+      "title": "Tester",
+      "name": "Tester",
+      "note": "Portainer App Templates by <a href='https://www.technorabilia.com' target='_blank'>Technorabilia</a> based on data provided by <a href='https://www.linuxserver.io' target='_blank'>LinuxServer.io</a>.</p><p>Don't forget to create the volume directories on the host file system.</p>",
+      "description": "This internal tool is used as a desktop sandbox in our CI process to grab a screenshot of a hopefully functional endpoint",
+      "platform": "linux",
+      "logo": "https://avatars3.githubusercontent.com/u/12324908?s=200&v=4",
+      "image": "linuxserver/tester:latest",
+      "env": [
+        {
+          "name": "URL",
+          "label": "URL",
+          "default": "http://google.com",
+          "description": "Specify an endpoint, the container will automatically determine the correct protocol and program to use"
+        }
+      ],
+      "ports": [
+        "3000:3000/tcp"
+      ],
+      "restart_policy": "unless-stopped",
+      "maintainer": " https://github.com/technorabilia/portainer-templates/",
+      "categories": []
+    },
+    {
+      "id": 518,
+      "type": 1,
+      "title": "Ungoogled-chromium",
+      "name": "Ungoogled-chromium",
+      "note": "Portainer App Templates by <a href='https://www.technorabilia.com' target='_blank'>Technorabilia</a> based on data provided by <a href='https://www.linuxserver.io' target='_blank'>LinuxServer.io</a>.</p><p>Don't forget to create the volume directories on the host file system.</p><p>mkdir -p /volume1/docker/ungoogled-chromium/config</p>",
+      "description": "[Ungoogled Chromium](https://github.com/ungoogled-software/ungoogled-chromium) is Google Chromium, sans dependency on Google web services.",
+      "platform": "linux",
+      "logo": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/ungoogled-chromium-logo.png",
+      "image": "linuxserver/ungoogled-chromium:latest",
+      "env": [
+        {
+          "name": "PUID",
+          "label": "PUID",
+          "default": "1024",
+          "description": "for UserID"
+        },
+        {
+          "name": "PGID",
+          "label": "PGID",
+          "default": "100",
+          "description": "for GroupID"
+        },
+        {
+          "name": "TZ",
+          "label": "TZ",
+          "default": "Europe/Amsterdam",
+          "description": "specify a timezone to use, see this [list](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List)."
+        },
+        {
+          "name": "CHROME_CLI",
+          "label": "CHROME_CLI",
+          "default": "https://www.linuxserver.io/",
+          "description": "Specify one or multiple Chromium CLI flags, this string will be passed to the application in full."
+        }
+      ],
+      "ports": [
+        "3000:3000/tcp",
+        "3001:3001/tcp"
+      ],
+      "volumes": [
+        {
+          "container": "/config",
+          "bind": "/volume1/docker/ungoogled-chromium/config"
+        }
+      ],
+      "restart_policy": "unless-stopped",
+      "maintainer": " https://github.com/technorabilia/portainer-templates/",
+      "categories": []
+    },
+    {
+      "id": 519,
+      "type": 1,
+      "title": "Unifi-network-application",
+      "name": "Unifi-network-application",
+      "note": "Portainer App Templates by <a href='https://www.technorabilia.com' target='_blank'>Technorabilia</a> based on data provided by <a href='https://www.linuxserver.io' target='_blank'>LinuxServer.io</a>.</p><p>Don't forget to create the volume directories on the host file system.</p><p>mkdir -p /volume1/docker/unifi-network-application/config</p>",
+      "description": "The [Unifi-network-application](https://ui.com/) software is a powerful, enterprise wireless software engine ideal for high-density client deployments requiring low latency and high uptime performance.",
+      "platform": "linux",
+      "logo": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/unifi-banner.png",
+      "image": "linuxserver/unifi-network-application:latest",
+      "env": [
+        {
+          "name": "PUID",
+          "label": "PUID",
+          "default": "1024",
+          "description": "for UserID"
+        },
+        {
+          "name": "PGID",
+          "label": "PGID",
+          "default": "100",
+          "description": "for GroupID"
+        },
+        {
+          "name": "TZ",
+          "label": "TZ",
+          "default": "Europe/Amsterdam",
+          "description": "specify a timezone to use, see this [list](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List)."
+        },
+        {
+          "name": "MONGO_USER",
+          "label": "MONGO_USER",
+          "default": "unifi",
+          "description": "Mongodb Username. Only evaluated on first run. **Special characters must be [url encoded](https://en.wikipedia.org/wiki/Percent-encoding)**."
+        },
+        {
+          "name": "MONGO_PASS",
+          "label": "MONGO_PASS",
+          "default": "",
+          "description": "Mongodb Password. Only evaluated on first run. **Special characters must be [url encoded](https://en.wikipedia.org/wiki/Percent-encoding)**."
+        },
+        {
+          "name": "MONGO_HOST",
+          "label": "MONGO_HOST",
+          "default": "unifi-db",
+          "description": "Mongodb Hostname. Only evaluated on first run."
+        },
+        {
+          "name": "MONGO_PORT",
+          "label": "MONGO_PORT",
+          "default": "27017",
+          "description": "Mongodb Port. Only evaluated on first run."
+        },
+        {
+          "name": "MONGO_DBNAME",
+          "label": "MONGO_DBNAME",
+          "default": "unifi",
+          "description": "Mongodb Database Name (stats DB is automatically suffixed with `_stat`). Only evaluated on first run."
+        },
+        {
+          "name": "MONGO_AUTHSOURCE",
+          "label": "MONGO_AUTHSOURCE",
+          "default": "admin",
+          "description": "Mongodb [authSource](https://www.mongodb.com/docs/manual/reference/connection-string/#mongodb-urioption-urioption.authSource). For Atlas set to `admin`. Only evaluated on first run."
+        },
+        {
+          "name": "MEM_LIMIT",
+          "label": "MEM_LIMIT",
+          "default": "1024",
+          "description": "Optionally change the Java memory limit (in Megabytes). Set to `default` to reset to default"
+        },
+        {
+          "name": "MEM_STARTUP",
+          "label": "MEM_STARTUP",
+          "default": "1024",
+          "description": "Optionally change the Java initial/minimum memory (in Megabytes). Set to `default` to reset to default"
+        },
+        {
+          "name": "MONGO_TLS",
+          "label": "MONGO_TLS",
+          "default": "",
+          "description": "Mongodb enable [TLS](https://www.mongodb.com/docs/manual/reference/connection-string/#mongodb-urioption-urioption.tls). Only evaluated on first run."
+        }
+      ],
+      "ports": [
+        "8443:8443/tcp",
+        "3478:3478/udp",
+        "10001:10001/udp",
+        "8080:8080/tcp",
+        "1900:1900/udp",
+        "8843:8843/tcp",
+        "8880:8880/tcp",
+        "6789:6789/tcp",
+        "5514:5514/udp"
+      ],
+      "volumes": [
+        {
+          "container": "/config",
+          "bind": "/volume1/docker/unifi-network-application/config"
+        }
+      ],
+      "restart_policy": "unless-stopped",
+      "maintainer": " https://github.com/technorabilia/portainer-templates/",
+      "categories": []
+    },
+    {
+      "id": 520,
+      "type": 1,
+      "title": "Unrar",
+      "name": "Unrar",
+      "note": "Portainer App Templates by <a href='https://www.technorabilia.com' target='_blank'>Technorabilia</a> based on data provided by <a href='https://www.linuxserver.io' target='_blank'>LinuxServer.io</a>.</p><p>Don't forget to create the volume directories on the host file system.</p><p>mkdir -p /volume1/docker/unrar/config</p>",
+      "description": "# This container needs special attention. Please check https://hub.docker.com/r/linuxserver/unrar for details.",
+      "platform": "linux",
+      "logo": "",
+      "image": "linuxserver/unrar:latest",
+      "env": [
+        {
+          "name": "PUID",
+          "label": "PUID",
+          "default": "1024",
+          "description": "for UserID"
+        },
+        {
+          "name": "PGID",
+          "label": "PGID",
+          "default": "100",
+          "description": "for GroupID"
+        },
+        {
+          "name": "TZ",
+          "label": "TZ",
+          "default": "Europe/Amsterdam",
+          "description": "specify a timezone to use, see this [list](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List)."
+        }
+      ],
+      "ports": [
+        "80:80/tcp"
+      ],
+      "volumes": [
+        {
+          "container": "/config",
+          "bind": "/volume1/docker/unrar/config"
+        }
+      ],
+      "restart_policy": "unless-stopped",
+      "maintainer": " https://github.com/technorabilia/portainer-templates/",
+      "categories": []
+    },
+    {
+      "id": 521,
+      "type": 1,
+      "title": "Vscodium",
+      "name": "Vscodium",
+      "note": "Portainer App Templates by <a href='https://www.technorabilia.com' target='_blank'>Technorabilia</a> based on data provided by <a href='https://www.linuxserver.io' target='_blank'>LinuxServer.io</a>.</p><p>Don't forget to create the volume directories on the host file system.</p><p>mkdir -p /volume1/docker/vscodium/config</p>",
+      "description": "[VSCodium](https://vscodium.com/) is a community-driven, freely-licensed binary distribution of Microsoft’s editor VS Code.",
+      "platform": "linux",
+      "logo": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/vscodium-icon.png",
+      "image": "linuxserver/vscodium:latest",
+      "env": [
+        {
+          "name": "PUID",
+          "label": "PUID",
+          "default": "1024",
+          "description": "for UserID"
+        },
+        {
+          "name": "PGID",
+          "label": "PGID",
+          "default": "100",
+          "description": "for GroupID"
+        },
+        {
+          "name": "TZ",
+          "label": "TZ",
+          "default": "Europe/Amsterdam",
+          "description": "specify a timezone to use, see this [list](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List)."
+        }
+      ],
+      "ports": [
+        "3000:3000/tcp",
+        "3001:3001/tcp"
+      ],
+      "volumes": [
+        {
+          "container": "/config",
+          "bind": "/volume1/docker/vscodium/config"
+        }
+      ],
+      "restart_policy": "unless-stopped",
+      "maintainer": " https://github.com/technorabilia/portainer-templates/",
+      "categories": []
+    },
+    {
+      "id": 522,
+      "type": 1,
+      "title": "Webcord",
+      "name": "Webcord",
+      "note": "Portainer App Templates by <a href='https://www.technorabilia.com' target='_blank'>Technorabilia</a> based on data provided by <a href='https://www.linuxserver.io' target='_blank'>LinuxServer.io</a>.</p><p>Don't forget to create the volume directories on the host file system.</p><p>mkdir -p /volume1/docker/webcord/config</p>",
+      "description": "[WebCord](https://github.com/SpacingBat3/WebCord) can be summarized as a pack of security and privacy hardenings, Discord features reimplementations, Electron / Chromium / Discord bugs workarounds, stylesheets, internal pages and wrapped https://discord.com page, designed to conform with ToS as much as it is possible (or hide the changes that might violate it from Discord's eyes).",
+      "platform": "linux",
+      "logo": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/webcord-icon.png",
+      "image": "linuxserver/webcord:latest",
+      "env": [
+        {
+          "name": "PUID",
+          "label": "PUID",
+          "default": "1024",
+          "description": "for UserID"
+        },
+        {
+          "name": "PGID",
+          "label": "PGID",
+          "default": "100",
+          "description": "for GroupID"
+        },
+        {
+          "name": "TZ",
+          "label": "TZ",
+          "default": "Europe/Amsterdam",
+          "description": "specify a timezone to use, see this [list](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List)."
+        }
+      ],
+      "ports": [
+        "3000:3000/tcp",
+        "3001:3001/tcp"
+      ],
+      "volumes": [
+        {
+          "container": "/config",
+          "bind": "/volume1/docker/webcord/config"
+        }
+      ],
+      "restart_policy": "unless-stopped",
+      "maintainer": " https://github.com/technorabilia/portainer-templates/",
+      "categories": []
+    },
+    {
+      "id": 523,
+      "type": 1,
+      "title": "Wps-office",
+      "name": "Wps-office",
+      "note": "Portainer App Templates by <a href='https://www.technorabilia.com' target='_blank'>Technorabilia</a> based on data provided by <a href='https://www.linuxserver.io' target='_blank'>LinuxServer.io</a>.</p><p>Don't forget to create the volume directories on the host file system.</p><p>mkdir -p /volume1/docker/wps-office/config</p>",
+      "description": "[WPS Office](https://www.wps.com/) is a lightweight, feature-rich comprehensive office suite with high compatibility. As a handy and professional office software, WPS Office allows you to edit files in Writer, Presentation, Spreadsheet, and PDF to improve your work efficiency.",
+      "platform": "linux",
+      "logo": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/wps-office-icon.png",
+      "image": "linuxserver/wps-office:latest",
+      "env": [
+        {
+          "name": "PUID",
+          "label": "PUID",
+          "default": "1024",
+          "description": "for UserID"
+        },
+        {
+          "name": "PGID",
+          "label": "PGID",
+          "default": "100",
+          "description": "for GroupID"
+        },
+        {
+          "name": "TZ",
+          "label": "TZ",
+          "default": "Europe/Amsterdam",
+          "description": "specify a timezone to use, see this [list](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List)."
+        }
+      ],
+      "ports": [
+        "3000:3000/tcp",
+        "3001:3001/tcp"
+      ],
+      "volumes": [
+        {
+          "container": "/config",
+          "bind": "/volume1/docker/wps-office/config"
+        }
+      ],
+      "restart_policy": "unless-stopped",
+      "maintainer": " https://github.com/technorabilia/portainer-templates/",
+      "categories": []
+    },
+    {
+      "id": 524,
+      "type": 1,
+      "title": "Xbackbone",
+      "name": "Xbackbone",
+      "note": "Portainer App Templates by <a href='https://www.technorabilia.com' target='_blank'>Technorabilia</a> based on data provided by <a href='https://www.linuxserver.io' target='_blank'>LinuxServer.io</a>.</p><p>Don't forget to create the volume directories on the host file system.</p><p>mkdir -p /volume1/docker/xbackbone/config</p>",
+      "description": "[Xbackbone](https://github.com/SergiX44/XBackBone) is a simple, self-hosted, lightweight PHP file manager that support the instant sharing tool ShareX and *NIX systems. It supports uploading and displaying images, GIF, video, code, formatted text, and file downloading and uploading. Also have a web UI with multi user management, past uploads history and search support.",
+      "platform": "linux",
+      "logo": "https://raw.githubusercontent.com/SergiX44/XBackBone/master/docs/img/xbackbone.png",
+      "image": "linuxserver/xbackbone:latest",
+      "env": [
+        {
+          "name": "PUID",
+          "label": "PUID",
+          "default": "1024",
+          "description": "for UserID"
+        },
+        {
+          "name": "PGID",
+          "label": "PGID",
+          "default": "100",
+          "description": "for GroupID"
+        },
+        {
+          "name": "TZ",
+          "label": "TZ",
+          "default": "Europe/Amsterdam",
+          "description": "specify a timezone to use, see this [list](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List)."
+        }
+      ],
+      "ports": [
+        "80:80/tcp",
+        "443:443/tcp"
+      ],
+      "volumes": [
+        {
+          "container": "/config",
+          "bind": "/volume1/docker/xbackbone/config"
+        }
+      ],
+      "restart_policy": "unless-stopped",
+      "maintainer": " https://github.com/technorabilia/portainer-templates/",
+      "categories": []
+    },
+    {
+      "id": 525,
+      "type": 1,
+      "title": "Yaak",
+      "name": "Yaak",
+      "note": "Portainer App Templates by <a href='https://www.technorabilia.com' target='_blank'>Technorabilia</a> based on data provided by <a href='https://www.linuxserver.io' target='_blank'>LinuxServer.io</a>.</p><p>Don't forget to create the volume directories on the host file system.</p><p>mkdir -p /volume1/docker/yaak/config</p>",
+      "description": "[Yaak](https://yaak.app/) is a desktop API client for organizing and executing REST, GraphQL, and gRPC requests. It's built using [Tauri](https://tauri.app/), [Rust](https://www.rust-lang.org/), and [ReactJS](https://react.dev/).",
+      "platform": "linux",
+      "logo": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/yaak-logo.png",
+      "image": "linuxserver/yaak:latest",
+      "env": [
+        {
+          "name": "PUID",
+          "label": "PUID",
+          "default": "1024",
+          "description": "for UserID"
+        },
+        {
+          "name": "PGID",
+          "label": "PGID",
+          "default": "100",
+          "description": "for GroupID"
+        },
+        {
+          "name": "TZ",
+          "label": "TZ",
+          "default": "Europe/Amsterdam",
+          "description": "specify a timezone to use, see this [list](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List)."
+        }
+      ],
+      "ports": [
+        "3000:3000/tcp",
+        "3001:3001/tcp"
+      ],
+      "volumes": [
+        {
+          "container": "/config",
+          "bind": "/volume1/docker/yaak/config"
+        }
+      ],
+      "restart_policy": "unless-stopped",
+      "maintainer": " https://github.com/technorabilia/portainer-templates/",
+      "categories": []
+    },
+    {
+      "id": 526,
+      "type": 1,
+      "title": "Yq",
+      "name": "Yq",
+      "note": "Portainer App Templates by <a href='https://www.technorabilia.com' target='_blank'>Technorabilia</a> based on data provided by <a href='https://www.linuxserver.io' target='_blank'>LinuxServer.io</a>.</p><p>Don't forget to create the volume directories on the host file system.</p><p>mkdir -p /volume1/docker/yq/config</p>",
+      "description": "# This container needs special attention. Please check https://hub.docker.com/r/linuxserver/yq for details.",
+      "platform": "linux",
+      "logo": "",
+      "image": "linuxserver/yq:latest",
+      "env": [
+        {
+          "name": "PUID",
+          "label": "PUID",
+          "default": "1024",
+          "description": "for UserID"
+        },
+        {
+          "name": "PGID",
+          "label": "PGID",
+          "default": "100",
+          "description": "for GroupID"
+        },
+        {
+          "name": "TZ",
+          "label": "TZ",
+          "default": "Europe/Amsterdam",
+          "description": "specify a timezone to use, see this [list](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List)."
+        }
+      ],
+      "ports": [
+        "80:80/tcp"
+      ],
+      "volumes": [
+        {
+          "container": "/config",
+          "bind": "/volume1/docker/yq/config"
+        }
+      ],
+      "restart_policy": "unless-stopped",
+      "maintainer": " https://github.com/technorabilia/portainer-templates/",
+      "categories": []
+    },
+    {
+      "id": 527,
+      "type": 1,
+      "title": "Zotero",
+      "name": "Zotero",
+      "note": "Portainer App Templates by <a href='https://www.technorabilia.com' target='_blank'>Technorabilia</a> based on data provided by <a href='https://www.linuxserver.io' target='_blank'>LinuxServer.io</a>.</p><p>Don't forget to create the volume directories on the host file system.</p><p>mkdir -p /volume1/docker/zotero/config</p>",
+      "description": "[Zotero](https://www.zotero.org/) is a free, easy-to-use tool to help you collect, organize, annotate, cite, and share research.",
+      "platform": "linux",
+      "logo": "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/zotero-icon.png",
+      "image": "linuxserver/zotero:latest",
+      "env": [
+        {
+          "name": "PUID",
+          "label": "PUID",
+          "default": "1024",
+          "description": "for UserID"
+        },
+        {
+          "name": "PGID",
+          "label": "PGID",
+          "default": "100",
+          "description": "for GroupID"
+        },
+        {
+          "name": "TZ",
+          "label": "TZ",
+          "default": "Europe/Amsterdam",
+          "description": "specify a timezone to use, see this [list](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List)."
+        }
+      ],
+      "ports": [
+        "3000:3000/tcp",
+        "3001:3001/tcp"
+      ],
+      "volumes": [
+        {
+          "container": "/config",
+          "bind": "/volume1/docker/zotero/config"
+        }
+      ],
+      "restart_policy": "unless-stopped",
+      "maintainer": " https://github.com/technorabilia/portainer-templates/",
+      "categories": []
+    },
+    {
+      "id": 528,
+      "type": 1,
+      "title": "Registry (cache)",
+      "description": "Docker image registry configured as a DockerHub pull through cache",
+      "categories": [
+        "Docker"
+      ],
+      "platform": "linux",
+      "logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/registry.png",
+      "image": "registry:latest",
+      "ports": [
+        "5000/tcp"
+      ],
+      "volumes": [
+        {
+          "container": "/var/lib/registry"
+        }
+      ],
+      "env": [
+        {
+          "name": "REGISTRY_PROXY_REMOTEURL",
+          "default": "https://registry-1.docker.io",
+          "preset": true
+        }
+      ],
+      "maintainer": " https://github.com/portainer/templates/"
+    },
+    {
+      "id": 529,
+      "type": 1,
+      "title": "Ubuntu",
+      "description": "Debian-based Linux operating system",
+      "categories": [
+        "Operatingsystem"
+      ],
+      "platform": "linux",
+      "logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/ubuntu.png",
+      "image": "ubuntu:latest",
+      "interactive": true,
+      "command": "/bin/bash",
+      "maintainer": " https://github.com/portainer/templates/"
+    },
+    {
+      "id": 530,
+      "type": 1,
+      "title": "NodeJS",
+      "description": "JavaScript-based platform for server-side and networking applications",
+      "categories": [
+        "Development"
+      ],
+      "platform": "linux",
+      "logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/node.png",
+      "image": "node:latest",
+      "interactive": true,
+      "command": "/bin/bash",
+      "maintainer": " https://github.com/portainer/templates/"
+    },
+    {
+      "id": 531,
+      "type": 2,
+      "title": "Swarm monitoring",
+      "description": "Monitor your cluster performances with Prometheus & Grafana",
+      "note": "Requires Docker version 19.03.0+. <b>Make sure to add the <code>monitoring == true</code> one of your Swarm manager node before deploying this stack.</b>",
+      "categories": [
+        "Monitoring"
+      ],
+      "platform": "linux",
+      "logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/portainer.png",
+      "repository": {
+        "url": "https://github.com/portainer/templates",
+        "stackfile": "swarm/monitoring/docker-compose.yml"
+      },
+      "env": [
+        {
+          "name": "GRAFANA_USER",
+          "label": "Grafana admin user",
+          "default": "admin"
+        },
+        {
+          "name": "GRAFANA_PASSWORD",
+          "label": "Grafana admin password"
+        }
+      ],
+      "maintainer": " https://github.com/portainer/templates/"
+    },
+    {
+      "id": 532,
+      "type": 2,
+      "title": "Redis Cluster",
+      "description": "Open-source in-memory data structure store - Cluster mode",
+      "categories": [
+        "Database"
+      ],
+      "platform": "linux",
+      "logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/redis.png",
+      "repository": {
+        "url": "https://github.com/portainer/templates",
+        "stackfile": "stacks/redis-cluster/docker-stack.yaml"
+      },
+      "env": [
+        {
+          "name": "REDIS_PASSWD",
+          "label": "Redis password"
+        }
+      ],
+      "maintainer": " https://github.com/portainer/templates/"
+    },
+    {
+      "id": 533,
+      "type": 1,
+      "title": "Dokku",
+      "description": "Dokku setup as a container",
+      "categories": [
+        "Paas"
+      ],
+      "platform": "linux",
+      "logo": "",
+      "image": "dokku/dokku",
+      "ports": [
+        "22/tcp",
+        "80/tcp",
+        "443/tcp"
+      ],
+      "volumes": [
+        {
+          "container": "/mnt/dokku",
+          "bind": "/var/lib/dokku"
+        },
+        {
+          "container": "/var/run/docker.sock",
+          "bind": "/var/run/docker.sock"
+        }
+      ],
+      "env": [
+        {
+          "name": "DOKKU_HOSTNAME",
+          "label": "Dokku hostname",
+          "description": "Global hostname to be registered by Dokku"
+        },
+        {
+          "name": "DOKKU_HOST_ROOT",
+          "label": "Dokku host root",
+          "default": "/var/lib/dokku/home/dokku",
+          "description": "Image build cache path. Generally set to <data dir> + '/home/dokku'"
+        }
+      ],
+      "maintainer": " https://github.com/portainer/templates/"
+    },
+    {
+      "id": 534,
+      "type": 1,
+      "title": "OPC Router",
+      "description": "No-code middleware for industrial applications. The OPC Router connects PLCs, PCS, SCADA, MES, SQL databases and servers, label printers, e-mail servers and erp-systems via OPC UA, MQTT, REST, CSV and many others without any programming effort",
+      "note": "More information about the <a href=\"https://www.opc-router.com/terms-of-use-and-eula/?utm_source=DockerHub_runtime&utm_medium=click&utm_campaign=TermsOfUseAndEula\" target=\"_blank\">EULA</a>.",
+      "categories": [
+        "Edge"
+      ],
+      "platform": "linux",
+      "logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/opc-router.png",
+      "image": "opcrouter/runtime:latest",
+      "ports": [
+        "49429/tcp",
+        "8080/tcp",
+        "8081/tcp"
+      ],
+      "env": [
+        {
+          "name": "INITIAL_USERNAME",
+          "label": "Initial Admin User user"
+        },
+        {
+          "name": "INITIAL_PASSWORD",
+          "label": "Inital Admin User Password"
+        },
+        {
+          "name": "OR_I_ACCEPT_EULA",
+          "label": "Accept EULA",
+          "select": [
+            {
+              "text": "Yes, I accept",
+              "value": "true",
+              "default": true
+            }
+          ]
+        }
+      ],
+      "volumes": [
+        {
+          "container": "/data/database"
+        },
+        {
+          "container": "/inray"
+        },
+        {
+          "container": "/var/log/opcrouter"
+        }
+      ],
+      "maintainer": " https://github.com/portainer/templates/"
+    },
+    {
+      "id": 535,
+      "type": 1,
+      "title": "Floating License Server",
+      "description": "License Server for Softing edgeConnector products",
+      "categories": [
+        "Edge"
+      ],
+      "platform": "linux",
+      "logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/softing.png",
+      "image": "softingindustrial/floating-license-server:latest",
+      "ports": [
+        "6200/tcp"
+      ],
+      "interactive": true,
+      "volumes": [
+        {
+          "container": "/licsrv/licenses"
+        }
+      ],
+      "maintainer": " https://github.com/portainer/templates/"
+    },
+    {
+      "id": 536,
+      "type": 1,
+      "title": "EdgeConnector Modbus",
+      "description": "Connect Modbus TCP Sensors/PLCs and provide the data via OPC UA and MQTT",
+      "categories": [
+        "Edge"
+      ],
+      "platform": "linux",
+      "logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/softing.png",
+      "image": "softingindustrial/edgeconnector-modbus:latest",
+      "ports": [
+        "443/tcp",
+        "8099/tcp",
+        "4897/tcp"
+      ],
+      "maintainer": " https://github.com/portainer/templates/"
+    },
+    {
+      "id": 537,
+      "type": 1,
+      "title": "EdgeConnector 840D",
+      "description": "Access Siemens SINUMERIK 840D sl/pl controllers and provide data via OPC UA and MQTT",
+      "categories": [
+        "Edge"
+      ],
+      "platform": "linux",
+      "logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/softing.png",
+      "image": "softingindustrial/edgeconnector-840d",
+      "ports": [
+        "443/tcp",
+        "8099/tcp",
+        "4897/tcp"
+      ],
+      "maintainer": " https://github.com/portainer/templates/"
+    },
+    {
+      "id": 538,
+      "type": 1,
+      "title": "EdgeConnector Siemens",
+      "description": "Connect Siemens SIMATIC S7-300/400/1200/1500 PLCs and provide the data via OPC UA and MQTT",
+      "categories": [
+        "Edge"
+      ],
+      "platform": "linux",
+      "logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/softing.png",
+      "image": "softingindustrial/edgeconnector-siemens",
+      "ports": [
+        "443/tcp",
+        "8099/tcp",
+        "4897/tcp"
+      ],
+      "maintainer": " https://github.com/portainer/templates/"
+    },
+    {
+      "id": 539,
+      "type": 1,
+      "title": "EdgeConnector FANUC CNC",
+      "description": "Connect FANUC CNCs and provide the data via OPC UA and MQTT",
+      "categories": [
+        "Edge"
+      ],
+      "platform": "linux",
+      "logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/softing.png",
+      "image": "softingindustrial/edgeconnector-fanuc-cnc",
+      "ports": [
+        "443/tcp",
+        "8099/tcp",
+        "4897/tcp"
+      ],
+      "env": [
+        {
+          "name": "TZ",
+          "label": "TZ"
+        }
+      ],
+      "volumes": [
+        {
+          "container": "/config"
+        },
+        {
+          "container": "/mqtt"
+        }
+      ],
+      "maintainer": " https://github.com/portainer/templates/"
+    },
+    {
+      "id": 540,
+      "type": 1,
+      "title": "EdgeConnector Aggregator",
+      "description": "Offers a powerful OPC UA aggregation service which provides data via OPC UA, as well as MQTT",
+      "categories": [
+        "Edge"
+      ],
+      "platform": "linux",
+      "logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/softing.png",
+      "image": "softingindustrial/edgeaggregator",
+      "ports": [
+        "443/tcp",
+        "8099/tcp",
+        "4897/tcp"
+      ],
+      "env": [
+        {
+          "name": "TZ",
+          "label": "TZ"
+        }
+      ],
+      "volumes": [
+        {
+          "container": "/config"
+        },
+        {
+          "container": "/mqtt"
+        }
+      ],
+      "maintainer": " https://github.com/portainer/templates/"
+    },
+    {
+      "id": 541,
+      "type": 3,
+      "title": "OpenAMT",
+      "description": "OpenAMT Cloud Toolkit",
+      "note": "MPS password needs to be 8-32 characters including one uppercase, one lowercase letters, one base-10 digit and one special character.",
+      "categories": [
+        "Cloud"
+      ],
+      "platform": "linux",
+      "logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/intel.png",
+      "repository": {
+        "url": "https://github.com/portainer/templates",
+        "stackfile": "stacks/openamt/docker-compose.yml"
+      },
+      "env": [
+        {
+          "name": "POSTGRES_USER",
+          "label": "Database user"
+        },
+        {
+          "name": "POSTGRES_PASSWORD",
+          "label": "Database password"
+        },
+        {
+          "name": "MPS_USER",
+          "label": "MPS user"
+        },
+        {
+          "name": "MPS_PASSWORD",
+          "label": "MPS password"
+        },
+        {
+          "name": "MPS_COMMON_NAME",
+          "label": "MPS URL",
+          "description": "Used to connect to the MPS API."
+        },
+        {
+          "name": "MPS_SECRET",
+          "label": "MPS Secret",
+          "description": "Strong secret key used to log into MPS."
+        },
+        {
+          "name": "VAULT_SECRET",
+          "label": "Vault secret",
+          "description": "Secret token used to log into Vault (don't include '.' character)."
+        }
+      ],
+      "maintainer": " https://github.com/portainer/templates/"
+    },
+    {
+      "id": 542,
+      "type": 3,
+      "title": "FDO",
+      "description": "FDO",
+      "platform": "linux",
+      "logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/intel.png",
+      "repository": {
+        "url": "https://github.com/portainer/templates",
+        "stackfile": "stacks/fdo/docker-stack.yml"
+      },
+      "env": [
+        {
+          "name": "owner_api_user",
+          "label": "API Username"
+        },
+        {
+          "name": "owner_api_password",
+          "label": "API Password"
+        }
+      ],
+      "maintainer": " https://github.com/portainer/templates/",
+      "categories": []
+    },
+    {
+      "id": 543,
+      "type": 2,
+      "title": "LiveSwitch",
+      "description": "A basic LiveSwitch stack with gateway, caching, database and media server",
+      "categories": [
+        "Media"
+      ],
+      "platform": "linux",
+      "logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/liveswitch.png",
+      "repository": {
+        "url": "https://github.com/portainer/templates",
+        "stackfile": "stacks/liveswitch/docker-stack.yml"
+      },
+      "env": [
+        {
+          "name": "POSTGRES_PASSWORD",
+          "label": "Postgres password"
+        }
+      ],
+      "maintainer": " https://github.com/portainer/templates/"
+    },
+    {
+      "id": 544,
+      "type": 3,
+      "title": "TOSIBOX Lock for Container",
+      "description": "Lock for Container brings secure connectivity inside your industrial IoT devices",
+      "categories": [
+        "Edge"
+      ],
+      "platform": "linux",
+      "logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/tosibox.png",
+      "repository": {
+        "url": "https://github.com/portainer/templates",
+        "stackfile": "stacks/tosibox/docker-compose.yml"
+      },
+      "env": [
+        {
+          "name": "LICENSE_KEY",
+          "label": "License key"
+        }
+      ],
+      "maintainer": " https://github.com/portainer/templates/"
+    },
+    {
+      "id": 545,
+      "type": 3,
+      "title": "Pro Mosquitto with Management Center",
+      "description": "Commercial-grade Mosquitto MQTT broker with Management Center",
+      "note": "The Mosquitto broker password must be at least 12 characters.",
+      "categories": [
+        "Edge"
+      ],
+      "platform": "linux",
+      "logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/cedalo.png",
+      "repository": {
+        "url": "https://github.com/portainer/templates",
+        "stackfile": "edge/cedalo-mosquitto-mc/docker-compose.yml"
+      },
+      "env": [
+        {
+          "name": "CEDALO_LICENSE_KEY",
+          "label": "License key"
+        },
+        {
+          "name": "CEDALO_MOSQUITTO_PASSWORD",
+          "label": "Mosquitto password"
+        },
+        {
+          "name": "CEDALO_MC_USER",
+          "label": "Management Center username",
+          "default": "cedalo"
+        },
+        {
+          "name": "CEDALO_MC_PASSWORD",
+          "label": "Management Center password"
+        }
+      ],
+      "maintainer": " https://github.com/portainer/templates/"
+    },
+    {
+      "id": 546,
+      "type": 4,
+      "title": "Softing EdgeConnector modbus",
+      "description": "Connect Modbus TCP Sensors/PLCs and provide the data via OPC UA and MQTT",
+      "stackfile": "https://raw.githubusercontent.com/portainer/templates/master/edge/softing-edgeconnector-modbus/docker-compose.yml",
+      "maintainer": " https://github.com/portainer/templates/",
+      "categories": []
+    },
+    {
+      "id": 547,
+      "type": 4,
+      "title": "Softing EdgeConnector 840D",
+      "description": "Access Siemens SINUMERIK 840D sl/pl controllers and provide data via OPC UA and MQTT",
+      "stackfile": "https://raw.githubusercontent.com/portainer/templates/master/edge/softing-edgeconnector-840d/docker-compose.yml",
+      "maintainer": " https://github.com/portainer/templates/",
+      "categories": []
+    },
+    {
+      "id": 548,
+      "type": 4,
+      "title": "Softing EdgeConnector Siemens",
+      "description": "Connect Siemens SIMATIC S7-300/400/1200/1500 PLCs and provide the data via OPC UA and MQTT",
+      "stackfile": "https://raw.githubusercontent.com/portainer/templates/master/edge/softing-edgeconnector-siemens/docker-compose.yml",
+      "maintainer": " https://github.com/portainer/templates/",
+      "categories": []
+    },
+    {
+      "id": 549,
+      "type": 4,
+      "title": "Softing EdgeConnector FANUC CNC",
+      "description": "Connect FANUC CNCs and provide the data via OPC UA and MQTT",
+      "stackfile": "https://raw.githubusercontent.com/portainer/templates/master/edge/softing-edgeconnector-fanuc-cnc/docker-compose.yml",
+      "maintainer": " https://github.com/portainer/templates/",
+      "categories": []
+    },
+    {
+      "id": 550,
+      "type": 4,
+      "title": "Softing EdgeConnector Aggregator",
+      "description": "Offers a powerful OPC UA aggregation service which provides data via OPC UA, as well as MQTT",
+      "stackfile": "https://raw.githubusercontent.com/portainer/templates/master/edge/softing-edgeconnector-aggregator/docker-compose.yml",
+      "maintainer": " https://github.com/portainer/templates/",
+      "categories": []
+    },
+    {
+      "id": 551,
+      "type": 3,
+      "title": "Manubes Edge Node",
+      "description": "High-performance cloud platform for industrial production management. Manubes is a no-code solution that is used to structure, monitor and control production data, systems and processes in the cloud.",
+      "categories": [
+        "Edge"
+      ],
+      "platform": "linux",
+      "logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/inray-manubes.png",
+      "repository": {
+        "url": "https://github.com/portainer/templates",
+        "stackfile": "edge/inray-manubes-edge-node/docker-compose.yml"
+      },
+      "env": [
+        {
+          "name": "MANUBES_SECRET",
+          "label": "manubes secret"
+        },
+        {
+          "name": "ACCEPT_EULA",
+          "label": "Accept EULA",
+          "select": [
+            {
+              "text": "Yes, I accept",
+              "value": "true",
+              "default": true
+            }
+          ]
+        }
+      ],
+      "maintainer": " https://github.com/portainer/templates/"
+    }
+  ]
+}


### PR DESCRIPTION
If you point to `templates_v3.json` from your Portainer 2.23 instance, the templates will work.
Fixes #65 
Fixes #66 