### PR TITLE
Add Hivekeep template

### DIFF
--- a/sources/local/lissy93_templates.json
+++ b/sources/local/lissy93_templates.json
@@ -303,6 +303,30 @@
       },
       "title": "ZTNet",
       "type": 3
+    },
+    {
+      "type": 1,
+      "title": "Hivekeep",
+      "name": "hivekeep",
+      "description": "Self-hosted platform of autonomous, persistent personal AI agents that collaborate, remember, and build their own tools. Reachable via Telegram, WhatsApp, Slack, Discord, Signal and Matrix. Single container with Bun and SQLite, no external infrastructure.",
+      "categories": [
+        "AI",
+        "Productivity",
+        "Self-hosted"
+      ],
+      "platform": "linux",
+      "logo": "https://hivekeep.app/apple-touch-icon.png",
+      "image": "ghcr.io/marlburrow/hivekeep:latest",
+      "ports": [
+        "3000:3000/tcp"
+      ],
+      "volumes": [
+        {
+          "container": "/app/data",
+          "bind": "/var/lib/hivekeep"
+        }
+      ],
+      "restart_policy": "unless-stopped"
     }
   ]
 }


### PR DESCRIPTION
Adding a v3 template for Hivekeep to sources/local/lissy93_templates.json, following the existing entry format.

Hivekeep is a self-hosted, MIT-licensed platform of autonomous, persistent personal AI agents: specialized agents with continuous memory that collaborate, build their own tools, and are reachable over Telegram, WhatsApp, Slack, Discord, Signal and Matrix. Single container with Bun and SQLite, web UI on port 3000, all state in one volume.

Links: [GitHub](https://github.com/MarlBurroW/hivekeep) | [Website](https://hivekeep.app)

Disclosure: I am the author of the project. Thanks for maintaining this collection!