### PR TITLE
feat(templates): add cairn

### DIFF
--- a/sources/local/monitoring_templates.json
+++ b/sources/local/monitoring_templates.json
@@ -87,6 +87,30 @@
           "container": "/data"
         }
       ]
+    },
+    {
+      "categories": [
+        "Dashboard",
+        "Web"
+      ],
+      "description": "The directory page for the people you host services for: no account, multilingual, live status, one tiny container. Source: https://github.com/MorganKryze/cairn",
+      "env": [],
+      "image": "ghcr.io/morgankryze/cairn:latest",
+      "logo": "https://raw.githubusercontent.com/MorganKryze/cairn/main/docs/assets/brand/cairn.svg",
+      "name": "cairn",
+      "note": "Starts with no configuration at all and serves a getting-started page. Drop a services.yaml into the mounted /config directory and it reloads within seconds, no restart needed. It writes nothing at runtime, so it also runs read-only with every capability dropped.",
+      "platform": "linux",
+      "ports": [
+        "8080:8080/tcp"
+      ],
+      "restart_policy": "unless-stopped",
+      "title": "cairn",
+      "type": 1,
+      "volumes": [
+        {
+          "container": "/config"
+        }
+      ]
     }
   ],
   "version": "3"


### PR DESCRIPTION
### Category

New template

### Summary

Adds cairn to `sources/local/monitoring_templates.json`, alongside Glance and Gatus.

cairn is a directory page for the services you host, aimed at the people you host for rather than at the admin: a YAML file in, a static multilingual page out. I'm its author.

Thanks

`make validate_sources` passes, with no warnings on the new entry.

### Checklist

- [x] I've read the [contributing guide](.github/CONTRIBUTING.md)
- [x] I've self-reviewed my changes to ensure they are valid
- [x] I'm not modifying `templates.json` directly (it's auto-generated)
