### PR TITLE
Add Cantinarr

### DIFF
--- a/sources/local/media_templates.json
+++ b/sources/local/media_templates.json
@@ -285,12 +285,12 @@
         },
         {
           "default": "",
-          "description": "Origin your Radarr, Sonarr, and Chaptarr containers POST webhooks back to, for example http://192.168.1.10:8585. Leave blank to use whatever address you browse to.",
-          "label": "CANTINARR_PUBLIC_URL",
-          "name": "CANTINARR_PUBLIC_URL"
+          "description": "Origin your Radarr, Sonarr, and Chaptarr containers POST webhooks back to, for example http://192.168.1.10:8585. Leave blank to use whatever address you browse to. This is not the address people reach Cantinarr at; set that in the app under Settings, External Address. Formerly named CANTINARR_PUBLIC_URL, which existing containers can keep using.",
+          "label": "CANTINARR_ARR_CALLBACK_URL",
+          "name": "CANTINARR_ARR_CALLBACK_URL"
         }
       ],
-      "image": "ghcr.io/windoze95/cantinarr:0.2.0",
+      "image": "ghcr.io/windoze95/cantinarr:latest",
       "logo": "https://raw.githubusercontent.com/windoze95/cantinarr/main/app/web/icons/Icon-512.png",
       "name": "cantinarr",
       "note": "Web UI and API on port 8585. Radarr, Sonarr, Chaptarr, download clients, Tautulli, and Plex are all optional and are added from the admin UI after first run. Documentation: https://github.com/windoze95/cantinarr",

--- a/sources/local/media_templates.json
+++ b/sources/local/media_templates.json
@@ -269,6 +269,44 @@
           "container": "/data"
         }
       ]
+    },
+    {
+      "categories": [
+        "Media",
+        "Tools"
+      ],
+      "description": "One app over your whole media stack: household members browse and request movies, TV, and books, and admins get Radarr, Sonarr, and Chaptarr control down to the individual episode, live queues for SABnzbd, qBittorrent, NZBGet, and Transmission, Tautulli activity, Plex invites, plain-English fixes for stuck downloads, and an MCP server for Claude or any MCP client. GitHub: [windoze95/cantinarr](https://github.com/windoze95/cantinarr)",
+      "env": [
+        {
+          "default": "https://push.julian.codes",
+          "description": "Push gateway for the companion iOS and Android apps. The server enrolls itself on first start; clear to disable push, or point it at your own gateway.",
+          "label": "CANTINARR_PUSH_GATEWAY_URL",
+          "name": "CANTINARR_PUSH_GATEWAY_URL"
+        },
+        {
+          "default": "",
+          "description": "Origin your Radarr, Sonarr, and Chaptarr containers POST webhooks back to, for example http://192.168.1.10:8585. Leave blank to use whatever address you browse to.",
+          "label": "CANTINARR_PUBLIC_URL",
+          "name": "CANTINARR_PUBLIC_URL"
+        }
+      ],
+      "image": "ghcr.io/windoze95/cantinarr:0.2.0",
+      "logo": "https://raw.githubusercontent.com/windoze95/cantinarr/main/app/web/icons/Icon-512.png",
+      "name": "cantinarr",
+      "note": "Web UI and API on port 8585. Radarr, Sonarr, Chaptarr, download clients, Tautulli, and Plex are all optional and are added from the admin UI after first run. Documentation: https://github.com/windoze95/cantinarr",
+      "platform": "linux",
+      "ports": [
+        "8585:8585/tcp"
+      ],
+      "restart_policy": "unless-stopped",
+      "title": "Cantinarr",
+      "type": 1,
+      "volumes": [
+        {
+          "bind": "/portainer/Files/AppData/Cantinarr/config",
+          "container": "/config"
+        }
+      ]
     }
   ],
   "version": "3"


### PR DESCRIPTION
**Category**: Adding a new template

**Overview**: Adds **Cantinarr** (https://github.com/windoze95/cantinarr) to `sources/local/media_templates.json` — I'm the developer. It's a single-container media-stack manager: household members browse and request movies, TV, and books (with companion iPhone/Android apps and push notifications), and admins get Radarr/Sonarr/Chaptarr control down to the episode, live download queues across SABnzbd/qBittorrent/NZBGet/Transmission, Tautulli activity, Plex invites, plain-English fixes for stuck downloads, and an MCP server for Claude or any MCP client. Image is the multi-arch (amd64+arm64) release tag `ghcr.io/windoze95/cantinarr:0.2.0` on GHCR.

`make validate_sources` passes locally (only pre-existing warnings in other templates).

**Checklist**:
- [x] My changes are made to a file within `sources/local/` (or I've added a new source list to `sources.csv`)
- [x] My template matches the Portainer template format
- [x] I'm not modifying `templates.json` directly (it's auto-generated)
