### PR TITLE
Add Cloudflared-web

### DIFF
--- a/sources/local/homelab_templates.json
+++ b/sources/local/homelab_templates.json
@@ -621,6 +621,34 @@
           "container": "/app/data"
         }
       ]
+    },
+    {
+      "categories": [
+        "Networking",
+        "Tools"
+      ],
+      "description": "A docker image that packages both cloudflared cli and a simple Web UI to easily start or stop remotely-managed Cloudflare tunnel.",
+      "env": [
+        {
+          "default": "14333",
+          "label": "WEBUI_PORT",
+          "name": "WEBUI_PORT"
+        }
+      ],
+      "image": "wisdomsky/cloudflared-web:latest",
+      "logo": "https://raw.githubusercontent.com/WisdomSky/Cloudflared-web/refs/heads/main/app/frontend/public/cloudflare.ico",
+      "platform": "linux",
+      "network": "host",
+      "ports": [],
+      "restart_policy": "unless-stopped",
+      "title": "Cloudflared-web",
+      "name": "cloudflared-web",
+      "type": 1,
+      "volumes": [
+        {
+          "container": "/config"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
Added [**Cloudflared-web**](https://github.com/WisdomSky/Cloudflared-web), a docker image that packages both [cloudflared cli](https://github.com/cloudflare/cloudflared/releases) and a simple Web UI to easily start or stop remotely-managed Cloudflare tunnel. 

Project Page: https://github.com/WisdomSky/Cloudflared-web
Dockerhub: https://hub.docker.com/r/wisdomsky/cloudflared-web