### PR TITLE
deemix: Update DeeMix container to use the official one

### DIFF
--- a/templates.json
+++ b/templates.json
@@ -8956,13 +8956,13 @@
         "Music"
       ],
       "description": "Deemix is a deezer downloader built from the ashes of Deezloader Remix.",
-      "image": "registry.gitlab.com/bockiii/deemix-docker",
+      "image": "ghcr.io/bambanah/deemix:latest",
       "logo": "https://raw.githubusercontent.com/SelfhostedPro/selfhosted_templates/master/Images/deemix.png",
       "name": "deemix",
       "note": "Deemix may take a few minutes to install. Be sure to check the logs for details. Refer to <a href='https://notabug.org/RemixDevs/DeezloaderRemix/wiki/Login+via+userToken'>this page</a> for userToken details.",
       "platform": "linux",
       "ports": [
-        "9666:9666/tcp"
+        "6595:6595/tcp"
       ],
       "restart_policy": "unless-stopped",
       "title": "DeeMix",
@@ -8977,7 +8977,7 @@
           "container": "/downloads"
         }
       ],
-      "maintainer": " https://github.com/SelfhostedPro/selfhosted_templates/"
+      "maintainer": "https://github.com/bambanah/deemix"
     },
     {
       "categories": [


### PR DESCRIPTION
https://github.com/bambanah/deemix?tab=readme-ov-file#docker-image

Includes an update to the default port, though we could keep it as 9666 with `DEEMIX_SERVER_PORT`.