### PR TITLE
Update README.md to new v3 link

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -8,7 +8,7 @@
 </p>
 
 > **TL;DR** Under Settings → App Templates in your Portainer GUI, paste this URL:<br>
-> `https://raw.githubusercontent.com/Lissy93/portainer-templates/main/templates.json`<br>
+> `https://raw.githubusercontent.com/Lissy93/portainer-templates/main/templates_v3.json`<br>
 
 
 <details>
@@ -43,8 +43,10 @@ You can browse all supported apps and stacks and see stats, config options and s
 
 1. Log into your Portainer web UI
 2. Under <ins>Settings</ins> --> <ins>App Templates</ins>, update the URL to
-    - `https://raw.githubusercontent.com/Lissy93/portainer-templates/main/templates.json`
+    - `https://raw.githubusercontent.com/Lissy93/portainer-templates/main/templates_v3.json`
 3. Now under <ins>Home</ins> --> <ins>App Templates</ins>, you should see all apps. Click one to deploy.
+
+The old v2 (`https://raw.githubusercontent.com/Lissy93/portainer-templates/main/templates.json`) is no longer working with the current portainer version.    
 
 <details>
 <summary>Show me...</summary>


### PR DESCRIPTION
replaced old v2 link with new v3 version (https://raw.githubusercontent.com/Lissy93/portainer-templates/main/templates_v3.json)