### PR TITLE
Cantinarr: point the push gateway default at push.cantinarr.com

### DIFF
--- a/sources/local/media_templates.json
+++ b/sources/local/media_templates.json
@@ -278,7 +278,7 @@
       "description": "One app over your whole media stack: household members browse and request movies, TV, books, and music, and admins get Radarr, Sonarr, Chaptarr, and Lidarr control down to the individual episode, live queues for SABnzbd, qBittorrent, NZBGet, and Transmission, Tautulli activity, Plex invites, plain-English fixes for stuck downloads, and an MCP server for Claude or any MCP client. GitHub: [windoze95/cantinarr](https://github.com/windoze95/cantinarr)",
       "env": [
         {
-          "default": "https://push.julian.codes",
+          "default": "https://push.cantinarr.com",
           "description": "Push gateway for the companion iOS and Android apps. The server enrolls itself on first start; clear to disable push, or point it at your own gateway.",
           "label": "CANTINARR_PUSH_GATEWAY_URL",
           "name": "CANTINARR_PUSH_GATEWAY_URL"


### PR DESCRIPTION
Cantinarr's community push relay moved to `https://push.cantinarr.com`. This updates the default for the `CANTINARR_PUSH_GATEWAY_URL` env in the Cantinarr template source. `templates.json` is left to the build workflow, as in #135.

Existing stacks are unaffected: `push.julian.codes` still answers from the same gateway, and current Cantinarr images rewrite it to the new name at start.
