### PR TITLE
Add tela — markdown-native team wiki

### DIFF
--- a/sources/local/tela_templates.json
+++ b/sources/local/tela_templates.json
@@ -1,0 +1,45 @@
+{
+  "version": "3",
+  "templates": [
+    {
+      "categories": [
+        "Productivity",
+        "Documentation"
+      ],
+      "description": "Self-hostable, markdown-native team wiki: Go + PostgreSQL backend, a React editor with live Yjs collaboration, full-text + optional semantic search, WebDAV sync, public/blog spaces, Slidev decks and PDF export. A built-in MCP server makes AI agents first-class editors, and Atlas can generate a cited wiki from your existing sources (git, Jira). After the stack is up, open the app on :8780 and complete /setup to create your admin account.",
+      "env": [
+        {
+          "default": "http://localhost:8780",
+          "label": "Public base URL",
+          "name": "TELA_PUBLIC_BASE_URL"
+        },
+        {
+          "default": "",
+          "label": "Postgres password (required, no default)",
+          "name": "TELA_PG_PASSWORD"
+        },
+        {
+          "default": "",
+          "label": "Share secret (required) — generate with: openssl rand -hex 32",
+          "name": "TELA_SHARE_SECRET"
+        },
+        {
+          "default": "",
+          "label": "API key / PAT secret (required) — generate with: openssl rand -hex 32",
+          "name": "TELA_API_KEY_SECRET"
+        }
+      ],
+      "logo": "https://raw.githubusercontent.com/zcag/tela/main/docs/submission-assets/app-icon-512.png",
+      "name": "tela",
+      "note": "Three secrets are required and have no defaults: <b>TELA_PG_PASSWORD</b>, <b>TELA_SHARE_SECRET</b> and <b>TELA_API_KEY_SECRET</b> (generate each with <code>openssl rand -hex 32</code>). Keep them stable across redeploys — rotating TELA_API_KEY_SECRET invalidates every personal access token, and TELA_SHARE_SECRET invalidates outstanding share links. The app is served on port 8780; open it and complete <code>/setup</code> to create the first admin.",
+      "platform": "linux",
+      "repository": {
+        "stackfile": "sources/stacks/tela.yml",
+        "url": "https://github.com/lissy93/portainer-templates"
+      },
+      "restart_policy": "unless-stopped",
+      "title": "tela",
+      "type": 3
+    }
+  ]
+}

--- a/sources/stacks/tela.yml
+++ b/sources/stacks/tela.yml
@@ -1,0 +1,87 @@
+version: "3.8"
+
+# tela — self-hostable markdown-native team wiki (https://telawiki.com)
+# Caddy `proxy` is the only web-exposed service and is the mandatory single
+# entrypoint; it fronts the Go `backend` and the static `frontend`. Postgres
+# uses the pgvector image (semantic search needs the `vector` extension).
+# The three required secrets have NO defaults — set them in Portainer before
+# deploying and keep them stable (rotating TELA_API_KEY_SECRET invalidates all
+# personal access tokens). After the stack is up, open :8780 and complete /setup
+# to create the admin account.
+
+services:
+
+  proxy:
+    image: ghcr.io/zcag/tela-proxy:0.7.0
+    restart: unless-stopped
+    environment:
+      TELA_SITE_ADDRESS: ":80"
+      TELA_UPSTREAM_BACKEND: backend:8080
+      TELA_UPSTREAM_FRONTEND: frontend:80
+    ports:
+      - "8780:80"
+    volumes:
+      - tela-caddy-data:/data
+      - tela-caddy-config:/config
+    depends_on:
+      - backend
+      - frontend
+
+  backend:
+    image: ghcr.io/zcag/tela-backend:0.7.0
+    restart: unless-stopped
+    environment:
+      TELA_PUBLIC_BASE_URL: ${TELA_PUBLIC_BASE_URL:-http://localhost:8780}
+      TELA_SHARE_SECRET: ${TELA_SHARE_SECRET}
+      TELA_API_KEY_SECRET: ${TELA_API_KEY_SECRET}
+      TELA_DATABASE_URL: postgres://tela:${TELA_PG_PASSWORD}@postgres:5432/tela?sslmode=disable
+      TELA_GOTENBERG_URL: http://gotenberg:3000
+      TELA_PDF_RENDER_BASE_URL: http://proxy
+      TELA_DECK_URL: http://deck:3344
+    expose:
+      - "8080"
+    depends_on:
+      postgres:
+        condition: service_healthy
+
+  postgres:
+    image: pgvector/pgvector:pg17
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: tela
+      POSTGRES_PASSWORD: ${TELA_PG_PASSWORD}
+      POSTGRES_DB: tela
+    volumes:
+      - tela-pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U tela -d tela"]
+      interval: 5s
+      timeout: 3s
+      retries: 20
+      start_period: 10s
+
+  frontend:
+    image: ghcr.io/zcag/tela-frontend:0.7.0
+    restart: unless-stopped
+    expose:
+      - "80"
+
+  deck:
+    image: ghcr.io/zcag/tela-deck:0.7.0
+    restart: unless-stopped
+    volumes:
+      - tela-deckcache:/data
+    expose:
+      - "3344"
+
+  gotenberg:
+    image: gotenberg/gotenberg:8
+    restart: unless-stopped
+    expose:
+      - "3000"
+
+volumes:
+  tela-pgdata:
+  tela-deckcache:
+  tela-caddy-data:
+  tela-caddy-config:


### PR DESCRIPTION
Adds **tela** as a new app template.

[tela](https://telawiki.com) ([github.com/zcag/tela](https://github.com/zcag/tela), AGPL-3.0) is a self-hostable, markdown-native team wiki — Go + PostgreSQL backend, a React editor with live Yjs collaboration, full-text + optional semantic search, WebDAV sync, public/blog spaces, Slidev decks and PDF export. It ships a built-in **MCP server** so AI agents are first-class editors, and **Atlas** can generate a cited wiki from existing sources (git, Jira).

### What this PR does
Follows the repo's established pattern for self-contained `type: 3` (compose) stacks (Outline, Databag, CryptPad, …):

- **`sources/local/tela_templates.json`** — the template entry (categories Productivity/Documentation, logo, the 3 required-secret note, env vars). No `id` — assigned by `lib/combine.py`, matching the other local sources.
- **`sources/stacks/tela.yml`** — the compose stack referenced by `repository.stackfile`, using the published multi-arch GHCR images `ghcr.io/zcag/tela-{proxy,backend,frontend,deck}:0.7.0` + `pgvector/pgvector:pg17` (semantic search needs the `vector` extension). Caddy `proxy` is the single web-exposed service on `:8780`.

### Required secrets (no defaults)
`TELA_PG_PASSWORD`, `TELA_SHARE_SECRET`, `TELA_API_KEY_SECRET` (each `openssl rand -hex 32`); keep them stable across redeploys. After the stack is up, open `:8780` and complete `/setup` to create the admin.

### Verification
- `lib/combine.py` runs clean and emits the tela entry into `templates.json` (id auto-assigned).
- JSON + YAML both parse; the compose stack was smoke-tested via `docker compose`.