### PR TITLE
Add HomeLab Monitor — self-hosted homelab dashboard with GPU/VRAM attribution

### DIFF
--- a/sources/local/homelab_templates.json
+++ b/sources/local/homelab_templates.json
@@ -581,6 +581,46 @@
       },
       "title": "Pumperly",
       "type": 3
+    },
+    {
+      "categories": [
+        "Monitoring",
+        "Homelab"
+      ],
+      "description": "Self-hosted homelab dashboard, one container. Per-container GPU/VRAM attribution (which process holds the card, not just total load), Docker health/logs, systemd status, host vitals (CPU/RAM/disk/temps), multiple hosts over SSH. Alerts via Discord/ntfy/Telegram. Read-only MCP server on :9810. MIT.",
+      "env": [
+        {
+          "default": "10",
+          "label": "SAMPLE_INTERVAL_SECONDS",
+          "name": "SAMPLE_INTERVAL_SECONDS",
+          "description": "Polling interval in seconds (default 10)"
+        },
+        {
+          "default": "180",
+          "label": "HISTORY_DAYS",
+          "name": "HISTORY_DAYS",
+          "description": "Days of history to retain"
+        }
+      ],
+      "image": "sikamikaniko123/homelab-monitor:latest",
+      "logo": "https://raw.githubusercontent.com/SikamikanikoBG/homelab-monitor/main/docs/logo-400.png",
+      "name": "homelab-monitor",
+      "network": "host",
+      "platform": "linux",
+      "ports": [],
+      "restart_policy": "unless-stopped",
+      "title": "HomeLab Monitor",
+      "type": 1,
+      "volumes": [
+        {
+          "bind": "/var/run/docker.sock",
+          "container": "/var/run/docker.sock",
+          "readonly": true
+        },
+        {
+          "container": "/app/data"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
Adds HomeLab Monitor to `sources/local/homelab_templates.json`.

Self-hosted monitoring dashboard, single Docker container. The point of it: per-container GPU/VRAM attribution - it tells you *which* container is holding the GPU, not just that it's busy. Handy if you run Ollama/ComfyUI next to other stuff.

Also does Docker/systemd health, host vitals (CPU/RAM/disk/temps), multi-machine over SSH, and push alerts to Discord/ntfy/Telegram. Read-only MCP server on :9810 for agents.

- GitHub: https://github.com/SikamikanikoBG/homelab-monitor
- License: MIT
- Network: host (needed for GPU PID mapping + SSH)

Entry is `type` 1 (container), host networking, no published ports. Validated against `Schema.json` before submitting.
