### PR TITLE
Add MyNeS template source

### DIFF
--- a/sources.csv
+++ b/sources.csv
@@ -8,3 +8,4 @@ novaspirit_templates, https://raw.githubusercontent.com/novaspirit/pi-hosted/mas
 mediadepot_templates, https://raw.githubusercontent.com/mediadepot/templates/master/portainer.json, https://github.com/mediadepot/templates/
 shmolf_templates, https://raw.githubusercontent.com/shmolf/portainer-templates/main/templates-2.0.json, https://github.com/shmolf/portainer-templates/
 portainer_templates, https://raw.githubusercontent.com/portainer/templates/v3/templates.json, https://github.com/portainer/templates/
+mynes_templates, https://raw.githubusercontent.com/fxerkan/my_network_scanner/main/deploy/marketplaces/portainer/portainer-template.json, https://github.com/fxerkan/my_network_scanner/


### PR DESCRIPTION
Adds one row to `sources.csv` for **MyNeS (My Network Scanner)**.

- Template: https://raw.githubusercontent.com/fxerkan/my_network_scanner/main/deploy/marketplaces/portainer/portainer-template.json
- Source: https://github.com/fxerkan/my_network_scanner (MIT)
- Image: https://hub.docker.com/r/fxerkan/my_network_scanner — `linux/amd64` + `linux/arm64`, pinned to `1.3.0`

MyNeS is a self-hosted LAN scanner and device inventory. It discovers devices over ARP, mDNS/Bonjour, SSDP/UPnP, Matter, Bluetooth LE and MQTT — reading retained Zigbee2MQTT / Z-Wave JS / Tasmota topics is the only way to inventory a radio device with no IP address, so Zigbee bulbs and Z-Wave sensors show up next to the servers.

It is a **type 3** (Compose stack) template rather than type 1. The app needs `network_mode: host` plus `NET_ADMIN`/`NET_RAW` — raw ARP frames and mDNS/SSDP multicast do not cross a bridge network — and the Portainer container-template schema has no `cap_add` field, so a type 1 template would have installed something that silently degraded to a ping sweep. The referenced stack file has no `build:` directive, so Portainer pulls the published image rather than building.

Validated against `Schema.json`: single template, `id` / `type` / `title` / `description` present, `logo` and `note` set.