### PR TITLE
Update Docker image for Lidarr template

### DIFF
--- a/templates.json
+++ b/templates.json
@@ -3439,7 +3439,7 @@
           "name": "PGID"
         }
       ],
-      "image": "hotio/lidarr:release",
+      "image": "linuxserver/lidarr:latest",
       "logo": "https://raw.githubusercontent.com/xneo1/portainer_templates/master/Images/lidarr.png",
       "name": "lidarr",
       "platform": "linux",


### PR DESCRIPTION
Changed Lidarr repo as hotio/lidarr:release not working to linuxserver/lidarr:latest