### PR TITLE
Cantinarr: mention music in the description

### DIFF
--- a/sources/local/media_templates.json
+++ b/sources/local/media_templates.json
@@ -275,7 +275,7 @@
         "Media",
         "Tools"
       ],
-      "description": "One app over your whole media stack: household members browse and request movies, TV, and books, and admins get Radarr, Sonarr, and Chaptarr control down to the individual episode, live queues for SABnzbd, qBittorrent, NZBGet, and Transmission, Tautulli activity, Plex invites, plain-English fixes for stuck downloads, and an MCP server for Claude or any MCP client. GitHub: [windoze95/cantinarr](https://github.com/windoze95/cantinarr)",
+      "description": "One app over your whole media stack: household members browse and request movies, TV, books, and music, and admins get Radarr, Sonarr, Chaptarr, and Lidarr control down to the individual episode, live queues for SABnzbd, qBittorrent, NZBGet, and Transmission, Tautulli activity, Plex invites, plain-English fixes for stuck downloads, and an MCP server for Claude or any MCP client. GitHub: [windoze95/cantinarr](https://github.com/windoze95/cantinarr)",
       "env": [
         {
           "default": "https://push.julian.codes",


### PR DESCRIPTION
Cantinarr 0.8.0 added a Lidarr music module; the template description still stopped at books. One-line copy change in `sources/local/media_templates.json`: "movies, TV, books, and music" and "Radarr, Sonarr, Chaptarr, and Lidarr". `make validate_sources` passes.
