### PR TITLE
[SOURCE] Add DockRoute templates

### DIFF
--- a/sources.csv
+++ b/sources.csv
@@ -8,3 +8,4 @@ novaspirit_templates, https://raw.githubusercontent.com/novaspirit/pi-hosted/mas
 mediadepot_templates, https://raw.githubusercontent.com/mediadepot/templates/master/portainer.json, https://github.com/mediadepot/templates/
 shmolf_templates, https://raw.githubusercontent.com/shmolf/portainer-templates/main/templates-2.0.json, https://github.com/shmolf/portainer-templates/
 portainer_templates, https://raw.githubusercontent.com/portainer/templates/v3/templates.json, https://github.com/portainer/templates/
+dockroute_templates, https://raw.githubusercontent.com/Dockroute/Dockroute/main/templates/portainer/dockroute.json, https://github.com/Dockroute/Dockroute/


### PR DESCRIPTION
### Category
New source

### Summary
Adds [DockRoute](https://github.com/Dockroute/Dockroute) as a template source — External-DNS for plain Docker hosts: it watches running containers, reads `dockroute.*` labels and reconciles the matching DNS records (and Cloudflare Tunnel routes) in a pluggable provider, with ExternalDNS-style TXT ownership so it never touches records it cannot prove it manages.

The source URL serves a v3 template file maintained in the project's repo ([templates/portainer/dockroute.json](https://github.com/Dockroute/Dockroute/blob/main/templates/portainer/dockroute.json)), validated against this repo's `Schema.json` with ajv. Deploys with zero configuration — the image handles Docker socket permissions itself and defaults to a credential-free dry-run provider.

### Checklist
- [x] I've read the [contributing guide](.github/CONTRIBUTING.md)
- [x] I've self-reviewed my changes to ensure they are valid
- [x] I'm not modifying `templates.json` directly (it's auto-generated)