### PR TITLE
Update templates.json

### DIFF
--- a/templates.json
+++ b/templates.json
@@ -5057,7 +5057,7 @@
           "container": "/data"
         },
         {
-          "bind": " /etc/timezone",
+          "bind": "/etc/timezone",
           "container": "/etc/timezone:ro"
         },
         {


### PR DESCRIPTION
Fix: Remove extra space in volume bind path

Remove extra whitespace in volume bind path to prevent potential mount issues.