### PR TITLE
Adds Louez template

### DIFF
--- a/sources/local/productivity_templates.json
+++ b/sources/local/productivity_templates.json
@@ -312,6 +312,52 @@
       },
       "title": "Pumperly",
       "type": 3
+    },
+    {
+      "categories": [
+        "Business",
+        "Productivity",
+        "Self-hosted"
+      ],
+      "description": "Open-source equipment rental platform. Rent out cameras, tools, bikes, party gear or vehicles from a branded storefront with live availability, and manage products, reservations, pickups and returns, customers, PDF contracts and revenue statistics from one dashboard. The storefront is served at the root of the site, the dashboard under /dashboard, and the app installs its own database schema on first boot. Source: https://github.com/Synapsr/Louez",
+      "env": [
+        {
+          "default": "http://localhost:3000",
+          "label": "Public URL of your instance, sign-in is bound to it",
+          "name": "APP_URL"
+        },
+        {
+          "default": "3000",
+          "label": "Host port mapped to the app",
+          "name": "LOUEZ_PORT"
+        },
+        {
+          "default": "",
+          "label": "MySQL password for the louez user, set one before first boot",
+          "name": "DB_PASSWORD"
+        },
+        {
+          "default": "",
+          "label": "MySQL root password, set one before first boot",
+          "name": "DB_ROOT_PASSWORD"
+        },
+        {
+          "default": "",
+          "label": "Image store password, set one before first boot",
+          "name": "MINIO_PASSWORD"
+        }
+      ],
+      "logo": "https://raw.githubusercontent.com/Synapsr/Louez/main/apps/web/public/icons/icon-512.png",
+      "name": "louez",
+      "note": "Deploys the app, MySQL and a private MinIO bucket for product images. The first account you create becomes the store owner. Outgoing email is optional: without SMTP credentials you sign in with a password.",
+      "platform": "linux",
+      "repository": {
+        "stackfile": "sources/stacks/louez.yml",
+        "url": "https://github.com/lissy93/portainer-templates"
+      },
+      "restart_policy": "unless-stopped",
+      "title": "Louez",
+      "type": 3
     }
   ],
   "version": "3"

--- a/sources/stacks/louez.yml
+++ b/sources/stacks/louez.yml
@@ -1,0 +1,75 @@
+services:
+  louez:
+    image: synapsr/louez:2.1.0
+    restart: unless-stopped
+    ports:
+      - "${LOUEZ_PORT:-3000}:3000"
+    environment:
+      - LOUEZ_MODE=standalone
+      - DATABASE_URL=mysql://louez:${DB_PASSWORD:-louez}@db:3306/louez
+      - AUTH_URL=${APP_URL:-http://localhost:3000}
+      - AUTH_TRUST_HOST=true
+      - NEXT_PUBLIC_APP_URL=${APP_URL:-http://localhost:3000}
+      # The bucket stays private: Louez streams product images same-origin
+      # under /files with its own credentials.
+      - S3_ENDPOINT=http://minio:9000
+      - S3_REGION=us-east-1
+      - S3_BUCKET=louez
+      - S3_ACCESS_KEY_ID=louez
+      - S3_SECRET_ACCESS_KEY=${MINIO_PASSWORD:-louez-minio-secret}
+      - S3_PUBLIC_URL=/files
+      # Optional: outgoing email. Louez runs without it (password sign-in).
+      - SMTP_HOST=${SMTP_HOST:-}
+      - SMTP_PORT=${SMTP_PORT:-587}
+      - SMTP_USER=${SMTP_USER:-}
+      - SMTP_PASSWORD=${SMTP_PASSWORD:-}
+      - SMTP_FROM=${SMTP_FROM:-}
+    volumes:
+      # Holds the auth secret generated on first boot, so sessions survive
+      # container recreation.
+      - louez-data:/app/data
+    depends_on:
+      db:
+        condition: service_healthy
+      minio:
+        condition: service_healthy
+
+  db:
+    image: mysql:8.4
+    restart: unless-stopped
+    environment:
+      - MYSQL_DATABASE=louez
+      - MYSQL_USER=louez
+      - MYSQL_PASSWORD=${DB_PASSWORD:-louez}
+      - MYSQL_ROOT_PASSWORD=${DB_ROOT_PASSWORD:-louez-root}
+    volumes:
+      - mysql-data:/var/lib/mysql
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+
+  minio:
+    image: minio/minio:RELEASE.2025-09-07T16-13-09Z
+    restart: unless-stopped
+    # A bucket is a top-level directory of the data drive, so it is created
+    # before MinIO starts. The entrypoint is replaced because the image's own
+    # prepends `minio` to its arguments.
+    entrypoint: ["/bin/sh", "-c"]
+    command: ["mkdir -p /data/louez && exec minio server /data"]
+    environment:
+      - MINIO_ROOT_USER=louez
+      - MINIO_ROOT_PASSWORD=${MINIO_PASSWORD:-louez-minio-secret}
+    volumes:
+      - minio-data:/data
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sf http://localhost:9000/minio/health/live || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+
+volumes:
+  louez-data:
+  mysql-data:
+  minio-data:


### PR DESCRIPTION
## Adds Louez

[Louez](https://github.com/Synapsr/Louez) is an open-source equipment rental platform (AGPL-3.0). Rent out cameras, tools, bikes, party gear or vehicles from a branded storefront with live availability, and manage products, reservations, pickups and returns, customers, PDF contracts and revenue statistics from one dashboard. UI in 8 languages.

- `sources/stacks/louez.yml` — three services: the app (`synapsr/louez:2.1.0`), `mysql:8.4`, and `minio` for product images. The app creates its own database schema on first boot, so there is nothing to import.
- `sources/local/productivity_templates.json` — one type-3 stack entry, with env prompts for the public URL, the host port and the three passwords.

The storefront is served at the root of the site and the dashboard under `/dashboard`. Outgoing email is optional: without SMTP credentials the owner signs in with a password and the app skips sending mail.

### Checks

- `python lib/validate_sources.py sources/local` → all sources valid, no warning on the new entry
- `python lib/validate_sources.py sources/stacks` → `Checked sources/stacks/louez.yml: 0 errors, 0 warnings`
- The same stack was deployed locally end to end before submitting: services healthy, schema installed automatically, account created, product image uploaded through the app into the MinIO bucket and served back byte-identical.

One detail that bites every MinIO-based stack, in case it is useful elsewhere in this repo: the bucket is created by the storage service's start command, which needs an explicit `entrypoint: ["/bin/sh", "-c"]`. MinIO's own entrypoint prepends `minio` to whatever arguments it receives, so a plain `command: sh -c '…'` becomes `minio sh -c '…'` and the container crash-loops.
